### PR TITLE
Skip refresh in replay mode; filter to candidate symbols in live

### DIFF
--- a/engine/crates/runner/src/main.rs
+++ b/engine/crates/runner/src/main.rs
@@ -161,6 +161,33 @@ struct ReplayArgs {
 
 const DEFAULT_CONFIG: &str = "config/pairs.toml";
 
+/// Extract the unique symbols (leg_a/leg_b) from a candidates JSON file.
+///
+/// Used to narrow the refresh pass in live/paper mode — the engine only reads bars
+/// for symbols that appear in the candidate pairs, so refreshing the rest is waste.
+/// Returns `None` on read/parse failure so the caller can fall back to a full refresh.
+fn load_symbols_from_candidates(path: &std::path::Path) -> Option<Vec<String>> {
+    #[derive(serde::Deserialize)]
+    struct Pair {
+        leg_a: String,
+        leg_b: String,
+    }
+    #[derive(serde::Deserialize)]
+    struct File {
+        pairs: Vec<Pair>,
+    }
+    let content = std::fs::read_to_string(path).ok()?;
+    let file: File = serde_json::from_str(&content).ok()?;
+    let mut symbols: Vec<String> = file
+        .pairs
+        .into_iter()
+        .flat_map(|p| [p.leg_a, p.leg_b])
+        .collect();
+    symbols.sort();
+    symbols.dedup();
+    Some(symbols)
+}
+
 /// Resolve engine-specific defaults for config, candidates, and pipeline.
 /// Explicit CLI flags always override engine defaults.
 fn resolve_engine(
@@ -312,14 +339,22 @@ async fn run(
         }
     };
 
-    // ── Refresh quant-data before anything else ──
-    // Brings parquet bars up to today, checks contiguity, fixes gaps.
-    {
+    // ── Refresh quant-data (live/paper only) ──
+    // Replay reads static historical parquets — refresh would fetch [today, today+1)
+    // which returns zero bars for every symbol and wastes ~4 minutes of startup.
+    // Live/paper needs fresh bars, but only for symbols in the active candidates file;
+    // refreshing the other ~436 symbols in a 501-symbol universe is dead work.
+    if matches!(run_mode, RunMode::Stream(_)) {
         let bars_dir = refresh::default_bars_dir();
         if bars_dir.exists() {
+            let filter = candidates.as_deref().and_then(load_symbols_from_candidates);
             let target = chrono::Utc::now().format("%Y-%m-%d").to_string();
-            info!(target = target.as_str(), "refreshing quant-data bars");
-            match refresh::refresh_all(&bars_dir, &target, &alpaca).await {
+            info!(
+                target = target.as_str(),
+                filter_count = filter.as_ref().map(Vec::len).unwrap_or(0),
+                "refreshing quant-data bars"
+            );
+            match refresh::refresh_all(&bars_dir, &target, &alpaca, filter.as_deref()).await {
                 Ok(n) if n > 0 => info!(bars = n, "quant-data refreshed"),
                 Ok(_) => info!("quant-data already up to date"),
                 Err(e) => warn!(
@@ -330,6 +365,8 @@ async fn run(
         } else {
             warn!(path = %bars_dir.display(), "quant-data dir not found — skipping refresh");
         }
+    } else {
+        info!("replay mode: skipping quant-data refresh (parquets are static)");
     }
 
     // ── Load config ──

--- a/engine/crates/runner/src/refresh.rs
+++ b/engine/crates/runner/src/refresh.rs
@@ -274,7 +274,11 @@ fn bootstrap_fulfilled(
     fulfilled: &mut Fulfilled,
     today: NaiveDate,
 ) {
-    if fulfilled.get(symbol).map(|s| !s.is_empty()).unwrap_or(false) {
+    if fulfilled
+        .get(symbol)
+        .map(|s| !s.is_empty())
+        .unwrap_or(false)
+    {
         return;
     }
     if timestamps.is_empty() {
@@ -497,23 +501,40 @@ pub async fn refresh_symbol(
     Ok(added)
 }
 
-/// Refresh all symbols in bars_dir to target_date.
+/// Refresh symbols in bars_dir to target_date.
+///
+/// When `filter` is `Some`, only symbols listed there (that also exist as parquets)
+/// are refreshed. When `None`, every parquet in `bars_dir` is refreshed. In live/paper
+/// mode the engine only reads bars for active-pair symbols, so filtering cuts ~4 min
+/// of startup work on a 501-symbol universe.
 pub async fn refresh_all(
     bars_dir: &Path,
     target_date: &str,
     client: &AlpacaClient,
+    filter: Option<&[String]>,
 ) -> Result<usize, String> {
-    let mut symbols: Vec<String> = Vec::new();
+    let mut available: Vec<String> = Vec::new();
     for entry in std::fs::read_dir(bars_dir).map_err(|e| format!("read dir: {e}"))? {
         let entry = entry.map_err(|e| format!("entry: {e}"))?;
         let path = entry.path();
         if path.extension().is_some_and(|ext| ext == "parquet") {
             if let Some(stem) = path.file_stem() {
-                symbols.push(stem.to_string_lossy().to_string());
+                available.push(stem.to_string_lossy().to_string());
             }
         }
     }
-    symbols.sort();
+    available.sort();
+
+    let symbols: Vec<String> = match filter {
+        Some(wanted) => {
+            let want: std::collections::HashSet<&str> = wanted.iter().map(String::as_str).collect();
+            available
+                .into_iter()
+                .filter(|s| want.contains(s.as_str()))
+                .collect()
+        }
+        None => available,
+    };
 
     info!(
         symbols = symbols.len(),
@@ -546,7 +567,10 @@ pub async fn refresh_all(
             // Periodically persist fulfilled state in case of crash
             fulfilled.last_updated = Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
             if let Err(e) = save_fulfilled(bars_dir, &fulfilled) {
-                warn!(error = e.as_str(), "failed to persist fulfilled.json mid-run");
+                warn!(
+                    error = e.as_str(),
+                    "failed to persist fulfilled.json mid-run"
+                );
             }
         }
     }
@@ -669,7 +693,10 @@ mod tests {
         f.insert("TEST", "2026-04-10".to_string());
         f.insert("TEST", "2026-04-09".to_string());
         let got = latest_fulfilled("TEST", &f).unwrap();
-        assert_eq!(got, NaiveDate::parse_from_str("2026-04-10", "%Y-%m-%d").unwrap());
+        assert_eq!(
+            got,
+            NaiveDate::parse_from_str("2026-04-10", "%Y-%m-%d").unwrap()
+        );
     }
 
     #[test]
@@ -717,5 +744,4 @@ mod tests {
         assert_eq!(c[0], 100.5);
         assert_eq!(v[0], 1000);
     }
-
 }


### PR DESCRIPTION
## Summary

- **Replay mode**: Skip refresh entirely — parquets are static historical data, so fetching [today, today+1) returns zero bars and wastes ~4 minutes of startup
- **Live/paper mode**: Filter refresh to only symbols in the active candidates file (~65 unique symbols from ~100 pairs vs 501 total), cutting refresh work by ~87%
- Added `filter: Option<&[String]>` param to `refresh_all()` for selective refresh

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy -D warnings` clean
- [x] `cargo fmt --check` passes
- [x] Verified replay logs `replay mode: skipping quant-data refresh (parquets are static)`
- [ ] Q1 2026 baseline replay in progress — will verify 38 trades, 73.7%, +3399 bps

🤖 Generated with [Claude Code](https://claude.com/claude-code)