### PR TITLE
Fix Kelly sizing: reject zero/negative edge (#160)

### DIFF
--- a/engine/crates/core/src/risk.rs
+++ b/engine/crates/core/src/risk.rs
@@ -300,6 +300,14 @@ pub fn check(
                         MarketRegime::Unknown => config.kelly_fraction,
                     };
                     let raw = kelly_state.kelly_fraction();
+                    // Zero or negative edge → zero exposure. The min clamp is
+                    // for cold-start uncertainty on positive edge, not to override
+                    // the model when it says "don't bet." (#160)
+                    if raw <= 0.0 {
+                        return Err(Rejection {
+                            reason: "Kelly: zero or negative edge".into(),
+                        });
+                    }
                     let fractional = raw * regime_kelly * dd_mult;
                     fractional.clamp(config.kelly_min_size, config.kelly_max_size)
                 }


### PR DESCRIPTION
## Summary

Kelly fraction clamp (`min_size=0.05`) was forcing 5% position even when raw Kelly <= 0 (zero/negative edge). Now returns `Rejection` before the clamp.

Currently mitigated by `bet_sizing="linear"` but would be live when we switch to Kelly after 50+ trades.

All risk tests pass.

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)