### PR TITLE
Add sigmoid bet sizing for score-scaled positions (closes #65)

### DIFF
--- a/engine/crates/core/src/risk.rs
+++ b/engine/crates/core/src/risk.rs
@@ -10,6 +10,23 @@
 
 use crate::signals::{Side, SignalOutput};
 
+/// Bet sizing method.
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BetSizingMethod {
+    /// Fixed sizing: qty = max_notional / price (current behavior).
+    Linear,
+    /// Sigmoid scaling: qty = max_notional / price × sigmoid(score).
+    /// Higher conviction signals get larger positions.
+    Sigmoid,
+}
+
+impl Default for BetSizingMethod {
+    fn default() -> Self {
+        Self::Linear
+    }
+}
+
 /// Risk configuration.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(default)]
@@ -22,6 +39,12 @@ pub struct RiskConfig {
     pub min_reward_cost_ratio: f64,
     /// Estimated round-trip cost as fraction of price. Default: 0.001 (10 bps)
     pub estimated_cost_bps: f64,
+    /// Bet sizing method: "linear" (fixed) or "sigmoid" (score-scaled). Default: linear
+    pub bet_sizing: BetSizingMethod,
+    /// Sigmoid steepness — higher = sharper transition. Default: 10.0
+    pub sigmoid_slope: f64,
+    /// Sigmoid center — score at which sizing = 50% of max. Default: 0.5
+    pub sigmoid_center: f64,
 }
 
 impl Default for RiskConfig {
@@ -31,8 +54,17 @@ impl Default for RiskConfig {
             max_daily_loss: 500.0,
             min_reward_cost_ratio: 3.0,
             estimated_cost_bps: 0.001,
+            bet_sizing: BetSizingMethod::Linear,
+            sigmoid_slope: 10.0,
+            sigmoid_center: 0.5,
         }
     }
+}
+
+/// Sigmoid function mapping score to [0, 1] confidence.
+/// sigmoid(score) = 1 / (1 + exp(-slope * (score - center)))
+fn sigmoid(score: f64, slope: f64, center: f64) -> f64 {
+    1.0 / (1.0 + (-slope * (score - center)).exp())
 }
 
 /// Mutable risk state that tracks daily P&L.
@@ -115,11 +147,21 @@ pub fn check(
     let qty = match signal.side {
         Side::Buy => {
             let max_qty = config.max_position_notional / price;
+
+            // Apply bet sizing method
+            let scale = match config.bet_sizing {
+                BetSizingMethod::Linear => 1.0,
+                BetSizingMethod::Sigmoid => {
+                    sigmoid(signal.score, config.sigmoid_slope, config.sigmoid_center)
+                }
+            };
+            let scaled_qty = max_qty * scale;
+
             // Allow fractional quantities (crypto). Cap at 100 units for stocks.
             let desired = if price > 1000.0 {
-                max_qty // fractional for expensive assets
+                scaled_qty // fractional for expensive assets
             } else {
-                max_qty.min(100.0).floor() // whole shares for cheaper ones
+                scaled_qty.min(100.0).floor() // whole shares for cheaper ones
             };
             if desired <= 0.0 {
                 return Err(Rejection {
@@ -228,5 +270,54 @@ mod tests {
         state.reset_daily();
         assert!(!state.killed);
         assert_eq!(state.daily_pnl, 0.0);
+    }
+
+    #[test]
+    fn test_sigmoid_function() {
+        // At center, sigmoid = 0.5
+        assert!((sigmoid(0.5, 10.0, 0.5) - 0.5).abs() < 1e-10);
+        // Well above center → close to 1.0
+        assert!(sigmoid(1.0, 10.0, 0.5) > 0.99);
+        // Well below center → close to 0.0
+        assert!(sigmoid(0.0, 10.0, 0.5) < 0.01);
+        // Higher slope = sharper transition
+        assert!(sigmoid(0.6, 20.0, 0.5) > sigmoid(0.6, 5.0, 0.5));
+    }
+
+    #[test]
+    fn test_sigmoid_bet_sizing_scales_qty() {
+        let state = RiskState::new();
+        let config = RiskConfig {
+            max_position_notional: 10_000.0,
+            min_reward_cost_ratio: 0.0,
+            bet_sizing: BetSizingMethod::Sigmoid,
+            sigmoid_slope: 10.0,
+            sigmoid_center: 0.5,
+            ..Default::default()
+        };
+
+        // High score → large position
+        let high = check(&buy_signal(1.0), 100.0, 0.0, &state, &config).unwrap();
+        // Low score → small position (but above cost filter since ratio=0)
+        let low = check(&buy_signal(0.1), 100.0, 0.0, &state, &config).unwrap();
+
+        assert!(high > low, "high score ({high}) should get larger position than low score ({low})");
+        // Full linear qty would be 100 (10_000/100). Sigmoid at 1.0 is ~0.993 → ~99
+        assert!(high > 90.0, "high conviction should be near max, got {high}");
+    }
+
+    #[test]
+    fn test_linear_bet_sizing_ignores_score() {
+        let state = RiskState::new();
+        let config = RiskConfig {
+            max_position_notional: 10_000.0,
+            min_reward_cost_ratio: 0.0,
+            bet_sizing: BetSizingMethod::Linear,
+            ..Default::default()
+        };
+
+        let high = check(&buy_signal(1.0), 100.0, 0.0, &state, &config).unwrap();
+        let low = check(&buy_signal(0.1), 100.0, 0.0, &state, &config).unwrap();
+        assert_eq!(high, low, "linear sizing should give same qty regardless of score");
     }
 }

--- a/openquant.toml
+++ b/openquant.toml
@@ -199,6 +199,20 @@ min_reward_cost_ratio = 3.0
 # Typical values: 0.001 (1 bp) for maker, 0.002-0.003 for taker.
 estimated_cost_bps = 0.001
 
+# Bet sizing method: "linear" (fixed qty) or "sigmoid" (score-scaled).
+# Sigmoid maps signal score through a sigmoid curve so higher conviction
+# signals get larger positions. Default: "linear" (backward compatible).
+# Note: sigmoid needs tuning of slope/center per strategy before enabling.
+bet_sizing = "linear"
+
+# Sigmoid steepness — higher = sharper transition around center.
+# 10.0 gives smooth scaling; 20.0 is more binary (low or full size).
+sigmoid_slope = 10.0
+
+# Score at which sigmoid outputs 50% of max position size.
+# Below this: smaller positions. Above: larger positions.
+sigmoid_center = 0.5
+
 
 # ---------------------------------------------------------------------------
 # Exit — stop-loss, take-profit, and time-based exits


### PR DESCRIPTION
## Summary

- Add opt-in **sigmoid bet sizing** that scales position size by signal conviction
- `qty = max_notional / price × sigmoid(score, slope, center)`
- Higher conviction signals get larger positions, low conviction get smaller
- Config: `bet_sizing = "sigmoid"`, `sigmoid_slope = 10.0`, `sigmoid_center = 0.5`
- Default: `"linear"` (backward compatible, no behavior change)

## Backtest comparison (March 17 replay)

### With old config (min_exit_strategies=2)

| Metric | Linear | Sigmoid | Delta |
|--------|--------|---------|-------|
| Round trips | 59 | 45 | -14 |
| Win rate | 37.3% | 42.2% | **+4.9%** |
| Total P&L | $-152.66 | $-43.60 | **+$109.05** |

### With winning config (exp 22, min_exit_strategies=1)

| Metric | Linear | Sigmoid | Delta |
|--------|--------|---------|-------|
| Round trips | 70 | 52 | -18 |
| Win rate | 48.6% | 44.2% | -4.3% |
| Total P&L | $+176.28 | $+17.07 | -$159.21 |

**Conclusion**: Sigmoid helps when signals are noisy (old config) but over-dampens when exits are already fast (winning config). The default `sigmoid_center=0.5` is too aggressive — needs per-strategy tuning. Shipped as opt-in `"linear"` default.

## Test plan

- [x] `cargo test` — 247 tests pass (3 new: sigmoid function, sigmoid scaling, linear unchanged)
- [x] TOML parsing with new fields works
- [x] Default `"linear"` preserves existing behavior exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)