### PR TITLE
Add confidence decay for aging positions (closes #68)

### DIFF
--- a/engine/crates/core/src/engine.rs
+++ b/engine/crates/core/src/engine.rs
@@ -148,7 +148,8 @@ impl Engine {
             combiner::StrategyCombiner::new(strategies, config.combiner.min_net_score)
                 .with_min_strategies(config.combiner.min_strategies)
                 .with_min_exit_strategies(config.combiner.min_exit_strategies)
-                .with_cusum_entry_gate(config.combiner.cusum_entry_gate),
+                .with_cusum_entry_gate(config.combiner.cusum_entry_gate)
+                .with_exit_decay(&config.combiner),
         )
     }
 
@@ -275,7 +276,7 @@ impl Engine {
         // 1. Update features (always, even for stale bars — keeps warmup state correct)
         let feature_state = self.features.entry(bar.symbol.clone()).or_default();
 
-        let features =
+        let mut features =
             feature_state.update(bar.close, bar.high, bar.low, bar.volume, bar.timestamp);
         self.last_features
             .insert(bar.symbol.clone(), features.clone());
@@ -324,6 +325,12 @@ impl Engine {
 
         // 3. Score via strategy (per-symbol strategy, only if no exit and no position)
         let has_position = self.open_positions.contains_key(&bar.symbol);
+        // Inject bars_held for confidence decay
+        features.bars_held = self
+            .open_positions
+            .get(&bar.symbol)
+            .map(|p| self.bar_counter.saturating_sub(p.entry_bar))
+            .unwrap_or(0);
         let strategy = self.strategy_for(&bar.symbol);
         let signal = match strategy.score(&features, has_position) {
             Some(s) => s,
@@ -408,7 +415,7 @@ impl Engine {
         // 1. Update features (always, even for stale bars)
         let feature_state = self.features.entry(bar.symbol.clone()).or_default();
 
-        let features =
+        let mut features =
             feature_state.update(bar.close, bar.high, bar.low, bar.volume, bar.timestamp);
         self.last_features
             .insert(bar.symbol.clone(), features.clone());
@@ -477,6 +484,11 @@ impl Engine {
 
         // 3. Score via strategy (per-symbol)
         let has_position = self.open_positions.contains_key(&bar.symbol);
+        features.bars_held = self
+            .open_positions
+            .get(&bar.symbol)
+            .map(|p| self.bar_counter.saturating_sub(p.entry_bar))
+            .unwrap_or(0);
         let strategy = self.strategy_for(&bar.symbol);
         let signal = match strategy.score(&features, has_position) {
             Some(s) => s,

--- a/engine/crates/core/src/features/mod.rs
+++ b/engine/crates/core/src/features/mod.rs
@@ -103,6 +103,9 @@ pub struct FeatureValues {
 
     // --- V4: CUSUM structural break detection ---
     pub cusum_triggered: bool, // true when cumulative returns exceed threshold
+
+    // --- Engine-injected context (not computed by feature pipeline) ---
+    pub bars_held: usize, // bars since position entry (0 if no position), set by engine
 }
 
 // ---------------------------------------------------------------------------
@@ -361,6 +364,7 @@ impl FeatureState {
             squeeze,
             bandwidth_percentile,
             cusum_triggered,
+            bars_held: 0, // set by engine before strategy.score()
         }
     }
 }

--- a/engine/crates/core/src/signals/combiner.rs
+++ b/engine/crates/core/src/signals/combiner.rs
@@ -96,6 +96,16 @@ pub struct Config {
     /// When true, BUY signals are blocked unless features.cusum_triggered is set.
     /// Does NOT affect SELL/exit signals — positions can always be closed.
     pub cusum_entry_gate: bool,
+
+    /// Enable confidence decay for aging positions. Default: true.
+    /// Progressively lowers exit threshold for positions held beyond decay_start_bars.
+    pub exit_decay_enabled: bool,
+    /// Bars before decay begins. Default: 30 (~30 min at 1-min bars).
+    pub exit_decay_start_bars: usize,
+    /// Bars over which decay ramps to full effect. Default: 60.
+    pub exit_decay_window: usize,
+    /// Maximum decay fraction (0.0-1.0). Default: 0.8 (reduce threshold by 80%).
+    pub exit_decay_rate: f64,
 }
 
 impl Default for Config {
@@ -110,6 +120,10 @@ impl Default for Config {
             weight_vwap_reversion: 0.0,
             weight_breakout: 0.0,
             cusum_entry_gate: false,
+            exit_decay_enabled: true,
+            exit_decay_start_bars: 30,
+            exit_decay_window: 60,
+            exit_decay_rate: 0.8,
         }
     }
 }
@@ -125,6 +139,10 @@ pub struct StrategyCombiner {
     min_strategies: usize,
     min_exit_strategies: usize,
     cusum_entry_gate: bool,
+    exit_decay_enabled: bool,
+    exit_decay_start_bars: usize,
+    exit_decay_window: usize,
+    exit_decay_rate: f64,
 }
 
 impl StrategyCombiner {
@@ -135,6 +153,10 @@ impl StrategyCombiner {
             min_strategies: 1,
             min_exit_strategies: 2,
             cusum_entry_gate: false,
+            exit_decay_enabled: true,
+            exit_decay_start_bars: 30,
+            exit_decay_window: 60,
+            exit_decay_rate: 0.8,
         }
     }
 
@@ -150,6 +172,14 @@ impl StrategyCombiner {
 
     pub fn with_cusum_entry_gate(mut self, enabled: bool) -> Self {
         self.cusum_entry_gate = enabled;
+        self
+    }
+
+    pub fn with_exit_decay(mut self, config: &Config) -> Self {
+        self.exit_decay_enabled = config.exit_decay_enabled;
+        self.exit_decay_start_bars = config.exit_decay_start_bars;
+        self.exit_decay_window = config.exit_decay_window;
+        self.exit_decay_rate = config.exit_decay_rate;
         self
     }
 }
@@ -211,9 +241,25 @@ impl Strategy for StrategyCombiner {
         // Exit gate: when holding a position and the net vote is SELL,
         // require more strategy agreement than for entries. This prevents
         // one strategy from immediately unwinding what another opened.
+        //
+        // Confidence decay: after decay_start_bars, progressively lower
+        // the effective threshold so stale positions exit faster.
         let num_sell_voters = vote_parts.iter().filter(|v| v.contains("SELL")).count();
-        if has_position && net < 0.0 && num_sell_voters < self.min_exit_strategies {
-            return None;
+        if has_position && net < 0.0 {
+            let effective_min_exit =
+                if self.exit_decay_enabled && features.bars_held > self.exit_decay_start_bars {
+                    let elapsed = (features.bars_held - self.exit_decay_start_bars) as f64;
+                    let decay =
+                        (elapsed / self.exit_decay_window as f64).min(1.0) * self.exit_decay_rate;
+                    let reduced = self.min_exit_strategies as f64 * (1.0 - decay);
+                    // Floor at 1 — always need at least one strategy to vote sell
+                    (reduced.ceil() as usize).max(1)
+                } else {
+                    self.min_exit_strategies
+                };
+            if num_sell_voters < effective_min_exit {
+                return None;
+            }
         }
 
         let votes = vote_parts.join("+");

--- a/openquant.toml
+++ b/openquant.toml
@@ -130,6 +130,14 @@ weight_breakout = 0.0
 # Try atr_multiplier < 0.5 or static threshold ~0.003 for lighter filtering.
 cusum_entry_gate = false
 
+# Confidence decay: progressively lower exit threshold for aging positions.
+# Only has effect when min_exit_strategies >= 2 (consensus mode).
+# With min_exit_strategies=1, exits already fire immediately — decay is a no-op.
+exit_decay_enabled = false
+exit_decay_start_bars = 30    # begin decay after 30 bars (~30 min)
+exit_decay_window = 60        # ramp to full decay over 60 bars
+exit_decay_rate = 0.8         # reduce exit threshold by up to 80%
+
 
 # ---------------------------------------------------------------------------
 # VWAP Reversion — volume-weighted average price mean-reversion


### PR DESCRIPTION
## Summary

- Add **confidence decay** that progressively lowers exit consensus threshold for aging positions
- Prevents stale positions from sitting until max_hold forced exit
- Infrastructure for future use — **disabled by default** with current config

## How it works

```
bars 0-30:   Normal exit rules (min_exit_strategies required)
bars 30-90:  Threshold decays linearly (80% reduction over 60 bars)
bars 90+:    Nearly any single sell signal triggers exit
```

## Backtest comparison (21-day cross-day validation)

### With current config (min_exit_strategies=1)

| Config | Trades | P&L | WR |
|--------|--------|-----|-----|
| Decay OFF | 1,351 | +$489 | 49.3% |
| Decay ON | 1,351 | +$489 | 49.3% |

**No effect** — min_exit_strategies=1 means exits already fire on any single sell vote. Nothing to decay.

### With consensus exits (min_exit_strategies=2)

| Config | Trades | P&L |
|--------|--------|-----|
| Decay OFF | — | -$380 |
| Decay ON | — | -$505 |

**Makes it worse** (-$125) — decay allows premature exits before reversion completes.

### Conclusion

The winning config (#69) already solved exit timing by setting min_exit_strategies=1. Decay is redundant with current config but provides useful infrastructure if we ever return to consensus-based exits (e.g., with regime detection).

## Test plan

- [x] `cargo test` — 260 tests pass
- [x] `cargo fmt && cargo clippy -- -D warnings` — clean
- [x] 21-day backtest: no regression (decay disabled)
- [x] Verified decay fires correctly with min_exit_strategies=2

🤖 Generated with [Claude Code](https://claude.com/claude-code)