### PR TITLE
Fail closed on incomplete basket live data

### DIFF
--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -29,7 +29,7 @@ use basket_engine::{
     PositionIntent, Side,
 };
 use basket_picker::{load_universe, validate, ValidatorConfig};
-use chrono::{DateTime, NaiveDate, Timelike, Utc};
+use chrono::{DateTime, Datelike, NaiveDate, Timelike, Utc, Weekday};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use tracing::{debug, error, info, warn};
 
@@ -283,14 +283,18 @@ pub async fn run_basket_live(
                 if past_close && !processed_sessions.contains(&today) {
                     let closes_for_day = day_closes.remove(&today).unwrap_or_default();
                     if closes_for_day.is_empty() {
-                        // Weekend / holiday / blackout — mark processed to avoid busy-looping.
-                        info!(
-                            date = %today,
-                            minute_now,
-                            "session close grace elapsed but no RTH closes buffered — marking processed"
-                        );
-                        processed_sessions.insert(today);
-                        continue;
+                        if matches!(today.weekday(), Weekday::Sat | Weekday::Sun) {
+                            info!(
+                                date = %today,
+                                minute_now,
+                                "session close grace elapsed on weekend — marking processed"
+                            );
+                            processed_sessions.insert(today);
+                            continue;
+                        }
+                        return Err(format!(
+                            "session close grace elapsed on weekday {today} but no RTH closes were buffered"
+                        ));
                     }
                     // Log exactly which symbols' closes we have and, crucially,
                     // which expected ones are missing. Yesterday we had no
@@ -311,6 +315,12 @@ pub async fn run_basket_live(
                         missing_sample = ?missing.iter().take(10).collect::<Vec<_>>(),
                         "session close firing"
                     );
+                    if !missing.is_empty() {
+                        return Err(format!(
+                            "incomplete close snapshot for {today}: missing {} symbols",
+                            missing.len()
+                        ));
+                    }
                     processed_sessions.insert(today);
                     process_session_close(
                         &mut engine,
@@ -645,6 +655,7 @@ fn load_warmup_closes(
     use arrow::array::{Array, Float64Array, TimestampMicrosecondArray};
     use std::collections::BTreeMap;
     let cutoff = Utc::now().date_naive() - chrono::Duration::days(window_days);
+    let today = Utc::now().date_naive();
 
     let mut out = HashMap::new();
     for symbol in symbols {
@@ -692,7 +703,7 @@ fn load_warmup_closes(
                     continue;
                 }
                 let date = dt.date();
-                if date < cutoff {
+                if date < cutoff || date >= today {
                     continue;
                 }
                 daily

--- a/engine/crates/runner/src/stream.rs
+++ b/engine/crates/runner/src/stream.rs
@@ -387,7 +387,7 @@ async fn handle_text(
     for msg in messages {
         match msg.msg_type.as_str() {
             "b" => process_bar(msg, metrics, tx).await?,
-            "subscription" => log_subscription_ack(&msg, expected),
+            "subscription" => log_subscription_ack(&msg, expected)?,
             "success" => info!(msg = msg.message_body.as_str(), "stream success"),
             "error" => {
                 error!(
@@ -405,7 +405,7 @@ async fn handle_text(
     Ok(())
 }
 
-fn log_subscription_ack(msg: &StreamMessage, expected: &HashSet<String>) {
+fn log_subscription_ack(msg: &StreamMessage, expected: &HashSet<String>) -> Result<(), String> {
     let confirmed: HashSet<String> = msg.bars_confirmed.iter().cloned().collect();
     let missing: Vec<String> = expected.difference(&confirmed).cloned().collect();
     let extra: Vec<String> = confirmed.difference(expected).cloned().collect();
@@ -414,6 +414,7 @@ fn log_subscription_ack(msg: &StreamMessage, expected: &HashSet<String>) {
             confirmed = confirmed.len(),
             "subscription ack — server confirmed all requested symbols"
         );
+        Ok(())
     } else {
         warn!(
             requested = expected.len(),
@@ -424,6 +425,12 @@ fn log_subscription_ack(msg: &StreamMessage, expected: &HashSet<String>) {
             extra_sample = ?extra.iter().take(10).collect::<Vec<_>>(),
             "subscription ack — mismatch between requested and confirmed symbols"
         );
+        Err(format!(
+            "subscription ack mismatch: confirmed={}, missing={}, extra={}",
+            confirmed.len(),
+            missing.len(),
+            extra.len()
+        ))
     }
 }
 
@@ -581,4 +588,33 @@ fn emit_heartbeat(metrics: &mut StreamMetrics, expected: &HashSet<String>) {
     // Reset window counters but keep the per-symbol map alive across windows.
     metrics.bars_last_window = 0;
     metrics.window_started = Instant::now();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_subscription_ack_mismatch_fails_closed() {
+        let expected: HashSet<String> = ["AAPL".to_string(), "MSFT".to_string()]
+            .into_iter()
+            .collect();
+        let msg = StreamMessage {
+            msg_type: "subscription".to_string(),
+            symbol: String::new(),
+            timestamp: String::new(),
+            close: 0.0,
+            open: 0.0,
+            high: 0.0,
+            low: 0.0,
+            volume: 0.0,
+            bars_confirmed: vec!["AAPL".to_string()],
+            trades_confirmed: vec![],
+            quotes_confirmed: vec![],
+            message_body: String::new(),
+            code: 0,
+        };
+
+        assert!(log_subscription_ack(&msg, &expected).is_err());
+    }
 }


### PR DESCRIPTION
## Summary
- treat partial Alpaca subscription acknowledgements as fatal so the stream reconnects instead of trading with a subset of symbols
- fail the basket live runner when a weekday session reaches close+grace with no close snapshot or with missing symbols
- exclude today's partial parquet day from live warmup validation
- add stream coverage for the fail-closed subscription path

## Why
The live basket path was still willing to keep running after incomplete subscriptions and partial or empty close snapshots. That is unsafe for a multi-leg EOD strategy because stale or missing legs can silently distort signals and orders. Warmup was also still able to fit against today's incomplete parquet tail on intraday starts.

## Validation
- `cargo test -p openquant-runner -- --nocapture`
