### PR TITLE
Fix basket session handling across DST

### DIFF
--- a/engine/crates/runner/Cargo.toml
+++ b/engine/crates/runner/Cargo.toml
@@ -20,6 +20,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
 tracing-appender = "0.2"
 clap = { version = "4", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.10"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", features = ["json"] }
 tokio-tungstenite = { version = "0.24", features = ["native-tls"] }

--- a/engine/crates/runner/src/alpaca.rs
+++ b/engine/crates/runner/src/alpaca.rs
@@ -2,10 +2,11 @@
 //!
 //! Pure Rust, no Python. Reads API keys from .env file.
 
-use chrono::Timelike;
 use serde::Deserialize;
 use std::collections::HashMap;
 use tracing::{error, info};
+
+use crate::market_session;
 
 const DATA_URL_DEFAULT: &str = "https://data.alpaca.markets/v2/stocks/bars";
 
@@ -96,13 +97,6 @@ impl AlpacaClient {
         Ok(Self::new(api_key, api_secret))
     }
 
-    // ── RTH session filter (13:30–20:00 UTC ≈ 9:30–16:00 EDT) ──
-    // Must match quant-lab's aggregation so pair-picker, engine warmup,
-    // and lab all compute statistics on the same daily close prices.
-    // See CLAUDE.md: "one data source for everything — 1-min IEX bars."
-    const RTH_START_MINUTES: i64 = 13 * 60 + 30; // 13:30 UTC
-    const RTH_END_MINUTES: i64 = 20 * 60; // 20:00 UTC
-
     /// Aggregate 1-min bars to daily RTH close (last tick per session day).
     /// Groups by (symbol, calendar date), filters to RTH, takes last close.
     fn aggregate_to_daily(
@@ -119,11 +113,11 @@ impl AlpacaClient {
                     if !bar.c.is_finite() || bar.c <= 0.0 {
                         continue;
                     }
-                    let minutes = dt.hour() as i64 * 60 + dt.minute() as i64;
-                    if !(Self::RTH_START_MINUTES..Self::RTH_END_MINUTES).contains(&minutes) {
+                    let dt_utc = dt.with_timezone(&chrono::Utc);
+                    if !market_session::is_rth_utc(dt_utc) {
                         continue;
                     }
-                    let date_key = dt.format("%Y-%m-%d").to_string();
+                    let date_key = market_session::trading_day_utc(dt_utc).to_string();
                     let ts_ms = dt.timestamp_millis();
                     let entry = day_map.entry(date_key).or_insert((ts_ms, bar.c));
                     if ts_ms >= entry.0 {
@@ -207,15 +201,13 @@ impl AlpacaClient {
             .await?;
         let aggregated = Self::aggregate_to_daily(&raw);
 
-        // Adjust timestamp to 16:00 ET (market close) so the engine's
-        // is_daily_close check recognizes warmup bars.
-        const CLOSE_HOUR_UTC: i64 = 20; // 16:00 ET (EDT) = 20:00 UTC
         let mut all_bars: Vec<(String, i64, f64)> = Vec::new();
         for (symbol, days) in &aggregated {
             for &(ts_ms, close) in days {
-                // Snap timestamp to 20:00 UTC of that day
-                let day_start = ts_ms / 86_400_000 * 86_400_000;
-                let close_ts = day_start + CLOSE_HOUR_UTC * 3600 * 1000;
+                let day = chrono::DateTime::from_timestamp_millis(ts_ms)
+                    .map(|dt| market_session::trading_day_utc(dt.to_utc()))
+                    .unwrap_or_else(|| chrono::DateTime::UNIX_EPOCH.date_naive());
+                let close_ts = market_session::close_timestamp_utc_for_day(day);
                 all_bars.push((symbol.clone(), close_ts, close));
             }
         }

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -29,11 +29,12 @@ use basket_engine::{
     PositionIntent, Side,
 };
 use basket_picker::{load_universe, validate, ValidatorConfig};
-use chrono::{DateTime, NaiveDate, Timelike, Utc};
+use chrono::{DateTime, NaiveDate, Utc};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use tracing::{debug, error, info, warn};
 
 use crate::alpaca::{AlpacaClient, ExecutionMode};
+use crate::market_session;
 use crate::stream;
 
 /// Execution mode for basket live/paper.
@@ -67,13 +68,6 @@ impl BasketExecution {
         }
     }
 }
-
-/// Session close in UTC minutes (RTH end = 20:00). The last 1-min bar finalizes
-/// at 19:59 (Alpaca's `t` is bar-open; close is `t + 60s`).
-const SESSION_CLOSE_MIN: u32 = 20 * 60;
-
-/// RTH window start in UTC minutes (13:30).
-const RTH_START_MIN: u32 = 13 * 60 + 30;
 
 /// Warmup window: days of history to seed state. Needs >= residual_window from
 /// the universe config (60 by default) + a small buffer for safety.
@@ -212,18 +206,16 @@ pub async fn run_basket_live(
                     Some(d) => d,
                     None => continue,
                 };
-                let minute = dt.hour() * 60 + dt.minute();
-                if !(RTH_START_MIN..SESSION_CLOSE_MIN).contains(&minute) {
+                if !market_session::is_rth_utc(dt) {
                     // Outside RTH — ignore (do not contaminate daily close).
                     debug!(
                         symbol = bar.symbol.as_str(),
-                        minute,
                         ts = bar.timestamp,
                         "bar outside RTH — discarded"
                     );
                     continue;
                 }
-                let date = dt.date_naive();
+                let date = market_session::trading_day_utc(dt);
                 if bar.close.is_finite() && bar.close > 0.0 {
                     let entry = day_closes.entry(date).or_default();
                     entry.insert(bar.symbol.clone(), bar.close);
@@ -247,10 +239,9 @@ pub async fn run_basket_live(
                 // the channel is backed up or the RTH filter is rejecting
                 // everything.
                 let now = Utc::now();
-                let today = now.date_naive();
-                let minute_now = now.hour() * 60 + now.minute();
-                let in_rth = (RTH_START_MIN..SESSION_CLOSE_MIN).contains(&minute_now);
-                let past_close = minute_now >= SESSION_CLOSE_MIN + CLOSE_GRACE_MIN;
+                let today = market_session::trading_day_utc(now);
+                let in_rth = market_session::is_rth_utc(now);
+                let past_close = market_session::is_after_close_grace_utc(now, CLOSE_GRACE_MIN);
                 let buffered_today = day_closes.get(&today).map(|m| m.len()).unwrap_or(0);
                 let last_bar_age_s = if last_bar_rx_ts_ms == 0 {
                     -1i64
@@ -262,7 +253,6 @@ pub async fn run_basket_live(
                     bars_processed_window,
                     buffered_today,
                     symbols_expected,
-                    minute_now,
                     in_rth,
                     past_close,
                     processed_today = processed_sessions.contains(&today),
@@ -277,16 +267,14 @@ pub async fn run_basket_live(
                 // given date and haven't processed it yet, fire now — regardless
                 // of which symbols' 19:59 bars landed.
                 let now = Utc::now();
-                let today = now.date_naive();
-                let minute_now = now.hour() * 60 + now.minute();
-                let past_close = minute_now >= SESSION_CLOSE_MIN + CLOSE_GRACE_MIN;
+                let today = market_session::trading_day_utc(now);
+                let past_close = market_session::is_after_close_grace_utc(now, CLOSE_GRACE_MIN);
                 if past_close && !processed_sessions.contains(&today) {
                     let closes_for_day = day_closes.remove(&today).unwrap_or_default();
                     if closes_for_day.is_empty() {
                         // Weekend / holiday / blackout — mark processed to avoid busy-looping.
                         info!(
                             date = %today,
-                            minute_now,
                             "session close grace elapsed but no RTH closes buffered — marking processed"
                         );
                         processed_sessions.insert(today);
@@ -303,8 +291,6 @@ pub async fn run_basket_live(
                         .collect();
                     info!(
                         date = %today,
-                        minute_now,
-                        grace_elapsed_past_min = minute_now.saturating_sub(SESSION_CLOSE_MIN + CLOSE_GRACE_MIN),
                         closes_in_buffer = closes_for_day.len(),
                         symbols_expected,
                         missing_count = missing.len(),
@@ -683,15 +669,15 @@ fn load_warmup_closes(
                     Some(d) => d.naive_utc(),
                     None => continue,
                 };
-                let minute = dt.hour() * 60 + dt.minute();
-                if !(RTH_START_MIN..SESSION_CLOSE_MIN).contains(&minute) {
+                let dt_utc = dt.and_utc();
+                if !market_session::is_rth_utc(dt_utc) {
                     continue;
                 }
                 let px = close.value(i);
                 if !px.is_finite() || px <= 0.0 {
                     continue;
                 }
-                let date = dt.date();
+                let date = market_session::trading_day_utc(dt_utc);
                 if date < cutoff {
                     continue;
                 }
@@ -755,6 +741,7 @@ fn align_basket_history(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Timelike;
 
     #[test]
     fn test_basket_execution_alpaca_mode_mapping() {
@@ -792,7 +779,7 @@ mod tests {
         let minute = dt.hour() * 60 + dt.minute();
         assert_eq!(minute, 19 * 60 + 59, "unshift must recover bar-open minute");
         assert!(
-            (RTH_START_MIN..SESSION_CLOSE_MIN).contains(&minute),
+            market_session::is_rth_utc(dt),
             "last RTH bar (19:59 open) must pass RTH filter after unshift"
         );
     }

--- a/engine/crates/runner/src/basket_runner.rs
+++ b/engine/crates/runner/src/basket_runner.rs
@@ -16,10 +16,12 @@ use std::path::Path;
 
 use arrow::array::{Array, Float64Array, TimestampMicrosecondArray};
 use basket_picker::{fit_ou_ar1, load_universe, optimize_symmetric_thresholds, Universe};
-use chrono::{NaiveDate, Timelike};
+use chrono::NaiveDate;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
+
+use crate::market_session;
 
 // Quant-lab walk-forward fit_dates (matches baseline.json)
 const FIT_DATES: &[&str] = &[
@@ -32,10 +34,6 @@ const FIT_DATES: &[&str] = &[
     "2025-12-31",
     "2026-01-31",
 ];
-
-// RTH session: 13:30–20:00 UTC
-const RTH_START_MIN: u32 = 13 * 60 + 30;
-const RTH_END_MIN: u32 = 20 * 60;
 
 /// Portfolio stats matching quant-lab's portfolio_stats.
 #[derive(Debug, Clone, Serialize)]
@@ -426,15 +424,15 @@ fn read_daily_closes(path: &Path) -> Result<BTreeMap<NaiveDate, f64>, String> {
                 Some(d) => d.naive_utc(),
                 None => continue,
             };
-            let minute = dt.hour() * 60 + dt.minute();
-            if !(RTH_START_MIN..RTH_END_MIN).contains(&minute) {
+            let dt_utc = dt.and_utc();
+            if !market_session::is_rth_utc(dt_utc) {
                 continue;
             }
             let px = close.value(i);
             if !px.is_finite() || px <= 0.0 {
                 continue;
             }
-            let date = dt.date();
+            let date = market_session::trading_day_utc(dt_utc);
             daily
                 .entry(date)
                 .and_modify(|(prev_ts, prev_close)| {

--- a/engine/crates/runner/src/main.rs
+++ b/engine/crates/runner/src/main.rs
@@ -19,6 +19,7 @@ mod bar_cache;
 mod basket_live;
 mod basket_runner;
 mod earnings;
+mod market_session;
 mod pair_picker_service;
 pub mod refresh;
 mod stream;

--- a/engine/crates/runner/src/market_session.rs
+++ b/engine/crates/runner/src/market_session.rs
@@ -1,0 +1,69 @@
+use chrono::{DateTime, NaiveDate, NaiveTime, TimeZone, Timelike, Utc};
+use chrono_tz::America::New_York;
+
+const RTH_OPEN: NaiveTime = NaiveTime::from_hms_opt(9, 30, 0).expect("valid open");
+const RTH_CLOSE: NaiveTime = NaiveTime::from_hms_opt(16, 0, 0).expect("valid close");
+
+fn session_minute(local: DateTime<chrono_tz::Tz>) -> u32 {
+    local.time().hour() * 60 + local.time().minute()
+}
+
+pub fn trading_day_utc(dt_utc: DateTime<Utc>) -> NaiveDate {
+    dt_utc.with_timezone(&New_York).date_naive()
+}
+
+pub fn is_rth_utc(dt_utc: DateTime<Utc>) -> bool {
+    let local = dt_utc.with_timezone(&New_York);
+    let minute = session_minute(local);
+    let open = RTH_OPEN.hour() * 60 + RTH_OPEN.minute();
+    let close = RTH_CLOSE.hour() * 60 + RTH_CLOSE.minute();
+    (open..close).contains(&minute)
+}
+
+pub fn is_after_close_grace_utc(dt_utc: DateTime<Utc>, grace_min: u32) -> bool {
+    let local = dt_utc.with_timezone(&New_York);
+    session_minute(local) >= (RTH_CLOSE.hour() * 60 + RTH_CLOSE.minute() + grace_min)
+}
+
+pub fn close_timestamp_utc_for_day(day: NaiveDate) -> i64 {
+    let local = New_York
+        .from_local_datetime(&day.and_time(RTH_CLOSE))
+        .single()
+        .expect("unambiguous cash close");
+    local.with_timezone(&Utc).timestamp_millis()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rth_detection_handles_dst() {
+        let summer_open = Utc.with_ymd_and_hms(2026, 7, 1, 13, 30, 0).unwrap();
+        let winter_open = Utc.with_ymd_and_hms(2026, 1, 15, 14, 30, 0).unwrap();
+        let winter_pre_open = Utc.with_ymd_and_hms(2026, 1, 15, 14, 29, 0).unwrap();
+
+        assert!(is_rth_utc(summer_open));
+        assert!(is_rth_utc(winter_open));
+        assert!(!is_rth_utc(winter_pre_open));
+    }
+
+    #[test]
+    fn test_close_timestamp_handles_dst() {
+        let summer_day = NaiveDate::from_ymd_opt(2026, 7, 1).unwrap();
+        let winter_day = NaiveDate::from_ymd_opt(2026, 1, 15).unwrap();
+
+        assert_eq!(
+            DateTime::<Utc>::from_timestamp_millis(close_timestamp_utc_for_day(summer_day))
+                .unwrap()
+                .time(),
+            NaiveTime::from_hms_opt(20, 0, 0).unwrap()
+        );
+        assert_eq!(
+            DateTime::<Utc>::from_timestamp_millis(close_timestamp_utc_for_day(winter_day))
+                .unwrap()
+                .time(),
+            NaiveTime::from_hms_opt(21, 0, 0).unwrap()
+        );
+    }
+}

--- a/engine/crates/runner/src/refresh.rs
+++ b/engine/crates/runner/src/refresh.rs
@@ -42,10 +42,7 @@ type BarColumns = (
 );
 
 use crate::alpaca::{AlpacaBar, AlpacaClient};
-
-/// RTH session: 13:30–20:00 UTC (same as quant-lab and mock_alpaca.py).
-const RTH_START_MINUTES: i64 = 13 * 60 + 30;
-const RTH_END_MINUTES: i64 = 20 * 60;
+use crate::market_session;
 
 /// Number of trading days to check for fulfillment.
 const LOOKBACK_DAYS: i64 = 90;
@@ -233,26 +230,22 @@ fn write_parquet(path: &Path, cols: &BarColumns) -> Result<(), String> {
     Ok(())
 }
 
-fn micros_to_hm(us: i64) -> (i64, i64) {
-    let secs = us / 1_000_000;
-    let h = (secs % 86400) / 3600;
-    let m = (secs % 3600) / 60;
-    (h, m)
-}
-
 fn micros_to_date(us: i64) -> String {
     let secs = us / 1_000_000;
-    let dt = chrono::DateTime::from_timestamp(secs, 0).unwrap_or(chrono::DateTime::UNIX_EPOCH);
-    dt.format("%Y-%m-%d").to_string()
+    chrono::DateTime::from_timestamp(secs, 0)
+        .map(|dt| market_session::trading_day_utc(dt.to_utc()).to_string())
+        .unwrap_or_else(|| chrono::DateTime::UNIX_EPOCH.date_naive().to_string())
 }
 
 /// Count RTH bars per date from a timestamp slice.
 fn rth_bars_by_date(timestamps: &[i64]) -> HashMap<String, usize> {
     let mut by_date: HashMap<String, usize> = HashMap::new();
     for &ts in timestamps {
-        let (h, m) = micros_to_hm(ts);
-        let minutes = h * 60 + m;
-        if !(RTH_START_MINUTES..RTH_END_MINUTES).contains(&minutes) {
+        let secs = ts / 1_000_000;
+        let Some(dt) = chrono::DateTime::from_timestamp(secs, 0) else {
+            continue;
+        };
+        if !market_session::is_rth_utc(dt.to_utc()) {
             continue;
         }
         *by_date.entry(micros_to_date(ts)).or_insert(0) += 1;

--- a/engine/crates/runner/src/stream.rs
+++ b/engine/crates/runner/src/stream.rs
@@ -37,6 +37,8 @@ use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::Message;
 use tracing::{debug, error, info, warn};
 
+use crate::market_session;
+
 const ALPACA_STREAM_URL: &str = "wss://stream.data.alpaca.markets/v2/iex";
 
 /// Alpaca reports bar OPEN time in the `t` field (both REST and WebSocket).
@@ -52,11 +54,6 @@ const HEARTBEAT_INTERVAL_SECS: u64 = 60;
 /// for illiquid names that don't print every minute while still catching
 /// genuinely broken subscriptions.
 const SYMBOL_STALE_THRESHOLD_SECS: u64 = 180;
-
-/// Regular trading hours (UTC) — watchdog only warns about stale symbols
-/// during this window. Outside RTH, absence of bars is expected.
-const RTH_OPEN_MIN_UTC: u32 = 13 * 60 + 30; // 13:30 UTC
-const RTH_CLOSE_MIN_UTC: u32 = 20 * 60; // 20:00 UTC
 
 /// A bar received from the Alpaca stream.
 #[derive(Debug, Clone)]
@@ -501,12 +498,8 @@ async fn process_bar(
 fn emit_heartbeat(metrics: &mut StreamMetrics, expected: &HashSet<String>) {
     let window_secs = metrics.window_started.elapsed().as_secs().max(1);
     let now_ms = chrono::Utc::now().timestamp_millis();
-    let now_minute_utc = {
-        let now = chrono::Utc::now();
-        use chrono::Timelike;
-        now.hour() * 60 + now.minute()
-    };
-    let in_rth = (RTH_OPEN_MIN_UTC..RTH_CLOSE_MIN_UTC).contains(&now_minute_utc);
+    let now_utc = chrono::Utc::now();
+    let in_rth = market_session::is_rth_utc(now_utc);
 
     // Age of the oldest last-seen bar — flags whether ANY symbols are getting
     // bars at all.


### PR DESCRIPTION
## Summary
- centralize U.S. equity cash-session handling in a shared New York market-session helper
- remove fixed UTC RTH assumptions from basket live, replay, stream watchdog, refresh, and Alpaca historical aggregation
- add DST-aware tests for session detection and close timestamp construction

## Why
The basket stack was hard-coding `13:30-20:00 UTC` as regular trading hours. That is only correct during daylight saving time. In standard-time months, replay, warmup, live close processing, and stale-symbol monitoring were all using the wrong session window.

## Validation
- `cargo test -p openquant-runner -- --nocapture`
