### PR TITLE
Add frozen basket fit artifact for live runner

### DIFF
--- a/engine/crates/runner/src/basket_fits.rs
+++ b/engine/crates/runner/src/basket_fits.rs
@@ -1,0 +1,221 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use basket_picker::{load_universe, validate, BasketFit, Universe, ValidatorConfig};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+use crate::basket_live::{align_basket_history, collect_symbols, load_warmup_closes};
+
+const FIT_ARTIFACT_SCHEMA: &str = "basket_fit_artifact";
+const FIT_ARTIFACT_VERSION: &str = "v1";
+const WARMUP_DAYS: i64 = 90;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BasketFitArtifact {
+    pub schema: String,
+    pub version: String,
+    pub universe_version: String,
+    pub universe_frozen_at: String,
+    pub generated_at: String,
+    pub fits: Vec<BasketFit>,
+}
+
+pub fn default_fit_artifact_path(universe_path: &Path) -> PathBuf {
+    let stem = universe_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("basket_universe");
+    universe_path.with_file_name(format!("{stem}.fits.json"))
+}
+
+pub fn build_live_fit_artifact(
+    universe_path: &Path,
+    bars_dir: &Path,
+) -> Result<BasketFitArtifact, String> {
+    let universe = load_universe(universe_path)?;
+    let symbols = collect_symbols(&universe);
+    let closes = load_warmup_closes(bars_dir, &symbols, WARMUP_DAYS)?;
+    build_live_fit_artifact_from_inputs(&universe, &closes)
+}
+
+pub fn build_live_fit_artifact_from_inputs(
+    universe: &Universe,
+    closes: &std::collections::HashMap<String, Vec<(chrono::NaiveDate, f64)>>,
+) -> Result<BasketFitArtifact, String> {
+    let validator_config = ValidatorConfig {
+        residual_window: universe.strategy.residual_window_days,
+        k_clip_min: universe.strategy.threshold_clip_min,
+        k_clip_max: universe.strategy.threshold_clip_max,
+        cost: universe.strategy.cost_bps_assumed / 10_000.0,
+    };
+
+    let fits: Vec<BasketFit> = universe
+        .candidates
+        .iter()
+        .map(|c| {
+            let mut basket_symbols: Vec<&str> = Vec::with_capacity(c.members.len() + 1);
+            basket_symbols.push(c.target.as_str());
+            basket_symbols.extend(c.members.iter().map(String::as_str));
+            let aligned = align_basket_history(closes, &basket_symbols);
+            validate(c, &aligned, &validator_config)
+        })
+        .collect();
+    ensure_unique_fit_ids(&fits)?;
+
+    Ok(BasketFitArtifact {
+        schema: FIT_ARTIFACT_SCHEMA.to_string(),
+        version: FIT_ARTIFACT_VERSION.to_string(),
+        universe_version: universe.version.version.clone(),
+        universe_frozen_at: universe.version.frozen_at.clone(),
+        generated_at: Utc::now().to_rfc3339(),
+        fits,
+    })
+}
+
+pub fn save_fit_artifact(path: &Path, artifact: &BasketFitArtifact) -> Result<(), String> {
+    let content = serde_json::to_string_pretty(artifact)
+        .map_err(|e| format!("serialize fit artifact: {e}"))?;
+    fs::write(path, content).map_err(|e| format!("write {}: {e}", path.display()))
+}
+
+pub fn load_fit_artifact(path: &Path, universe: &Universe) -> Result<BasketFitArtifact, String> {
+    let content = fs::read_to_string(path)
+        .map_err(|e| format!("read fit artifact {}: {e}", path.display()))?;
+    let artifact: BasketFitArtifact =
+        serde_json::from_str(&content).map_err(|e| format!("parse fit artifact: {e}"))?;
+
+    if artifact.schema != FIT_ARTIFACT_SCHEMA {
+        return Err(format!(
+            "unsupported fit artifact schema '{}'",
+            artifact.schema
+        ));
+    }
+    if artifact.version != FIT_ARTIFACT_VERSION {
+        return Err(format!(
+            "unsupported fit artifact version '{}'",
+            artifact.version
+        ));
+    }
+    if artifact.universe_version != universe.version.version {
+        return Err(format!(
+            "fit artifact universe version mismatch: artifact={}, universe={}",
+            artifact.universe_version, universe.version.version
+        ));
+    }
+    if artifact.universe_frozen_at != universe.version.frozen_at {
+        return Err(format!(
+            "fit artifact frozen_at mismatch: artifact={}, universe={}",
+            artifact.universe_frozen_at, universe.version.frozen_at
+        ));
+    }
+    ensure_unique_fit_ids(&artifact.fits)?;
+
+    let expected_ids: HashSet<String> = universe.candidates.iter().map(|c| c.id()).collect();
+    let artifact_ids: HashSet<String> = artifact.fits.iter().map(|f| f.candidate.id()).collect();
+    if expected_ids != artifact_ids {
+        return Err(format!(
+            "fit artifact candidate set mismatch: artifact={}, universe={}",
+            artifact_ids.len(),
+            expected_ids.len()
+        ));
+    }
+
+    Ok(artifact)
+}
+
+fn ensure_unique_fit_ids(fits: &[BasketFit]) -> Result<(), String> {
+    let mut seen = HashSet::new();
+    for fit in fits {
+        let id = fit.candidate.id();
+        if !seen.insert(id.clone()) {
+            return Err(format!("duplicate basket fit id '{id}' in artifact"));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use basket_picker::load_universe_from_str;
+    use std::collections::HashMap;
+
+    const TEST_UNIVERSE: &str = r#"
+[version]
+schema = "basket_universe"
+version = "v1"
+frozen_at = "2026-04-20"
+
+[strategy]
+method = "basket_spread_ou_bertram"
+spread_formula = "log(target) - mean(log(peers))"
+threshold_method = "bertram_symmetric"
+threshold_clip_min = 0.15
+threshold_clip_max = 2.5
+residual_window_days = 60
+forward_window_days = 60
+refit_cadence = "quarterly"
+cost_bps_assumed = 5.0
+leverage_assumed = 4.0
+sizing = "equal_weight_across_baskets"
+
+[sectors.test]
+members = ["AAA", "BBB", "CCC"]
+traded_targets = ["AAA"]
+"#;
+
+    fn mk_series(base: f64) -> Vec<(chrono::NaiveDate, f64)> {
+        let mut out = Vec::new();
+        for i in 0..90 {
+            let d = chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap() + chrono::Days::new(i);
+            out.push((d, base + (i as f64 * 0.01)));
+        }
+        out
+    }
+
+    #[test]
+    fn test_artifact_roundtrip_and_validation() {
+        let universe = load_universe_from_str(TEST_UNIVERSE).unwrap();
+        let mut closes: HashMap<String, Vec<(chrono::NaiveDate, f64)>> = HashMap::new();
+        closes.insert("AAA".to_string(), mk_series(100.0));
+        closes.insert("BBB".to_string(), mk_series(101.0));
+        closes.insert("CCC".to_string(), mk_series(99.0));
+
+        let artifact = build_live_fit_artifact_from_inputs(&universe, &closes).unwrap();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        save_fit_artifact(tmp.path(), &artifact).unwrap();
+        let loaded = load_fit_artifact(tmp.path(), &universe).unwrap();
+
+        assert_eq!(loaded.schema, FIT_ARTIFACT_SCHEMA);
+        assert_eq!(loaded.fits.len(), 1);
+        assert_eq!(loaded.fits[0].candidate.id(), universe.candidates[0].id());
+    }
+
+    #[test]
+    fn test_default_fit_artifact_path() {
+        let path = Path::new("config/basket_universe_v1.toml");
+        assert_eq!(
+            default_fit_artifact_path(path),
+            PathBuf::from("config/basket_universe_v1.fits.json")
+        );
+    }
+
+    #[test]
+    fn test_duplicate_fit_ids_are_rejected() {
+        let universe = load_universe_from_str(TEST_UNIVERSE).unwrap();
+        let mut closes: HashMap<String, Vec<(chrono::NaiveDate, f64)>> = HashMap::new();
+        closes.insert("AAA".to_string(), mk_series(100.0));
+        closes.insert("BBB".to_string(), mk_series(101.0));
+        closes.insert("CCC".to_string(), mk_series(99.0));
+
+        let mut artifact = build_live_fit_artifact_from_inputs(&universe, &closes).unwrap();
+        artifact.fits.push(artifact.fits[0].clone());
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        save_fit_artifact(tmp.path(), &artifact).unwrap();
+
+        let err = load_fit_artifact(tmp.path(), &universe).unwrap_err();
+        assert!(err.contains("duplicate basket fit id"));
+    }
+}

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -5,8 +5,8 @@
 //! bars from the Alpaca WebSocket.
 //!
 //! Flow per trading day:
-//!   1. Warmup (startup): read last N days of parquets, validate candidates,
-//!      build `BasketEngine` from `BasketFit`s. Engine enters with empty state.
+//!   1. Startup: load the frozen basket fit artifact and build `BasketEngine`
+//!      from those persisted `BasketFit`s. Engine enters with empty state.
 //!   2. Bar loop: for each 1-min bar, update per-symbol "last RTH bar".
 //!   3. Session close (19:59 UTC): snapshot the day's closes, call
 //!      `BasketEngine::on_bars()`, get `PositionIntent`s.
@@ -28,7 +28,7 @@ use basket_engine::{
     aggregate_positions, diff_to_orders, BasketEngine, DailyBar, OrderIntent, PortfolioConfig,
     PositionIntent, Side,
 };
-use basket_picker::{load_universe, validate, ValidatorConfig};
+use basket_picker::{load_universe, BasketFit};
 use chrono::{DateTime, NaiveDate, Utc};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use tracing::{debug, error, info, warn};
@@ -69,23 +69,20 @@ impl BasketExecution {
     }
 }
 
-/// Warmup window: days of history to seed state. Needs >= residual_window from
-/// the universe config (60 by default) + a small buffer for safety.
-const WARMUP_DAYS: i64 = 90;
-
 /// Run the basket live/paper loop.
 ///
 /// Returns on Ctrl+C or fatal error.
 pub async fn run_basket_live(
     alpaca: &AlpacaClient,
     universe_path: &Path,
-    bars_dir: &Path,
+    fit_artifact_path: &Path,
     execution: BasketExecution,
     portfolio_config: PortfolioConfig,
+    fits: &[BasketFit],
 ) -> Result<(), String> {
     info!(
         universe = %universe_path.display(),
-        bars_dir = %bars_dir.display(),
+        fit_artifact = %fit_artifact_path.display(),
         execution = execution.label(),
         "========== BASKET LIVE RUNNER =========="
     );
@@ -94,7 +91,7 @@ pub async fn run_basket_live(
         warn!("LIVE MODE — real-money orders will be placed on every EOD signal");
     }
 
-    // 1. Load universe + validate candidates using parquet warmup data.
+    // 1. Load universe + frozen fit artifact.
     let universe = load_universe(universe_path)?;
     info!(
         baskets = universe.num_baskets(),
@@ -103,46 +100,23 @@ pub async fn run_basket_live(
     );
 
     let symbols = collect_symbols(&universe);
-    let closes = load_warmup_closes(bars_dir, &symbols, WARMUP_DAYS)?;
     info!(
         symbols = symbols.len(),
-        loaded_series = closes.len(),
-        "loaded warmup closes"
+        fits = fits.len(),
+        "loaded frozen basket fit artifact"
     );
 
-    let validator_config = ValidatorConfig {
-        residual_window: universe.strategy.residual_window_days,
-        k_clip_min: universe.strategy.threshold_clip_min,
-        k_clip_max: universe.strategy.threshold_clip_max,
-        cost: universe.strategy.cost_bps_assumed / 10_000.0,
-    };
-
-    // Validate each candidate with its OWN per-basket date intersection.
-    // A universe-wide intersection lets one sparse symbol shrink every series
-    // below `residual_window` and reject otherwise-valid baskets, even when
-    // the candidate's own symbols have sufficient history.
-    let fits: Vec<_> = universe
-        .candidates
-        .iter()
-        .map(|c| {
-            let mut basket_symbols: Vec<&str> = Vec::with_capacity(c.members.len() + 1);
-            basket_symbols.push(c.target.as_str());
-            basket_symbols.extend(c.members.iter().map(String::as_str));
-            let aligned = align_basket_history(&closes, &basket_symbols);
-            validate(c, &aligned, &validator_config)
-        })
-        .collect();
     let valid_count = fits.iter().filter(|f| f.valid).count();
     info!(
         total = fits.len(),
         valid = valid_count,
-        "validated basket candidates"
+        "loaded basket fits"
     );
     if valid_count == 0 {
-        return Err("no valid baskets after warmup validation".to_string());
+        return Err("no valid baskets in fit artifact".to_string());
     }
 
-    let mut engine = BasketEngine::new(&fits);
+    let mut engine = BasketEngine::new(fits);
     info!(baskets = engine.num_baskets(), "basket engine initialized");
 
     // 2. Seed current_notionals from Alpaca positions (startup reconciliation).
@@ -635,7 +609,7 @@ fn log_order(order: &OrderIntent, label: &str) {
     );
 }
 
-fn collect_symbols(universe: &basket_picker::Universe) -> Vec<String> {
+pub(crate) fn collect_symbols(universe: &basket_picker::Universe) -> Vec<String> {
     let mut symbols: Vec<String> = universe
         .sectors
         .values()
@@ -648,7 +622,7 @@ fn collect_symbols(universe: &basket_picker::Universe) -> Vec<String> {
 
 /// Read the last `window_days` trading days of daily closes for each symbol.
 /// Aggregates 1-min parquets to RTH-last-bar closes (same rule as replay).
-fn load_warmup_closes(
+pub(crate) fn load_warmup_closes(
     bars_dir: &Path,
     symbols: &[String],
     window_days: i64,
@@ -732,7 +706,7 @@ fn load_warmup_closes(
 /// requires, intersecting dates across ONLY this basket's symbols. Missing
 /// symbols are passed through unaligned (length 0 after intersection with
 /// nothing), so the validator emits a precise "missing symbol" rejection.
-fn align_basket_history(
+pub(crate) fn align_basket_history(
     closes: &HashMap<String, Vec<(NaiveDate, f64)>>,
     symbols: &[&str],
 ) -> HashMap<String, Vec<f64>> {

--- a/engine/crates/runner/src/main.rs
+++ b/engine/crates/runner/src/main.rs
@@ -16,6 +16,7 @@
 
 mod alpaca;
 mod bar_cache;
+mod basket_fits;
 mod basket_live;
 mod basket_runner;
 mod earnings;
@@ -51,6 +52,8 @@ enum Command {
     /// Replay — historical minute bars from Alpaca REST, no orders.
     /// The engine processes bars identically to live; it doesn't know it's replaying.
     Replay(ReplayArgs),
+    /// Build a frozen basket fit artifact from the current universe and parquet history.
+    FreezeBasketFits(BasketFitArgs),
 }
 
 /// Asset class / strategy variant. Each variant defines its own config,
@@ -155,6 +158,10 @@ struct StreamArgs {
     ///   live:  real-money Alpaca (explicit opt-in required)
     #[arg(long, default_value = "noop")]
     execution: String,
+
+    /// Frozen basket fit artifact. Defaults to `<universe>.fits.json`.
+    #[arg(long)]
+    fit_artifact: Option<PathBuf>,
 }
 
 /// Args for replay (adds date range).
@@ -212,6 +219,24 @@ struct ReplayArgs {
     /// Output TSV for basket replay metrics (default: data/basket_parity.tsv).
     #[arg(long)]
     tsv_out: Option<PathBuf>,
+}
+
+#[derive(clap::Args, Debug, Clone)]
+struct BasketFitArgs {
+    /// Basket universe TOML file. Defaults to `config/basket_universe_v1.toml`.
+    #[arg(long)]
+    universe: Option<PathBuf>,
+
+    #[arg(long, default_value = "data")]
+    data_dir: PathBuf,
+
+    /// Directory containing per-symbol 1-min parquets.
+    #[arg(long)]
+    bars_dir: Option<PathBuf>,
+
+    /// Output fit artifact path. Defaults to `<universe>.fits.json`.
+    #[arg(long)]
+    out: Option<PathBuf>,
 }
 
 const DEFAULT_CONFIG: &str = "config/pairs.toml";
@@ -279,6 +304,7 @@ async fn main() {
     let data_dir = match &cli.command {
         Command::Live(a) | Command::Paper(a) => &a.data_dir,
         Command::Replay(a) => &a.data_dir,
+        Command::FreezeBasketFits(a) => &a.data_dir,
     };
 
     let journal_dir = data_dir.join("journal");
@@ -307,6 +333,11 @@ async fn main() {
             run_basket_stream(a.clone(), matches!(&cli.command, Command::Live(_))).await;
             return;
         }
+    }
+
+    if let Command::FreezeBasketFits(a) = &cli.command {
+        run_freeze_basket_fits(a.clone());
+        return;
     }
 
     // Convert CLI command → (config, trading_dir, data_dir, candidates, pipeline, run_mode)
@@ -427,6 +458,7 @@ async fn main() {
                 },
             )
         }
+        Command::FreezeBasketFits(_) => unreachable!("handled before run-mode dispatch"),
     };
 
     run(
@@ -460,6 +492,10 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
                 PathBuf::from(home).join("quant-data/bars/v3_sp500_2024-2026_1min_adjusted")
             })
     });
+    let fit_artifact_path = args
+        .fit_artifact
+        .clone()
+        .unwrap_or_else(|| basket_fits::default_fit_artifact_path(&universe_path));
 
     // Parse execution mode. Default = noop (shadow).
     // Extra safety: `paper live` must come from `Command::Live` (real-money path),
@@ -492,10 +528,10 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
         }
     };
 
-    // Refresh quant-data before warmup. Without this, the basket path reads
-    // potentially-stale parquets, and the validator fits OU on outdated prices
-    // — the same failure mode the pairs path fixes at main.rs refresh block.
-    // Filter refresh to only the universe's symbols (avoid refreshing unrelated SP500 names).
+    // Refresh quant-data before the session starts so the universe's parquet
+    // history stays current for any future artifact rebuilds and operator
+    // diagnostics. Filter refresh to only the universe's symbols to avoid
+    // touching unrelated SP500 names.
     if bars_dir.exists() {
         let filter = match basket_picker::load_universe(&universe_path) {
             Ok(u) => {
@@ -534,19 +570,97 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
     // Portfolio config: use sensible defaults for now. Capital & leverage can
     // be surfaced to CLI/config in a follow-up; defaults match baseline config.
     let portfolio_config = basket_engine::PortfolioConfig::default();
+    let universe = match basket_picker::load_universe(&universe_path) {
+        Ok(u) => u,
+        Err(e) => {
+            error!(error = %e, "failed to load basket universe");
+            std::process::exit(1);
+        }
+    };
+    let fit_artifact = match basket_fits::load_fit_artifact(&fit_artifact_path, &universe) {
+        Ok(a) => a,
+        Err(e) => {
+            error!(
+                error = %e,
+                fit_artifact = %fit_artifact_path.display(),
+                "failed to load frozen basket fit artifact"
+            );
+            error!(
+                "build it first with: openquant-runner freeze-basket-fits --universe {} --bars-dir {} --out {}",
+                universe_path.display(),
+                bars_dir.display(),
+                fit_artifact_path.display()
+            );
+            std::process::exit(1);
+        }
+    };
 
     if let Err(e) = basket_live::run_basket_live(
         &alpaca,
         &universe_path,
-        &bars_dir,
+        &fit_artifact_path,
         execution,
         portfolio_config,
+        &fit_artifact.fits,
     )
     .await
     {
         error!(error = %e, "basket live runner failed");
         std::process::exit(1);
     }
+}
+
+fn run_freeze_basket_fits(args: BasketFitArgs) {
+    let universe_path = args
+        .universe
+        .unwrap_or_else(|| PathBuf::from("config/basket_universe_v1.toml"));
+    let bars_dir = args.bars_dir.unwrap_or_else(|| {
+        std::env::var("QUANT_DATA_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| {
+                let home = std::env::var("HOME").unwrap_or_default();
+                PathBuf::from(home).join("quant-data/bars/v3_sp500_2024-2026_1min_adjusted")
+            })
+    });
+    let out = args
+        .out
+        .unwrap_or_else(|| basket_fits::default_fit_artifact_path(&universe_path));
+
+    info!(
+        universe = %universe_path.display(),
+        bars_dir = %bars_dir.display(),
+        out = %out.display(),
+        "========== FREEZE BASKET FITS =========="
+    );
+
+    let artifact = match basket_fits::build_live_fit_artifact(&universe_path, &bars_dir) {
+        Ok(a) => a,
+        Err(e) => {
+            error!(error = %e, "failed to build basket fit artifact");
+            std::process::exit(1);
+        }
+    };
+    let valid = artifact.fits.iter().filter(|f| f.valid).count();
+    if valid == 0 {
+        error!(
+            total = artifact.fits.len(),
+            out = %out.display(),
+            "refusing to write basket fit artifact with zero valid baskets"
+        );
+        std::process::exit(1);
+    }
+    if let Err(e) = basket_fits::save_fit_artifact(&out, &artifact) {
+        error!(error = %e, "failed to save basket fit artifact");
+        std::process::exit(1);
+    }
+    info!(
+        path = %out.display(),
+        total = artifact.fits.len(),
+        valid,
+        invalid = artifact.fits.len().saturating_sub(valid),
+        generated_at = artifact.generated_at.as_str(),
+        "wrote frozen basket fit artifact"
+    );
 }
 
 // ── Unified run function ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add a frozen basket fit artifact format with schema/version/universe metadata validation
- add `openquant-runner freeze-basket-fits` to build the artifact from the basket universe and parquet history
- make the basket live runner load a persisted fit artifact instead of re-fitting baskets on startup
- default the artifact path to `<universe>.fits.json`

## Why
The live basket path was still fitting OU/Bertram parameters at process start from the latest warmup tail. That makes live behavior depend on restart date and available parquet history rather than on a frozen research artifact. This PR makes live consume a persisted fit set instead.

## Validation
- `cargo test -p openquant-runner -- --nocapture`
- `cargo test -p openquant-runner basket_fits::tests::test_artifact_roundtrip_and_validation -- --nocapture`
