### PR TITLE
Update GLD/SLV to PBO-validated params for live trading

### DIFF
--- a/openquant.toml
+++ b/openquant.toml
@@ -391,14 +391,20 @@ max_bar_age_seconds = 120
 # Per-symbol combiner weight overrides — data-driven from #110 baseline.
 # Categories: metals (profitable), oil/gas (mixed), tech/pharma/energy (losing).
 
-# --- Metals: PROFITABLE (+$1,233). Restore full mean-reversion. ---
+# --- Metals: PBO-validated configs (GLD PBO=6.7%, SLV PBO=46.7%) ---
 [symbol_overrides.GLD]
+buy_z_threshold = -2.0          # PBO-optimal (IS=+0.249, OOS=+0.228)
+sell_z_threshold = 1.5
+stop_loss_atr_mult = 2.0
 weight_mean_reversion = 0.40    # full mean-reversion (works on commodities)
 weight_momentum = 0.25
 weight_vwap_reversion = 0.35
 
 [symbol_overrides.SLV]
-weight_mean_reversion = 0.40    # SLV was +$1,071 alone
+buy_z_threshold = -2.5          # PBO-optimal (IS=+0.233, OOS=+0.302)
+sell_z_threshold = 2.5
+stop_loss_atr_mult = 2.0
+weight_mean_reversion = 0.40
 weight_momentum = 0.25
 weight_vwap_reversion = 0.35
 


### PR DESCRIPTION
## Summary
Update metals symbol overrides to PBO-validated optimal configs before live paper trading.

| Symbol | PBO | buy_z | sell_z | ATR mult |
|--------|-----|-------|--------|----------|
| GLD | 6.7% (PASS) | -2.0 | 1.5 | 2.0 |
| SLV | 46.7% (MARGINAL) | -2.5 | 2.5 | 2.0 |

Both retain full mean-reversion weight (0.40) — commodities have genuine reversion properties.

## Test plan
- [x] Config-only change
- [x] Engine loads from TOML verified
- [x] Alpaca API keys verified
- [x] runner_multi dry-run clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)