### PR TITLE
Enable JSONL metrics recorder from Python

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -535,6 +535,7 @@ version = "0.1.0"
 dependencies = [
  "openquant-core",
  "openquant-journal",
+ "openquant-metrics",
  "pyo3",
  "serde_json",
 ]

--- a/engine/crates/journal/src/runtime.rs
+++ b/engine/crates/journal/src/runtime.rs
@@ -48,6 +48,11 @@ impl DataRuntime {
         }
     }
 
+    /// Access the underlying Tokio runtime (for installing metrics, etc.).
+    pub fn runtime(&self) -> &tokio::runtime::Runtime {
+        &self.runtime
+    }
+
     /// Get a clone of the journal handle for sending records.
     pub fn journal(&self) -> JournalHandle {
         self.handle.as_ref().expect("runtime not started").clone()

--- a/engine/crates/pybridge/Cargo.toml
+++ b/engine/crates/pybridge/Cargo.toml
@@ -10,5 +10,6 @@ crate-type = ["cdylib"]
 [dependencies]
 openquant-core = { path = "../core" }
 openquant-journal = { path = "../journal" }
+openquant-metrics = { path = "../metrics" }
 pyo3 = { version = "0.24", features = ["extension-module"] }
 serde_json = "1"

--- a/engine/crates/pybridge/src/lib.rs
+++ b/engine/crates/pybridge/src/lib.rs
@@ -13,6 +13,12 @@ use std::collections::HashMap;
 use openquant_journal::DataRuntime;
 use openquant_journal::writer::{BarRecord, FillRecord};
 
+/// Install the JSONL metrics recorder if not already installed.
+/// Requires a Tokio runtime (provided by the journal's DataRuntime).
+fn try_install_metrics(metrics_dir: &str) {
+    let _ = openquant_metrics::install(metrics_dir, std::time::Duration::from_secs(10));
+}
+
 #[pyclass]
 struct Engine {
     inner: CoreEngine,
@@ -37,6 +43,8 @@ impl Engine {
         max_bar_age_seconds = 0,
         symbol_overrides = None,
         journal_path = None,
+        metrics_enabled = false,
+        metrics_dir = "data/metrics",
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -53,6 +61,8 @@ impl Engine {
         max_bar_age_seconds: i64,
         symbol_overrides: Option<&Bound<'_, PyDict>>,
         journal_path: Option<String>,
+        metrics_enabled: bool,
+        metrics_dir: &str,
     ) -> PyResult<Self> {
         // Parse per-symbol overrides from Python dict
         let overrides = match symbol_overrides {
@@ -123,7 +133,7 @@ impl Engine {
             },
             symbol_overrides: overrides,
             max_bar_age_ms: max_bar_age_seconds * 1000,
-            metrics_enabled: false,
+            metrics_enabled,
         };
 
         // Get engine version from git
@@ -147,6 +157,15 @@ impl Engine {
             }
             None => None,
         };
+
+        // Install metrics recorder if enabled.
+        // The recorder's flush task needs a Tokio runtime — the journal's
+        // DataRuntime provides one. Without a journal, metrics still work
+        // (handles are noop without a recorder), but won't persist to disk.
+        if metrics_enabled && let Some(ref rt) = journal {
+            let _guard = rt.runtime().enter();
+            try_install_metrics(metrics_dir);
+        }
 
         Ok(Self {
             inner: CoreEngine::new(config),
@@ -332,9 +351,10 @@ impl Engine {
         Ok(dict)
     }
 
-    /// Gracefully shut down the journal (flushes all pending writes).
+    /// Gracefully shut down the journal and metrics (flushes all pending writes).
     fn shutdown_journal(&mut self) {
         if let Some(rt) = self.journal.take() {
+            rt.runtime().block_on(openquant_metrics::shutdown());
             rt.shutdown();
         }
     }
@@ -344,8 +364,12 @@ impl Engine {
     /// Reads the file, parses all sections, and builds the engine.
     /// Optional `journal_path` enables journaling (not in TOML — runtime concern).
     #[staticmethod]
-    #[pyo3(signature = (config_path, journal_path = None))]
-    fn from_toml(config_path: &str, journal_path: Option<String>) -> PyResult<Self> {
+    #[pyo3(signature = (config_path, journal_path = None, metrics_dir = "data/metrics"))]
+    fn from_toml(
+        config_path: &str,
+        journal_path: Option<String>,
+        metrics_dir: &str,
+    ) -> PyResult<Self> {
         let cfg_file = openquant_core::config::ConfigFile::load(std::path::Path::new(config_path))
             .map_err(pyo3::exceptions::PyValueError::new_err)?;
 
@@ -353,6 +377,7 @@ impl Engine {
             .unwrap_or("dev")
             .to_string();
 
+        let wants_metrics = cfg_file.metrics_enabled();
         let config = cfg_file.into_engine_config();
 
         let journal = match journal_path {
@@ -371,6 +396,11 @@ impl Engine {
             None => None,
         };
 
+        if wants_metrics && let Some(ref rt) = journal {
+            let _guard = rt.runtime().enter();
+            try_install_metrics(metrics_dir);
+        }
+
         Ok(Self {
             inner: CoreEngine::new(config),
             journal,
@@ -382,6 +412,7 @@ impl Engine {
 impl Drop for Engine {
     fn drop(&mut self) {
         if let Some(rt) = self.journal.take() {
+            rt.runtime().block_on(openquant_metrics::shutdown());
             rt.shutdown();
         }
     }

--- a/paper_trading/runner.py
+++ b/paper_trading/runner.py
@@ -210,6 +210,10 @@ def main():
     parser.add_argument("--max-retries", type=int, default=10, help="Max consecutive errors before exit")
     parser.add_argument("--max-bar-age", type=int, default=300,
                         help="Max bar age in seconds before skipping signals (0=disabled, default=300)")
+    parser.add_argument("--no-metrics", action="store_true",
+                        help="Disable JSONL metrics recording")
+    parser.add_argument("--metrics-dir", default="data/metrics",
+                        help="Directory for metrics JSONL files")
     args = parser.parse_args()
 
     engine = Engine(
@@ -218,6 +222,8 @@ def main():
         trend_filter=not args.no_trend_filter,
         journal_path=args.journal,
         max_bar_age_seconds=args.max_bar_age,
+        metrics_enabled=not args.no_metrics,
+        metrics_dir=args.metrics_dir,
     )
 
     run(args.symbol, args.interval, engine, max_retries=args.max_retries)


### PR DESCRIPTION
## Summary
- Wire up the `openquant-metrics` JSONL recorder so it actually gets installed when `metrics_enabled=true`
- Add `metrics_enabled` + `metrics_dir` params to `Engine()` constructor and `from_toml()`
- Install recorder on the journal's Tokio runtime (via `DataRuntime::runtime()`)
- Flush metrics on `shutdown_journal()` and `Drop`
- Live runner defaults to `metrics_enabled=True` with `--no-metrics` opt-out
- Backtest stays `metrics_enabled=false` (no Tokio runtime needed)

## Metrics output
`data/metrics/metrics-YYYY-MM-DD.jsonl` with per-symbol:
- **Counters**: `engine.bars_processed`, `signal.fired`, `signal.rejected`, `risk.passed`, `risk.rejected`, `exit.triggered`
- **Histograms**: `engine.on_bar.duration_ns`, `features.z_score`, `features.relative_volume`

## Test plan
- [x] End-to-end test: Engine with metrics_enabled=True produces JSONL file with correct counters/histograms
- [x] All 108 Rust tests pass
- [x] Pre-commit hooks pass (fmt + clippy)
- [x] Verified metrics flush on shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)