### PR TITLE
Display bar timestamps in Eastern Time

### DIFF
--- a/paper_trading/runner_multi.py
+++ b/paper_trading/runner_multi.py
@@ -14,6 +14,7 @@ import signal
 import sys
 import time
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
 from openquant import Engine
 
@@ -171,7 +172,7 @@ def run(
 
                 ts = datetime.fromtimestamp(
                     bar_time / 1000, tz=timezone.utc
-                ).strftime("%H:%M:%S")
+                ).astimezone(ZoneInfo("America/New_York")).strftime("%H:%M:%S ET")
 
                 age = (datetime.now(timezone.utc) - datetime.fromtimestamp(bar_time / 1000, tz=timezone.utc)).total_seconds()
                 log.info(


### PR DESCRIPTION
## Summary
- Converts UTC bar timestamps to Eastern Time (ET) in live runner logs
- Moves `ZoneInfo` import to module top-level instead of per-iteration
- Makes it easier to correlate logged bar times with US market hours

## Test plan
- [ ] Run `python -m paper_trading.runner_multi --symbols AAPL` and verify timestamps show ET suffix
- [ ] Confirm no import errors on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)