### PR TITLE
Wire SQLite journal into engine and pybridge

### DIFF
--- a/engine/crates/core/src/engine.rs
+++ b/engine/crates/core/src/engine.rs
@@ -35,6 +35,21 @@ pub struct OrderIntent {
     pub relative_volume: f64,
 }
 
+/// Full outcome of processing a bar — for journaling.
+/// Captures features, signal decision, and risk gate result.
+#[derive(Debug, Clone)]
+pub struct BarOutcome {
+    pub features: FeatureValues,
+    pub intents: Vec<OrderIntent>,
+    pub signal_fired: bool,
+    pub signal_side: Option<Side>,
+    pub signal_score: Option<f64>,
+    pub signal_reason: Option<SignalReason>,
+    pub risk_passed: Option<bool>,
+    pub risk_rejection: Option<String>,
+    pub qty_approved: Option<f64>,
+}
+
 /// Engine configuration.
 #[derive(Debug, Clone)]
 pub struct EngineConfig {
@@ -151,6 +166,101 @@ impl Engine {
             z_score: signal.z_score,
             relative_volume: signal.relative_volume,
         }]
+    }
+
+    /// Process a bar and return full decision details for journaling.
+    /// Same logic as `on_bar()` but captures feature state, signal, and risk gate results.
+    pub fn on_bar_journaled(&mut self, bar: &Bar) -> BarOutcome {
+        self.bar_counter += 1;
+
+        // 1. Update features
+        let feature_state = self
+            .features
+            .entry(bar.symbol.clone())
+            .or_insert_with(FeatureState::new);
+
+        let features = feature_state.update(bar.close, bar.high, bar.low, bar.volume);
+        self.last_features.insert(bar.symbol.clone(), features.clone());
+
+        // 2. Check exit rules on open positions
+        if let Some(pos) = self.open_positions.get(&bar.symbol) {
+            if let Some(exit_intent) = exit::check(pos, bar.close, self.bar_counter, &self.exit_config) {
+                return BarOutcome {
+                    features,
+                    signal_fired: true,
+                    signal_side: Some(exit_intent.side),
+                    signal_score: Some(exit_intent.signal_score),
+                    signal_reason: Some(exit_intent.reason),
+                    risk_passed: Some(true),
+                    risk_rejection: None,
+                    qty_approved: Some(exit_intent.qty),
+                    intents: vec![exit_intent],
+                };
+            }
+        }
+
+        // 3. Score via strategy
+        let has_position = self.open_positions.contains_key(&bar.symbol);
+        let signal = match self.strategy.score(&features, has_position) {
+            Some(s) => s,
+            None => {
+                return BarOutcome {
+                    features,
+                    intents: vec![],
+                    signal_fired: false,
+                    signal_side: None,
+                    signal_score: None,
+                    signal_reason: None,
+                    risk_passed: None,
+                    risk_rejection: None,
+                    qty_approved: None,
+                };
+            }
+        };
+
+        // 4. Risk gates
+        let position_qty = self.portfolio.position_qty(&bar.symbol);
+        match risk::check(
+            &signal,
+            bar.close,
+            position_qty,
+            &self.risk_state,
+            &self.risk_config,
+        ) {
+            Ok(qty) => {
+                let intent = OrderIntent {
+                    symbol: bar.symbol.clone(),
+                    side: signal.side,
+                    qty,
+                    reason: signal.reason,
+                    signal_score: signal.score,
+                    z_score: signal.z_score,
+                    relative_volume: signal.relative_volume,
+                };
+                BarOutcome {
+                    features,
+                    signal_fired: true,
+                    signal_side: Some(signal.side),
+                    signal_score: Some(signal.score),
+                    signal_reason: Some(signal.reason),
+                    risk_passed: Some(true),
+                    risk_rejection: None,
+                    qty_approved: Some(qty),
+                    intents: vec![intent],
+                }
+            }
+            Err(rejection) => BarOutcome {
+                features,
+                intents: vec![],
+                signal_fired: true,
+                signal_side: Some(signal.side),
+                signal_score: Some(signal.score),
+                signal_reason: Some(signal.reason),
+                risk_passed: Some(false),
+                risk_rejection: Some(rejection.reason),
+                qty_approved: None,
+            },
+        }
     }
 
     /// Notify engine that an order was filled (updates portfolio, risk, position tracking).

--- a/engine/crates/pybridge/src/lib.rs
+++ b/engine/crates/pybridge/src/lib.rs
@@ -9,9 +9,14 @@ use openquant_core::market_data::Bar;
 use openquant_core::signals::Side;
 use openquant_core::signals::mean_reversion;
 
+use openquant_journal::writer::{BarRecord, FillRecord};
+use openquant_journal::DataRuntime;
+
 #[pyclass]
 struct Engine {
     inner: CoreEngine,
+    journal: Option<DataRuntime>,
+    engine_version: String,
 }
 
 #[pymethods]
@@ -26,6 +31,7 @@ impl Engine {
         stop_loss_pct = 0.02,
         max_hold_bars = 100,
         take_profit_pct = 0.0,
+        journal_path = None,
     ))]
     fn new(
         max_position_notional: f64,
@@ -36,6 +42,7 @@ impl Engine {
         stop_loss_pct: f64,
         max_hold_bars: usize,
         take_profit_pct: f64,
+        journal_path: Option<String>,
     ) -> Self {
         let config = EngineConfig {
             signal: mean_reversion::Config {
@@ -55,12 +62,30 @@ impl Engine {
                 take_profit_pct,
             },
         };
+
+        // Get engine version from git
+        let engine_version = option_env!("CARGO_PKG_VERSION")
+            .unwrap_or("dev")
+            .to_string();
+
+        // Start journal if path provided
+        let journal = journal_path.map(|path| {
+            let p = std::path::PathBuf::from(path);
+            if let Some(parent) = p.parent() {
+                std::fs::create_dir_all(parent).ok();
+            }
+            DataRuntime::new(&p, 4096)
+        });
+
         Self {
             inner: CoreEngine::new(config),
+            journal,
+            engine_version,
         }
     }
 
     /// Feed a bar, get back list of order intent dicts.
+    /// If journal is enabled, logs the full bar record (features + decision).
     #[pyo3(signature = (symbol, timestamp, open, high, low, close, volume))]
     fn on_bar<'py>(
         &mut self,
@@ -78,9 +103,41 @@ impl Engine {
             timestamp, open, high, low, close, volume,
         };
 
-        let intents = self.inner.on_bar(&bar);
-        let mut results = Vec::with_capacity(intents.len());
+        // Use journaled path if journal is active, otherwise fast path
+        let (intents, journal_record) = if self.journal.is_some() {
+            let outcome = self.inner.on_bar_journaled(&bar);
+            let record = BarRecord {
+                symbol: bar.symbol.clone(),
+                timestamp: bar.timestamp,
+                open: bar.open,
+                high: bar.high,
+                low: bar.low,
+                close: bar.close,
+                volume: bar.volume,
+                features: outcome.features,
+                signal_fired: outcome.signal_fired,
+                signal_side: outcome.signal_side.map(|s| match s {
+                    Side::Buy => "buy".to_string(),
+                    Side::Sell => "sell".to_string(),
+                }),
+                signal_score: outcome.signal_score,
+                signal_reason: outcome.signal_reason,
+                risk_passed: outcome.risk_passed,
+                risk_rejection: outcome.risk_rejection,
+                qty_approved: outcome.qty_approved,
+                engine_version: self.engine_version.clone(),
+            };
+            (outcome.intents, Some(record))
+        } else {
+            (self.inner.on_bar(&bar), None)
+        };
 
+        // Send to journal (non-blocking)
+        if let (Some(rt), Some(record)) = (&self.journal, journal_record) {
+            rt.journal().log_bar(record);
+        }
+
+        let mut results = Vec::with_capacity(intents.len());
         for intent in &intents {
             let dict = PyDict::new(py);
             dict.set_item("symbol", &intent.symbol)?;
@@ -103,12 +160,25 @@ impl Engine {
     /// Notify engine of a fill (updates portfolio and risk state).
     #[pyo3(signature = (symbol, side, qty, fill_price))]
     fn on_fill(&mut self, symbol: &str, side: &str, qty: f64, fill_price: f64) -> PyResult<()> {
-        let side = match side {
+        let side_enum = match side {
             "buy" => Side::Buy,
             "sell" => Side::Sell,
             _ => return Err(pyo3::exceptions::PyValueError::new_err("side must be 'buy' or 'sell'")),
         };
-        self.inner.on_fill(symbol, side, qty, fill_price);
+        self.inner.on_fill(symbol, side_enum, qty, fill_price);
+
+        // Journal the fill
+        if let Some(rt) = &self.journal {
+            rt.journal().log_fill(FillRecord {
+                symbol: symbol.to_string(),
+                side: side.to_string(),
+                qty,
+                fill_price,
+                slippage: 0.0,
+                engine_version: self.engine_version.clone(),
+            });
+        }
+
         Ok(())
     }
 
@@ -151,6 +221,20 @@ impl Engine {
             results.push(dict);
         }
         Ok(results)
+    }
+
+    /// Number of journal records dropped due to backpressure.
+    fn journal_dropped(&self) -> u64 {
+        self.journal.as_ref()
+            .map(|rt| rt.journal().dropped_count())
+            .unwrap_or(0)
+    }
+
+    /// Gracefully shut down the journal (flushes all pending writes).
+    fn shutdown_journal(&mut self) {
+        if let Some(rt) = self.journal.take() {
+            rt.shutdown();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- **`Engine::on_bar_journaled()`** — new method that captures full decision context (features, signal, risk gate result) alongside order intents
- **Pybridge `journal_path` parameter** — pass `Engine(journal_path="data/journal/journal.db")` to enable journaling
- **Automatic logging** — `on_bar()` logs BarRecord, `on_fill()` logs FillRecord via async channel to the data runtime
- **`journal_dropped()` / `shutdown_journal()`** — Python methods for monitoring and graceful shutdown
- **Zero overhead when disabled** — without `journal_path`, uses original `on_bar()` path

## What gets logged per bar

| Table | Content |
|---|---|
| `bars` | OHLCV data as received |
| `features` | z-score, volatility, SMA, relative volume, close location |
| `decisions` | signal fired? side, score, reason, risk passed/rejected |
| `fills` | symbol, side, qty, price, slippage, engine version |

## Example queries enabled

```sql
-- Feature context 3 bars before each signal
SELECT b.id, f.return_z_score, f.relative_volume
FROM features f JOIN bars b ON f.bar_id = b.id
WHERE b.id BETWEEN signal_bar - 3 AND signal_bar;

-- Missed opportunities
SELECT * FROM features f JOIN decisions d ON d.bar_id = f.bar_id
WHERE f.return_z_score < -2.0 AND d.signal_fired = 0;

-- Volume profile: signal vs quiet bars
SELECT d.signal_fired, AVG(f.relative_volume)
FROM decisions d JOIN features f ON d.bar_id = f.bar_id
GROUP BY d.signal_fired;
```

## Test plan

- [x] Rust tests pass (`cargo test -p openquant-core -p openquant-journal`)
- [x] End-to-end test: 37 bars logged, 2 signals, 2 fills, all queries work
- [x] Zero dropped records under normal load

---
Generated with [Claude Code](https://claude.com/claude-code)