### PR TITLE
M6: Basket live/paper runner with shadow mode

### DIFF
--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -116,8 +116,6 @@ pub async fn run_basket_live(
         "loaded warmup closes"
     );
 
-    // Build price-history map for validator (HashMap<symbol, Vec<f64>> aligned by date).
-    let price_history = align_history(&closes);
     let validator_config = ValidatorConfig {
         residual_window: universe.strategy.residual_window_days,
         k_clip_min: universe.strategy.threshold_clip_min,
@@ -125,10 +123,20 @@ pub async fn run_basket_live(
         cost: universe.strategy.cost_bps_assumed / 10_000.0,
     };
 
+    // Validate each candidate with its OWN per-basket date intersection.
+    // A universe-wide intersection lets one sparse symbol shrink every series
+    // below `residual_window` and reject otherwise-valid baskets, even when
+    // the candidate's own symbols have sufficient history.
     let fits: Vec<_> = universe
         .candidates
         .iter()
-        .map(|c| validate(c, &price_history, &validator_config))
+        .map(|c| {
+            let mut basket_symbols: Vec<&str> = Vec::with_capacity(c.members.len() + 1);
+            basket_symbols.push(c.target.as_str());
+            basket_symbols.extend(c.members.iter().map(String::as_str));
+            let aligned = align_basket_history(&closes, &basket_symbols);
+            validate(c, &aligned, &validator_config)
+        })
         .collect();
     let valid_count = fits.iter().filter(|f| f.valid).count();
     info!(
@@ -147,12 +155,16 @@ pub async fn run_basket_live(
     //    Without this, a restart with live open positions would trigger
     //    target-minus-zero deltas, flooding Alpaca with duplicate orders.
     //    Noop skips this (no Alpaca account needed for shadow mode).
+    //    Paper/Live FAIL CLOSED: if reconciliation cannot load open positions,
+    //    we refuse to start. Trading from an empty notional map would diff
+    //    targets against zero and flood Alpaca with duplicate orders against
+    //    already-open broker positions, potentially double-sizing every leg.
     let mut current_notionals = match execution.alpaca_mode() {
         None => {
             info!("noop mode — skipping startup position reconciliation");
             HashMap::new()
         }
-        Some(mode) => seed_current_notionals_from_alpaca(alpaca, mode).await,
+        Some(mode) => seed_current_notionals_from_alpaca(alpaca, mode).await?,
     };
 
     // 3. Subscribe to all universe symbols over WebSocket.
@@ -240,33 +252,29 @@ pub async fn run_basket_live(
 
 /// Fetch open positions from Alpaca and express them as signed notional per symbol.
 /// Used on startup so `diff_to_orders` computes correct deltas from the engine's target.
+///
+/// Returns `Err` on any fetch failure; the caller must treat this as fatal for
+/// paper/live execution (trading from an empty notional map would double-size
+/// every already-open leg on the first session).
 async fn seed_current_notionals_from_alpaca(
     alpaca: &AlpacaClient,
     mode: ExecutionMode,
-) -> HashMap<String, f64> {
-    match alpaca.get_positions(mode).await {
-        Ok(positions) => {
-            let notionals: HashMap<String, f64> = positions
-                .into_iter()
-                .map(|(sym, (qty, avg_entry))| (sym, qty * avg_entry))
-                .collect();
-            info!(
-                n_positions = notionals.len(),
-                "seeded current_notionals from Alpaca open positions"
-            );
-            notionals
-        }
-        Err(e) => {
-            // Fail closed: if we can't read positions, we can't safely diff. Warn loudly
-            // and return empty so the operator notices in the first session's logs.
-            warn!(
-                error = %e,
-                "failed to fetch Alpaca positions on startup — current_notionals empty; \
-                 first session will emit target-minus-zero deltas and may double-size"
-            );
-            HashMap::new()
-        }
-    }
+) -> Result<HashMap<String, f64>, String> {
+    let positions = alpaca.get_positions(mode).await.map_err(|e| {
+        format!(
+            "startup position reconciliation failed — refusing to trade without a \
+             trusted notional map (fetch error: {e})"
+        )
+    })?;
+    let notionals: HashMap<String, f64> = positions
+        .into_iter()
+        .map(|(sym, (qty, avg_entry))| (sym, qty * avg_entry))
+        .collect();
+    info!(
+        n_positions = notionals.len(),
+        "seeded current_notionals from Alpaca open positions"
+    );
+    Ok(notionals)
 }
 
 /// Run the engine for one session close and dispatch orders.
@@ -367,44 +375,66 @@ async fn process_session_close(
         }
     }
 
-    // Update current_notionals ONLY for legs we successfully adjusted.
-    //   - successful order   → adopt target notional for that symbol
-    //   - failed order       → keep prior notional (next session will retry)
-    //   - symbol not in orders
-    //       - because delta was tiny        → sync to target (no-op / near-no-op)
-    //       - because price missing/invalid → keep prior notional
-    // `diff_to_orders` emits an order exactly when BOTH delta >= tolerance AND
+    // Reconcile current_notionals against what actually executed.
+    //
+    // We MUST iterate the union of `current_notionals ∪ target_notionals`
+    // — not just targets — so symbols dropped from the target set (e.g.,
+    // a basket that fully exited) are cleared after a successful close.
+    // Iterating only targets leaves the old notional in place, and
+    // `diff_to_orders` then emits another close order for it next session
+    // (current=X, target=0 → close X), producing repeat liquidation attempts.
+    //
+    // `diff_to_orders` emits an order exactly when BOTH |delta| >= 1.0 AND
     // price is finite+positive. So "in orders" ≡ "was adjustable this session".
+    //
+    // Per symbol, we update as follows:
+    //   - in successfully_adjusted
+    //       target present → set current to target
+    //       target absent  → remove (position closed)
+    //   - in orders but not adjusted      → order failed; keep prior notional
+    //   - not in orders + price valid
+    //       target present → set current to target (delta was negligible)
+    //       target absent  → remove (position effectively zero)
+    //   - not in orders + price missing   → keep prior notional (can't tell)
     let orders_by_symbol: std::collections::HashSet<&str> =
         orders.iter().map(|o| o.symbol.as_str()).collect();
+    let mut all_symbols: std::collections::HashSet<String> =
+        current_notionals.keys().cloned().collect();
+    all_symbols.extend(target_notionals.keys().cloned());
     let mut drift_count = 0usize;
-    for (sym, target) in &target_notionals {
-        if successfully_adjusted.contains(sym) {
-            current_notionals.insert(sym.clone(), *target);
-        } else if !orders_by_symbol.contains(sym.as_str()) {
-            // Not in orders: delta was below threshold (price valid) OR price missing.
-            // If price valid, sync to target — delta was negligible.
-            // If price missing, keep prior notional.
+    for sym in all_symbols {
+        let target_opt = target_notionals.get(&sym).copied();
+        let apply_target = |current: &mut HashMap<String, f64>| match target_opt {
+            Some(t) => {
+                current.insert(sym.clone(), t);
+            }
+            None => {
+                current.remove(&sym);
+            }
+        };
+        if successfully_adjusted.contains(&sym) {
+            apply_target(current_notionals);
+        } else if orders_by_symbol.contains(sym.as_str()) {
+            // Order was emitted but did not succeed → preserve prior notional.
+            drift_count += 1;
+        } else {
+            // No order emitted this session: either delta was below threshold
+            // (price valid) or price was missing.
             let has_price = closes
-                .get(sym)
+                .get(&sym)
                 .map(|p| p.is_finite() && *p > 0.0)
                 .unwrap_or(false);
             if has_price {
-                current_notionals.insert(sym.clone(), *target);
+                apply_target(current_notionals);
             }
-            // else: keep whatever was there (may be None/absent, that's fine)
-        } else {
-            // Symbol was in orders but not in successfully_adjusted → order failed.
-            // Preserve prior notional and count drift.
-            drift_count += 1;
+            // else: price missing — keep prior notional.
         }
     }
     if drift_count > 0 {
         warn!(
             drift_count,
             total_orders = orders.len(),
-            "some orders failed; current_notionals preserves prior values for failed legs \
-             — see #267 for full Alpaca reconciliation"
+            "some orders failed; current_notionals preserves prior values for failed legs"
         );
     }
 }
@@ -525,25 +555,40 @@ fn load_warmup_closes(
     Ok(out)
 }
 
-/// Transform per-symbol `Vec<(date, close)>` into aligned `HashMap<symbol, Vec<close>>`
-/// by the intersection of dates — required shape for `basket_picker::validate`.
-fn align_history(closes: &HashMap<String, Vec<(NaiveDate, f64)>>) -> HashMap<String, Vec<f64>> {
-    if closes.is_empty() {
+/// Align the date index for ONE basket (`target` + its peer `members`).
+///
+/// Produces the `HashMap<symbol, Vec<f64>>` shape that `basket_picker::validate`
+/// requires, intersecting dates across ONLY this basket's symbols. Missing
+/// symbols are passed through unaligned (length 0 after intersection with
+/// nothing), so the validator emits a precise "missing symbol" rejection.
+fn align_basket_history(
+    closes: &HashMap<String, Vec<(NaiveDate, f64)>>,
+    symbols: &[&str],
+) -> HashMap<String, Vec<f64>> {
+    let mut series_by_symbol: Vec<(&str, &Vec<(NaiveDate, f64)>)> =
+        Vec::with_capacity(symbols.len());
+    for s in symbols {
+        if let Some(v) = closes.get(*s) {
+            series_by_symbol.push((*s, v));
+        }
+    }
+    if series_by_symbol.is_empty() {
         return HashMap::new();
     }
-    // Intersection of dates across all symbols.
-    let first = closes.values().next().unwrap();
-    let mut common: std::collections::BTreeSet<NaiveDate> = first.iter().map(|(d, _)| *d).collect();
-    for series in closes.values() {
+
+    // Intersection of dates across ONLY this basket's symbols.
+    let mut common: std::collections::BTreeSet<NaiveDate> =
+        series_by_symbol[0].1.iter().map(|(d, _)| *d).collect();
+    for (_, series) in &series_by_symbol[1..] {
         let s: std::collections::BTreeSet<NaiveDate> = series.iter().map(|(d, _)| *d).collect();
         common = common.intersection(&s).cloned().collect();
     }
 
     let mut out = HashMap::new();
-    for (symbol, series) in closes {
+    for (symbol, series) in &series_by_symbol {
         let map: HashMap<NaiveDate, f64> = series.iter().copied().collect();
         let aligned: Vec<f64> = common.iter().filter_map(|d| map.get(d).copied()).collect();
-        out.insert(symbol.clone(), aligned);
+        out.insert((*symbol).to_string(), aligned);
     }
     out
 }
@@ -594,7 +639,7 @@ mod tests {
     }
 
     #[test]
-    fn test_align_history_intersects_dates() {
+    fn test_align_basket_history_intersects_only_basket_symbols() {
         let mut closes = HashMap::new();
         closes.insert(
             "A".to_string(),
@@ -612,11 +657,46 @@ mod tests {
                 (NaiveDate::from_ymd_opt(2026, 1, 3).unwrap(), 21.0),
             ],
         );
-        let aligned = align_history(&closes);
+        let aligned = align_basket_history(&closes, &["A", "B"]);
         // Intersection is [2026-01-02, 2026-01-03] — each series has 2 entries.
         assert_eq!(aligned.get("A").unwrap().len(), 2);
         assert_eq!(aligned.get("B").unwrap().len(), 2);
         assert_eq!(aligned.get("A").unwrap()[0], 11.0);
         assert_eq!(aligned.get("B").unwrap()[0], 20.0);
+    }
+
+    #[test]
+    fn test_align_basket_history_ignores_unrelated_sparse_symbols() {
+        // Basket X/Y both have full 3-day history; unrelated sparse C has
+        // only 1 day. A universe-wide intersection would shrink X/Y to that
+        // 1 day. Per-basket alignment must keep X/Y at 3.
+        let mut closes = HashMap::new();
+        closes.insert(
+            "X".to_string(),
+            vec![
+                (NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(), 10.0),
+                (NaiveDate::from_ymd_opt(2026, 1, 2).unwrap(), 11.0),
+                (NaiveDate::from_ymd_opt(2026, 1, 3).unwrap(), 12.0),
+            ],
+        );
+        closes.insert(
+            "Y".to_string(),
+            vec![
+                (NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(), 20.0),
+                (NaiveDate::from_ymd_opt(2026, 1, 2).unwrap(), 21.0),
+                (NaiveDate::from_ymd_opt(2026, 1, 3).unwrap(), 22.0),
+            ],
+        );
+        closes.insert(
+            "C_SPARSE".to_string(),
+            vec![(NaiveDate::from_ymd_opt(2026, 1, 3).unwrap(), 99.0)],
+        );
+        let aligned = align_basket_history(&closes, &["X", "Y"]);
+        assert_eq!(aligned.get("X").unwrap().len(), 3);
+        assert_eq!(aligned.get("Y").unwrap().len(), 3);
+        assert!(
+            !aligned.contains_key("C_SPARSE"),
+            "symbols outside the basket must not appear in the aligned map"
+        );
     }
 }

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -1,0 +1,482 @@
+//! Live/paper runner for the basket spread engine.
+//!
+//! Drives `basket_engine::BasketEngine` (continuous streaming state machine,
+//! NOT the walk-forward replay in `basket_runner.rs`) with real-time 1-min
+//! bars from the Alpaca WebSocket.
+//!
+//! Flow per trading day:
+//!   1. Warmup (startup): read last N days of parquets, validate candidates,
+//!      build `BasketEngine` from `BasketFit`s. Engine enters with empty state.
+//!   2. Bar loop: for each 1-min bar, update per-symbol "last RTH bar".
+//!   3. Session close (19:59 UTC): snapshot the day's closes, call
+//!      `BasketEngine::on_bars()`, get `PositionIntent`s.
+//!   4. Portfolio: aggregate intents → target notionals → `OrderIntent`s via
+//!      `diff_to_orders()`.
+//!   5. Execute: depending on `BasketExecution`, log only (Noop), or place
+//!      orders on paper/live Alpaca.
+//!
+//! Three execution modes:
+//!   - `Noop`:  log intents, place no orders. Use this for the first sessions
+//!              to verify engine behavior before any capital moves.
+//!   - `Paper`: paper-api.alpaca.markets (paper money).
+//!   - `Live`:  api.alpaca.markets (real money). Gated behind explicit opt-in.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use basket_engine::{
+    aggregate_positions, basket_to_legs, diff_to_orders, BasketEngine, DailyBar, OrderIntent,
+    PortfolioConfig, PositionIntent, Side,
+};
+use basket_picker::{load_universe, validate, ValidatorConfig};
+use chrono::{DateTime, NaiveDate, Timelike, Utc};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use tracing::{error, info, warn};
+
+use crate::alpaca::{AlpacaClient, ExecutionMode};
+use crate::stream;
+
+/// Execution mode for basket live/paper.
+///
+/// Distinct from [`ExecutionMode`] because basket adds a `Noop` shadow mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BasketExecution {
+    /// Log intents only; no Alpaca order placed.
+    Noop,
+    /// Paper trading API.
+    Paper,
+    /// Real-money trading API. Requires explicit `--execution live`.
+    Live,
+}
+
+impl BasketExecution {
+    /// Map to the Alpaca adapter's [`ExecutionMode`]. Noop returns None.
+    fn alpaca_mode(self) -> Option<ExecutionMode> {
+        match self {
+            Self::Noop => None,
+            Self::Paper => Some(ExecutionMode::Paper),
+            Self::Live => Some(ExecutionMode::Live),
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Noop => "NOOP (shadow)",
+            Self::Paper => "PAPER",
+            Self::Live => "LIVE",
+        }
+    }
+}
+
+/// Session close in UTC minutes (RTH end = 20:00). The last 1-min bar finalizes
+/// at 19:59 (Alpaca's `t` is bar-open; close is `t + 60s`).
+const SESSION_CLOSE_MIN: u32 = 20 * 60;
+
+/// RTH window start in UTC minutes (13:30).
+const RTH_START_MIN: u32 = 13 * 60 + 30;
+
+/// Warmup window: days of history to seed state. Needs >= residual_window from
+/// the universe config (60 by default) + a small buffer for safety.
+const WARMUP_DAYS: i64 = 90;
+
+/// Run the basket live/paper loop.
+///
+/// Returns on Ctrl+C or fatal error.
+pub async fn run_basket_live(
+    alpaca: &AlpacaClient,
+    universe_path: &Path,
+    bars_dir: &Path,
+    execution: BasketExecution,
+    portfolio_config: PortfolioConfig,
+) -> Result<(), String> {
+    info!(
+        universe = %universe_path.display(),
+        bars_dir = %bars_dir.display(),
+        execution = execution.label(),
+        "========== BASKET LIVE RUNNER =========="
+    );
+
+    if execution == BasketExecution::Live {
+        warn!("LIVE MODE — real-money orders will be placed on every EOD signal");
+    }
+
+    // 1. Load universe + validate candidates using parquet warmup data.
+    let universe = load_universe(universe_path)?;
+    info!(
+        baskets = universe.num_baskets(),
+        sectors = universe.sectors.len(),
+        "loaded universe"
+    );
+
+    let symbols = collect_symbols(&universe);
+    let closes = load_warmup_closes(bars_dir, &symbols, WARMUP_DAYS)?;
+    info!(
+        symbols = symbols.len(),
+        loaded_series = closes.len(),
+        "loaded warmup closes"
+    );
+
+    // Build price-history map for validator (HashMap<symbol, Vec<f64>> aligned by date).
+    let price_history = align_history(&closes);
+    let validator_config = ValidatorConfig {
+        residual_window: universe.strategy.residual_window_days,
+        k_clip_min: universe.strategy.threshold_clip_min,
+        k_clip_max: universe.strategy.threshold_clip_max,
+        cost: universe.strategy.cost_bps_assumed / 10_000.0,
+    };
+
+    let fits: Vec<_> = universe
+        .candidates
+        .iter()
+        .map(|c| validate(c, &price_history, &validator_config))
+        .collect();
+    let valid_count = fits.iter().filter(|f| f.valid).count();
+    info!(
+        total = fits.len(),
+        valid = valid_count,
+        "validated basket candidates"
+    );
+    if valid_count == 0 {
+        return Err("no valid baskets after warmup validation".to_string());
+    }
+
+    let mut engine = BasketEngine::new(&fits);
+    info!(baskets = engine.num_baskets(), "basket engine initialized");
+
+    // 2. Subscribe to all universe symbols over WebSocket.
+    let mut bar_rx = stream::start_bar_stream(&alpaca.api_key, &alpaca.api_secret, &symbols).await;
+    info!("subscribed to Alpaca 1-min bar stream");
+
+    // 3. Bar loop: buffer per (symbol, date) → last RTH bar. Trigger engine at session close.
+    let mut day_closes: HashMap<NaiveDate, HashMap<String, f64>> = HashMap::new();
+    let mut processed_sessions: std::collections::HashSet<NaiveDate> = Default::default();
+    let mut current_notionals: HashMap<String, f64> = HashMap::new();
+
+    let ctrl_c = tokio::signal::ctrl_c();
+    tokio::pin!(ctrl_c);
+
+    loop {
+        tokio::select! {
+            Some(bar) = bar_rx.recv() => {
+                let dt = match DateTime::<Utc>::from_timestamp_millis(bar.timestamp) {
+                    Some(d) => d,
+                    None => continue,
+                };
+                let minute = dt.hour() * 60 + dt.minute();
+                if !(RTH_START_MIN..SESSION_CLOSE_MIN).contains(&minute) {
+                    // Outside RTH — ignore (do not contaminate daily close).
+                    continue;
+                }
+                let date = dt.date_naive();
+                if bar.close.is_finite() && bar.close > 0.0 {
+                    day_closes
+                        .entry(date)
+                        .or_default()
+                        .insert(bar.symbol.clone(), bar.close);
+                }
+
+                // Trigger engine at session close. The 19:59 bar is the last RTH bar;
+                // its close becomes the daily close for the session.
+                if minute == SESSION_CLOSE_MIN - 1
+                    && bar.symbol == symbols[0]
+                    && !processed_sessions.contains(&date)
+                {
+                    processed_sessions.insert(date);
+                    let closes_for_day = day_closes.remove(&date).unwrap_or_default();
+                    process_session_close(
+                        &mut engine,
+                        alpaca,
+                        date,
+                        &closes_for_day,
+                        &portfolio_config,
+                        &mut current_notionals,
+                        execution,
+                    )
+                    .await;
+                }
+            }
+            _ = &mut ctrl_c => {
+                info!("========== SHUTDOWN ==========");
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Run the engine for one session close and dispatch orders.
+#[allow(clippy::too_many_arguments)]
+async fn process_session_close(
+    engine: &mut BasketEngine,
+    alpaca: &AlpacaClient,
+    date: NaiveDate,
+    closes: &HashMap<String, f64>,
+    portfolio_config: &PortfolioConfig,
+    current_notionals: &mut HashMap<String, f64>,
+    execution: BasketExecution,
+) {
+    if closes.is_empty() {
+        warn!(date = %date, "no RTH closes buffered for session — skipping engine");
+        return;
+    }
+
+    // Build DailyBar slice for BasketEngine.
+    let daily_bars: Vec<DailyBar> = closes
+        .iter()
+        .map(|(symbol, &close)| DailyBar {
+            symbol: symbol.clone(),
+            date,
+            close,
+        })
+        .collect();
+
+    let intents = engine.on_bars(&daily_bars);
+    info!(
+        date = %date,
+        symbols = closes.len(),
+        intents = intents.len(),
+        "session close processed"
+    );
+
+    for intent in &intents {
+        log_intent(intent);
+    }
+
+    // Portfolio layer: target notionals across symbols, then diff to orders.
+    let target_notionals = aggregate_positions(engine, portfolio_config);
+    let orders = diff_to_orders(current_notionals, &target_notionals, closes);
+    if orders.is_empty() {
+        return;
+    }
+
+    info!(date = %date, n_orders = orders.len(), "emitting orders");
+
+    match execution.alpaca_mode() {
+        None => {
+            // Noop — log only.
+            for order in &orders {
+                log_order(order, "NOOP");
+            }
+        }
+        Some(mode) => {
+            for order in &orders {
+                log_order(order, execution.label());
+                let side_str = match order.side {
+                    Side::Buy => "buy",
+                    Side::Sell => "sell",
+                };
+                match alpaca
+                    .place_order(&order.symbol, order.qty as f64, side_str, mode)
+                    .await
+                {
+                    Ok(o) => info!(
+                        symbol = order.symbol.as_str(),
+                        qty = order.qty,
+                        side = side_str,
+                        order_id = o.id.as_str(),
+                        status = o.status.as_str(),
+                        "ORDER PLACED"
+                    ),
+                    Err(e) => error!(
+                        symbol = order.symbol.as_str(),
+                        qty = order.qty,
+                        side = side_str,
+                        error = e.as_str(),
+                        "ORDER FAILED"
+                    ),
+                }
+            }
+        }
+    }
+
+    // After dispatching, adopt target notionals as current (ignoring reject/partial-fill
+    // edge cases — reconciliation lives in a separate follow-up).
+    *current_notionals = target_notionals;
+
+    // Also warn if any basket was held with legs that can't be modeled (diagnostic only).
+    let _ = basket_to_legs; // silence unused-import warning in smaller builds
+}
+
+fn log_intent(intent: &PositionIntent) {
+    info!(
+        basket_id = %intent.basket_id,
+        target_position = intent.target_position,
+        z = %format!("{:.4}", intent.z_score),
+        spread = %format!("{:.6}", intent.spread),
+        reason = intent.reason.as_str(),
+        date = %intent.date,
+        "BASKET_INTENT"
+    );
+}
+
+fn log_order(order: &OrderIntent, label: &str) {
+    let side_str = match order.side {
+        Side::Buy => "buy",
+        Side::Sell => "sell",
+    };
+    info!(
+        mode = label,
+        symbol = order.symbol.as_str(),
+        qty = order.qty,
+        side = side_str,
+        "BASKET_ORDER"
+    );
+}
+
+fn collect_symbols(universe: &basket_picker::Universe) -> Vec<String> {
+    let mut symbols: Vec<String> = universe
+        .sectors
+        .values()
+        .flat_map(|s| s.members.iter().cloned())
+        .collect();
+    symbols.sort();
+    symbols.dedup();
+    symbols
+}
+
+/// Read the last `window_days` trading days of daily closes for each symbol.
+/// Aggregates 1-min parquets to RTH-last-bar closes (same rule as replay).
+fn load_warmup_closes(
+    bars_dir: &Path,
+    symbols: &[String],
+    window_days: i64,
+) -> Result<HashMap<String, Vec<(NaiveDate, f64)>>, String> {
+    use arrow::array::{Array, Float64Array, TimestampMicrosecondArray};
+    use std::collections::BTreeMap;
+    let cutoff = Utc::now().date_naive() - chrono::Duration::days(window_days);
+
+    let mut out = HashMap::new();
+    for symbol in symbols {
+        let path = bars_dir.join(format!("{symbol}.parquet"));
+        let file = match std::fs::File::open(&path) {
+            Ok(f) => f,
+            Err(e) => {
+                warn!(symbol = %symbol, error = %e, "skip symbol — parquet missing");
+                continue;
+            }
+        };
+        let builder = ParquetRecordBatchReaderBuilder::try_new(file)
+            .map_err(|e| format!("reader {symbol}: {e}"))?;
+        let reader = builder
+            .build()
+            .map_err(|e| format!("build {symbol}: {e}"))?;
+
+        let mut daily: BTreeMap<NaiveDate, (i64, f64)> = BTreeMap::new();
+        for batch in reader {
+            let batch = batch.map_err(|e| format!("batch {symbol}: {e}"))?;
+            let ts = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<TimestampMicrosecondArray>()
+                .ok_or_else(|| format!("ts cast {symbol}"))?;
+            let close = batch
+                .column(4)
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .ok_or_else(|| format!("close cast {symbol}"))?;
+
+            for i in 0..batch.num_rows() {
+                let ts_us = ts.value(i);
+                let secs = ts_us / 1_000_000;
+                let dt = match DateTime::<Utc>::from_timestamp(secs, 0) {
+                    Some(d) => d.naive_utc(),
+                    None => continue,
+                };
+                let minute = dt.hour() * 60 + dt.minute();
+                if !(RTH_START_MIN..SESSION_CLOSE_MIN).contains(&minute) {
+                    continue;
+                }
+                let px = close.value(i);
+                if !px.is_finite() || px <= 0.0 {
+                    continue;
+                }
+                let date = dt.date();
+                if date < cutoff {
+                    continue;
+                }
+                daily
+                    .entry(date)
+                    .and_modify(|(prev_ts, prev_close)| {
+                        if ts_us > *prev_ts {
+                            *prev_ts = ts_us;
+                            *prev_close = px;
+                        }
+                    })
+                    .or_insert((ts_us, px));
+            }
+        }
+        let series: Vec<(NaiveDate, f64)> = daily.into_iter().map(|(d, (_, c))| (d, c)).collect();
+        if !series.is_empty() {
+            out.insert(symbol.clone(), series);
+        }
+    }
+    Ok(out)
+}
+
+/// Transform per-symbol `Vec<(date, close)>` into aligned `HashMap<symbol, Vec<close>>`
+/// by the intersection of dates — required shape for `basket_picker::validate`.
+fn align_history(closes: &HashMap<String, Vec<(NaiveDate, f64)>>) -> HashMap<String, Vec<f64>> {
+    if closes.is_empty() {
+        return HashMap::new();
+    }
+    // Intersection of dates across all symbols.
+    let first = closes.values().next().unwrap();
+    let mut common: std::collections::BTreeSet<NaiveDate> = first.iter().map(|(d, _)| *d).collect();
+    for series in closes.values() {
+        let s: std::collections::BTreeSet<NaiveDate> = series.iter().map(|(d, _)| *d).collect();
+        common = common.intersection(&s).cloned().collect();
+    }
+
+    let mut out = HashMap::new();
+    for (symbol, series) in closes {
+        let map: HashMap<NaiveDate, f64> = series.iter().copied().collect();
+        let aligned: Vec<f64> = common.iter().filter_map(|d| map.get(d).copied()).collect();
+        out.insert(symbol.clone(), aligned);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basket_execution_alpaca_mode_mapping() {
+        assert!(BasketExecution::Noop.alpaca_mode().is_none());
+        assert_eq!(
+            BasketExecution::Paper.alpaca_mode(),
+            Some(ExecutionMode::Paper)
+        );
+        assert_eq!(
+            BasketExecution::Live.alpaca_mode(),
+            Some(ExecutionMode::Live)
+        );
+    }
+
+    #[test]
+    fn test_align_history_intersects_dates() {
+        let mut closes = HashMap::new();
+        closes.insert(
+            "A".to_string(),
+            vec![
+                (NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(), 10.0),
+                (NaiveDate::from_ymd_opt(2026, 1, 2).unwrap(), 11.0),
+                (NaiveDate::from_ymd_opt(2026, 1, 3).unwrap(), 12.0),
+            ],
+        );
+        closes.insert(
+            "B".to_string(),
+            vec![
+                // Missing 2026-01-01
+                (NaiveDate::from_ymd_opt(2026, 1, 2).unwrap(), 20.0),
+                (NaiveDate::from_ymd_opt(2026, 1, 3).unwrap(), 21.0),
+            ],
+        );
+        let aligned = align_history(&closes);
+        // Intersection is [2026-01-02, 2026-01-03] — each series has 2 entries.
+        assert_eq!(aligned.get("A").unwrap().len(), 2);
+        assert_eq!(aligned.get("B").unwrap().len(), 2);
+        assert_eq!(aligned.get("A").unwrap()[0], 11.0);
+        assert_eq!(aligned.get("B").unwrap()[0], 20.0);
+    }
+}

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -16,17 +16,17 @@
 //!      orders on paper/live Alpaca.
 //!
 //! Three execution modes:
-//!   - `Noop`:  log intents, place no orders. Use this for the first sessions
-//!              to verify engine behavior before any capital moves.
+//!   - `Noop`: log intents, place no orders. Use this for the first sessions
+//!     to verify engine behavior before any capital moves.
 //!   - `Paper`: paper-api.alpaca.markets (paper money).
-//!   - `Live`:  api.alpaca.markets (real money). Gated behind explicit opt-in.
+//!   - `Live`: api.alpaca.markets (real money). Gated behind explicit opt-in.
 
 use std::collections::HashMap;
 use std::path::Path;
 
 use basket_engine::{
-    aggregate_positions, basket_to_legs, diff_to_orders, BasketEngine, DailyBar, OrderIntent,
-    PortfolioConfig, PositionIntent, Side,
+    aggregate_positions, diff_to_orders, BasketEngine, DailyBar, OrderIntent, PortfolioConfig,
+    PositionIntent, Side,
 };
 use basket_picker::{load_universe, validate, ValidatorConfig};
 use chrono::{DateTime, NaiveDate, Timelike, Utc};
@@ -143,15 +143,34 @@ pub async fn run_basket_live(
     let mut engine = BasketEngine::new(&fits);
     info!(baskets = engine.num_baskets(), "basket engine initialized");
 
-    // 2. Subscribe to all universe symbols over WebSocket.
+    // 2. Seed current_notionals from Alpaca positions (startup reconciliation).
+    //    Without this, a restart with live open positions would trigger
+    //    target-minus-zero deltas, flooding Alpaca with duplicate orders.
+    //    Noop skips this (no Alpaca account needed for shadow mode).
+    let mut current_notionals = match execution.alpaca_mode() {
+        None => {
+            info!("noop mode — skipping startup position reconciliation");
+            HashMap::new()
+        }
+        Some(mode) => seed_current_notionals_from_alpaca(alpaca, mode).await,
+    };
+
+    // 3. Subscribe to all universe symbols over WebSocket.
     let mut bar_rx = stream::start_bar_stream(&alpaca.api_key, &alpaca.api_secret, &symbols).await;
     info!("subscribed to Alpaca 1-min bar stream");
 
-    // 3. Bar loop: buffer per (symbol, date) → last RTH bar. Trigger engine at session close.
+    // 4. Bar loop: buffer per (symbol, date) → last RTH bar.
+    //    Engine is triggered by a wall-clock timer (not by `symbols[0]`'s 19:59 bar
+    //    arrival) so that no single symbol becoming a data source-of-failure can
+    //    silently skip an entire session.
     let mut day_closes: HashMap<NaiveDate, HashMap<String, f64>> = HashMap::new();
     let mut processed_sessions: std::collections::HashSet<NaiveDate> = Default::default();
-    let mut current_notionals: HashMap<String, f64> = HashMap::new();
 
+    // Grace period after session close before firing the engine. Lets late-arriving
+    // 19:59 bars land in the buffer.
+    const CLOSE_GRACE_MIN: u32 = 2;
+
+    let mut tick = tokio::time::interval(std::time::Duration::from_secs(30));
     let ctrl_c = tokio::signal::ctrl_c();
     tokio::pin!(ctrl_c);
 
@@ -174,19 +193,27 @@ pub async fn run_basket_live(
                         .or_default()
                         .insert(bar.symbol.clone(), bar.close);
                 }
-
-                // Trigger engine at session close. The 19:59 bar is the last RTH bar;
-                // its close becomes the daily close for the session.
-                if minute == SESSION_CLOSE_MIN - 1
-                    && bar.symbol == symbols[0]
-                    && !processed_sessions.contains(&date)
-                {
-                    processed_sessions.insert(date);
-                    let closes_for_day = day_closes.remove(&date).unwrap_or_default();
+            }
+            _ = tick.tick() => {
+                // Wall-clock trigger: if we are past session close + grace for a
+                // given date and haven't processed it yet, fire now — regardless
+                // of which symbols' 19:59 bars landed.
+                let now = Utc::now();
+                let today = now.date_naive();
+                let minute_now = now.hour() * 60 + now.minute();
+                let past_close = minute_now >= SESSION_CLOSE_MIN + CLOSE_GRACE_MIN;
+                if past_close && !processed_sessions.contains(&today) {
+                    let closes_for_day = day_closes.remove(&today).unwrap_or_default();
+                    if closes_for_day.is_empty() {
+                        // Weekend / holiday / blackout — mark processed to avoid busy-looping.
+                        processed_sessions.insert(today);
+                        continue;
+                    }
+                    processed_sessions.insert(today);
                     process_session_close(
                         &mut engine,
                         alpaca,
-                        date,
+                        today,
                         &closes_for_day,
                         &portfolio_config,
                         &mut current_notionals,
@@ -202,6 +229,37 @@ pub async fn run_basket_live(
         }
     }
     Ok(())
+}
+
+/// Fetch open positions from Alpaca and express them as signed notional per symbol.
+/// Used on startup so `diff_to_orders` computes correct deltas from the engine's target.
+async fn seed_current_notionals_from_alpaca(
+    alpaca: &AlpacaClient,
+    mode: ExecutionMode,
+) -> HashMap<String, f64> {
+    match alpaca.get_positions(mode).await {
+        Ok(positions) => {
+            let notionals: HashMap<String, f64> = positions
+                .into_iter()
+                .map(|(sym, (qty, avg_entry))| (sym, qty * avg_entry))
+                .collect();
+            info!(
+                n_positions = notionals.len(),
+                "seeded current_notionals from Alpaca open positions"
+            );
+            notionals
+        }
+        Err(e) => {
+            // Fail closed: if we can't read positions, we can't safely diff. Warn loudly
+            // and return empty so the operator notices in the first session's logs.
+            warn!(
+                error = %e,
+                "failed to fetch Alpaca positions on startup — current_notionals empty; \
+                 first session will emit target-minus-zero deltas and may double-size"
+            );
+            HashMap::new()
+        }
+    }
 }
 
 /// Run the engine for one session close and dispatch orders.
@@ -292,9 +350,6 @@ async fn process_session_close(
     // After dispatching, adopt target notionals as current (ignoring reject/partial-fill
     // edge cases — reconciliation lives in a separate follow-up).
     *current_notionals = target_notionals;
-
-    // Also warn if any basket was held with legs that can't be modeled (diagnostic only).
-    let _ = basket_to_legs; // silence unused-import warning in smaller builds
 }
 
 fn log_intent(intent: &PositionIntent) {

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -177,7 +177,14 @@ pub async fn run_basket_live(
     loop {
         tokio::select! {
             Some(bar) = bar_rx.recv() => {
-                let dt = match DateTime::<Utc>::from_timestamp_millis(bar.timestamp) {
+                // `stream.rs` shifts Alpaca bar timestamps by +60s (open→close time).
+                // Undo that here so `minute` reflects bar-OPEN time, matching the
+                // RTH filter used by replay (`basket_runner.rs::read_daily_closes`).
+                // Without this, the last RTH bar (open=19:59, stream=20:00) would be
+                // excluded by `RTH_START_MIN..SESSION_CLOSE_MIN` and the 19:59 close
+                // would never enter the buffer — missing the daily close.
+                let bar_open_ts_ms = bar.timestamp - 60_000;
+                let dt = match DateTime::<Utc>::from_timestamp_millis(bar_open_ts_ms) {
                     Some(d) => d,
                     None => continue,
                 };
@@ -309,11 +316,21 @@ async fn process_session_close(
 
     info!(date = %date, n_orders = orders.len(), "emitting orders");
 
+    // Track which symbols were successfully adjusted so we only update
+    // `current_notionals` for legs that actually executed. This matters
+    // when `diff_to_orders` skipped symbols (missing prices) or when
+    // Alpaca rejected orders — blindly syncing to target would desync
+    // internal state from the broker's view and prevent future corrective
+    // orders.
+    let mut successfully_adjusted: std::collections::HashSet<String> = Default::default();
+
     match execution.alpaca_mode() {
         None => {
-            // Noop — log only.
+            // Noop — log only, but treat every emitted order as "successful"
+            // so the simulated state evolves consistently across sessions.
             for order in &orders {
                 log_order(order, "NOOP");
+                successfully_adjusted.insert(order.symbol.clone());
             }
         }
         Some(mode) => {
@@ -327,14 +344,17 @@ async fn process_session_close(
                     .place_order(&order.symbol, order.qty as f64, side_str, mode)
                     .await
                 {
-                    Ok(o) => info!(
-                        symbol = order.symbol.as_str(),
-                        qty = order.qty,
-                        side = side_str,
-                        order_id = o.id.as_str(),
-                        status = o.status.as_str(),
-                        "ORDER PLACED"
-                    ),
+                    Ok(o) => {
+                        info!(
+                            symbol = order.symbol.as_str(),
+                            qty = order.qty,
+                            side = side_str,
+                            order_id = o.id.as_str(),
+                            status = o.status.as_str(),
+                            "ORDER PLACED"
+                        );
+                        successfully_adjusted.insert(order.symbol.clone());
+                    }
                     Err(e) => error!(
                         symbol = order.symbol.as_str(),
                         qty = order.qty,
@@ -347,9 +367,46 @@ async fn process_session_close(
         }
     }
 
-    // After dispatching, adopt target notionals as current (ignoring reject/partial-fill
-    // edge cases — reconciliation lives in a separate follow-up).
-    *current_notionals = target_notionals;
+    // Update current_notionals ONLY for legs we successfully adjusted.
+    //   - successful order   → adopt target notional for that symbol
+    //   - failed order       → keep prior notional (next session will retry)
+    //   - symbol not in orders
+    //       - because delta was tiny        → sync to target (no-op / near-no-op)
+    //       - because price missing/invalid → keep prior notional
+    // `diff_to_orders` emits an order exactly when BOTH delta >= tolerance AND
+    // price is finite+positive. So "in orders" ≡ "was adjustable this session".
+    let orders_by_symbol: std::collections::HashSet<&str> =
+        orders.iter().map(|o| o.symbol.as_str()).collect();
+    let mut drift_count = 0usize;
+    for (sym, target) in &target_notionals {
+        if successfully_adjusted.contains(sym) {
+            current_notionals.insert(sym.clone(), *target);
+        } else if !orders_by_symbol.contains(sym.as_str()) {
+            // Not in orders: delta was below threshold (price valid) OR price missing.
+            // If price valid, sync to target — delta was negligible.
+            // If price missing, keep prior notional.
+            let has_price = closes
+                .get(sym)
+                .map(|p| p.is_finite() && *p > 0.0)
+                .unwrap_or(false);
+            if has_price {
+                current_notionals.insert(sym.clone(), *target);
+            }
+            // else: keep whatever was there (may be None/absent, that's fine)
+        } else {
+            // Symbol was in orders but not in successfully_adjusted → order failed.
+            // Preserve prior notional and count drift.
+            drift_count += 1;
+        }
+    }
+    if drift_count > 0 {
+        warn!(
+            drift_count,
+            total_orders = orders.len(),
+            "some orders failed; current_notionals preserves prior values for failed legs \
+             — see #267 for full Alpaca reconciliation"
+        );
+    }
 }
 
 fn log_intent(intent: &PositionIntent) {
@@ -505,6 +562,34 @@ mod tests {
         assert_eq!(
             BasketExecution::Live.alpaca_mode(),
             Some(ExecutionMode::Live)
+        );
+    }
+
+    /// Verifies the bar-timestamp unshift needed in the live bar loop.
+    /// stream.rs adds +60s (open→close); we subtract it to get bar-open
+    /// time for RTH filtering, so the 19:59-open / 20:00-close bar is
+    /// correctly classified as RTH rather than being filtered out.
+    #[test]
+    fn test_bar_timestamp_unshift_keeps_last_rth_bar() {
+        // Alpaca bar open-time 19:59 UTC = 71940 minutes from epoch day start.
+        // stream.rs adds 60_000 ms → stream timestamp = 20:00 UTC.
+        let base = DateTime::<Utc>::from_timestamp(0, 0).unwrap();
+        let _ = base; // sanity: construction works
+                      // Build a millis value for some 2026-02-06 19:59 UTC, shift +60s.
+        let open = chrono::NaiveDate::from_ymd_opt(2026, 2, 6)
+            .unwrap()
+            .and_hms_opt(19, 59, 0)
+            .unwrap()
+            .and_utc();
+        let stream_ts_ms = open.timestamp_millis() + 60_000;
+        // Replicate the unshift used in the bar loop.
+        let bar_open_ts_ms = stream_ts_ms - 60_000;
+        let dt = DateTime::<Utc>::from_timestamp_millis(bar_open_ts_ms).unwrap();
+        let minute = dt.hour() * 60 + dt.minute();
+        assert_eq!(minute, 19 * 60 + 59, "unshift must recover bar-open minute");
+        assert!(
+            (RTH_START_MIN..SESSION_CLOSE_MIN).contains(&minute),
+            "last RTH bar (19:59 open) must pass RTH filter after unshift"
         );
     }
 

--- a/engine/crates/runner/src/main.rs
+++ b/engine/crates/runner/src/main.rs
@@ -481,6 +481,45 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
         }
     };
 
+    // Refresh quant-data before warmup. Without this, the basket path reads
+    // potentially-stale parquets, and the validator fits OU on outdated prices
+    // — the same failure mode the pairs path fixes at main.rs refresh block.
+    // Filter refresh to only the universe's symbols (avoid refreshing unrelated SP500 names).
+    if bars_dir.exists() {
+        let filter = match basket_picker::load_universe(&universe_path) {
+            Ok(u) => {
+                let mut syms: Vec<String> = u
+                    .sectors
+                    .values()
+                    .flat_map(|s| s.members.iter().cloned())
+                    .collect();
+                syms.sort();
+                syms.dedup();
+                Some(syms)
+            }
+            Err(e) => {
+                error!(error = %e, "failed to load universe for refresh filter");
+                std::process::exit(1);
+            }
+        };
+        let target = chrono::Utc::now().format("%Y-%m-%d").to_string();
+        info!(
+            target = target.as_str(),
+            filter_count = filter.as_ref().map(Vec::len).unwrap_or(0),
+            "refreshing quant-data bars (basket universe)"
+        );
+        match refresh::refresh_all(&bars_dir, &target, &alpaca, filter.as_deref()).await {
+            Ok(n) if n > 0 => info!(bars = n, "quant-data refreshed"),
+            Ok(_) => info!("quant-data already up to date"),
+            Err(e) => warn!(
+                error = e.as_str(),
+                "quant-data refresh failed — continuing with possibly stale data"
+            ),
+        }
+    } else {
+        warn!(path = %bars_dir.display(), "quant-data dir not found — skipping refresh");
+    }
+
     // Portfolio config: use sensible defaults for now. Capital & leverage can
     // be surfaced to CLI/config in a follow-up; defaults match baseline config.
     let portfolio_config = basket_engine::PortfolioConfig::default();

--- a/engine/crates/runner/src/main.rs
+++ b/engine/crates/runner/src/main.rs
@@ -16,6 +16,7 @@
 
 mod alpaca;
 mod bar_cache;
+mod basket_live;
 mod basket_runner;
 mod earnings;
 mod pair_picker_service;
@@ -129,6 +130,22 @@ struct StreamArgs {
     /// Override pipeline profile (default: selected by --engine).
     #[arg(long)]
     pipeline: Option<String>,
+
+    /// Basket universe TOML file. Required when --engine basket.
+    #[arg(long)]
+    universe: Option<PathBuf>,
+
+    /// Directory containing per-symbol 1-min parquets. Required when --engine basket.
+    /// Defaults to $QUANT_DATA_DIR if set, else `~/quant-data/bars/v3_sp500_2024-2026_1min_adjusted`.
+    #[arg(long)]
+    bars_dir: Option<PathBuf>,
+
+    /// Execution mode for --engine basket.
+    ///   noop:  log intents only, no orders placed (default, shadow mode)
+    ///   paper: paper Alpaca account
+    ///   live:  real-money Alpaca (explicit opt-in required)
+    #[arg(long, default_value = "noop")]
+    execution: String,
 }
 
 /// Args for replay (adds date range).
@@ -273,6 +290,16 @@ async fn main() {
         .with_writer(tee)
         .init();
 
+    // Basket engine in Live/Paper mode takes a dedicated path — it uses
+    // BasketEngine (continuous state machine) driven by 1-min bars, not the
+    // PairsEngine pipeline below. Early-return after the basket runner finishes.
+    if let Command::Live(a) | Command::Paper(a) = &cli.command {
+        if a.engine.is_basket() {
+            run_basket_stream(a.clone(), matches!(&cli.command, Command::Live(_))).await;
+            return;
+        }
+    }
+
     // Convert CLI command → (config, trading_dir, data_dir, candidates, pipeline, run_mode)
     let (config, trading_dir, data_dir, candidates, pipeline, run_mode) = match cli.command {
         Command::Live(a) => {
@@ -401,6 +428,75 @@ async fn main() {
         run_mode,
     )
     .await;
+}
+
+// ── Basket live/paper dispatch ──────────────────────────────────────
+
+async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
+    let universe_path = match args.universe {
+        Some(p) => p,
+        None => {
+            error!("--universe is required when --engine basket");
+            std::process::exit(1);
+        }
+    };
+
+    let bars_dir = args.bars_dir.unwrap_or_else(|| {
+        std::env::var("QUANT_DATA_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| {
+                let home = std::env::var("HOME").unwrap_or_default();
+                PathBuf::from(home).join("quant-data/bars/v3_sp500_2024-2026_1min_adjusted")
+            })
+    });
+
+    // Parse execution mode. Default = noop (shadow).
+    // Extra safety: `paper live` must come from `Command::Live` (real-money path),
+    // otherwise treat as paper.
+    let execution = match args.execution.as_str() {
+        "noop" => basket_live::BasketExecution::Noop,
+        "paper" => basket_live::BasketExecution::Paper,
+        "live" => {
+            if !is_live_command {
+                warn!(
+                    "--execution live requested but command is 'paper'; \
+                     downgrading to Paper to prevent accidental real-money orders"
+                );
+                basket_live::BasketExecution::Paper
+            } else {
+                basket_live::BasketExecution::Live
+            }
+        }
+        other => {
+            error!(requested = %other, "unknown --execution (expected noop|paper|live)");
+            std::process::exit(1);
+        }
+    };
+
+    let alpaca = match alpaca::AlpacaClient::from_env(&PathBuf::from(".env")) {
+        Ok(c) => c,
+        Err(e) => {
+            error!("{e}");
+            std::process::exit(1);
+        }
+    };
+
+    // Portfolio config: use sensible defaults for now. Capital & leverage can
+    // be surfaced to CLI/config in a follow-up; defaults match baseline config.
+    let portfolio_config = basket_engine::PortfolioConfig::default();
+
+    if let Err(e) = basket_live::run_basket_live(
+        &alpaca,
+        &universe_path,
+        &bars_dir,
+        execution,
+        portfolio_config,
+    )
+    .await
+    {
+        error!(error = %e, "basket live runner failed");
+        std::process::exit(1);
+    }
 }
 
 // ── Unified run function ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Wires `BasketEngine` (the continuous streaming state machine) into the `live` and `paper` commands. Replay was M5; this is M6 — the actual paper-trading path.

## What's new

**`crates/runner/src/basket_live.rs`** (new, ~480 LOC)

Flow per trading day:
1. **Warmup** (startup): read last 90 days of 1-min parquets, validate candidates via `basket_picker::validate`, build `BasketEngine` from `BasketFit`s.
2. **Bar loop**: buffer per `(symbol, date)` → last RTH 1-min close.
3. **Session close** (19:59 UTC, last RTH bar): snapshot closes, call `BasketEngine::on_bars()`, get `PositionIntent`s.
4. **Portfolio**: `aggregate_positions` → `diff_to_orders` → `OrderIntent`s via M3 layer.
5. **Execute**: depending on mode, log only (Noop), or place orders on paper/live Alpaca.

**New CLI flags** on `live`/`paper` subcommands:
| Flag | Purpose |
|---|---|
| `--universe <path>` | required when `--engine basket` |
| `--bars-dir <path>` | parquet dir (defaults to `$QUANT_DATA_DIR`) |
| `--execution <mode>` | `noop` (default) \| `paper` \| `live` |

**Execution modes:**
- **Noop** — log intents only, no Alpaca calls. Default. Use for first 2-3 sessions to verify engine sees correct bars and emits correct intents.
- **Paper** — paper-api.alpaca.markets.
- **Live** — real-money. Only reachable via the `live` subcommand. Passing `--execution live` to `paper` downgrades to Paper with a warning — prevents accidental real-money orders.

## Usage

Shadow mode (first runs):
```bash
openquant-runner paper --engine basket \\
  --universe engine/config/universe/basket_universe_v1.toml \\
  --execution noop
```

Paper trading:
```bash
openquant-runner paper --engine basket \\
  --universe engine/config/universe/basket_universe_v1.toml \\
  --execution paper
```

## Scope deliberately tight

This PR does first-cut wiring. Explicitly **not** in this PR:
- **Reconciliation** — diff actual fills vs engine-expected, log drift. Follow-up issue.
- **Refit cadence** — engine is built once at startup; no mid-run refit. Follow-up.
- **Portfolio config on CLI** — uses `PortfolioConfig::default()` (capital 100k, leverage 4, n_baskets 10). Surface to flags in follow-up.
- **Intra-session rebalance** — orders only fire at 19:59 UTC close.

## Pair engine regression

Pair engine paths are unchanged — the early-return at the top of `main()` only fires for `--engine basket` on Live/Paper. All existing pairs tests still pass.

## Test plan

- [x] `cargo test --bin openquant-runner basket` — 8/8 pass (2 new: `test_basket_execution_alpaca_mode_mapping`, `test_align_history_intersects_dates`; 6 existing)
- [x] `cargo build --release --bin openquant-runner` — clean
- [x] `cargo fmt --all` — clean
- [x] CLI `--help` surfaces new flags
- [ ] Live run verification — deferred to first noop session

## Go-live gate (not enforced in code, but noted)

Per `CLAUDE.md`, before `--execution live`:
1. 2+ weeks clean paper with reconciliation drift < 100 bps
2. Daily-stats dashboard comparing realized vs replay Sharpe
3. Manual review checkpoint

Reconciliation is the follow-up that unblocks that gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)