### PR TITLE
Persist basket live state across restarts

### DIFF
--- a/engine/crates/basket-engine/src/engine.rs
+++ b/engine/crates/basket-engine/src/engine.rs
@@ -347,6 +347,17 @@ impl BasketEngine {
             params.insert(p.basket_id.clone(), p);
         }
 
+        for basket_id in params.keys() {
+            if !snapshot.states.contains_key(basket_id) {
+                return Err(format!("missing runtime state for basket_id '{basket_id}'"));
+            }
+        }
+        for basket_id in snapshot.states.keys() {
+            if !params.contains_key(basket_id) {
+                return Err(format!("runtime state present for unknown basket_id '{basket_id}'"));
+            }
+        }
+
         Ok(Self {
             params,
             states: snapshot.states,

--- a/engine/crates/runner/src/basket_fits.rs
+++ b/engine/crates/runner/src/basket_fits.rs
@@ -30,6 +30,14 @@ pub fn default_fit_artifact_path(universe_path: &Path) -> PathBuf {
     universe_path.with_file_name(format!("{stem}.fits.json"))
 }
 
+pub fn default_live_state_path(fit_artifact_path: &Path) -> PathBuf {
+    let stem = fit_artifact_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("basket_fits");
+    fit_artifact_path.with_file_name(format!("{stem}.state.json"))
+}
+
 pub fn build_live_fit_artifact(universe_path: &Path, bars_dir: &Path) -> Result<BasketFitArtifact, String> {
     let universe = load_universe(universe_path)?;
     let symbols = collect_symbols(&universe);
@@ -183,6 +191,15 @@ traded_targets = ["AAA"]
         assert_eq!(
             default_fit_artifact_path(path),
             PathBuf::from("config/basket_universe_v1.fits.json")
+        );
+    }
+
+    #[test]
+    fn test_default_live_state_path() {
+        let path = Path::new("config/basket_universe_v1.fits.json");
+        assert_eq!(
+            default_live_state_path(path),
+            PathBuf::from("config/basket_universe_v1.fits.state.json")
         );
     }
 }

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -25,8 +25,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use basket_engine::{
-    aggregate_positions, diff_to_orders, BasketEngine, DailyBar, OrderIntent, PortfolioConfig,
-    PositionIntent, Side,
+    aggregate_positions, diff_to_orders, BasketEngine, DailyBar, OrderIntent, PortfolioConfig, PositionIntent, Side,
 };
 use basket_picker::{load_universe, BasketFit};
 use chrono::{DateTime, NaiveDate, Utc};
@@ -79,10 +78,12 @@ pub async fn run_basket_live(
     execution: BasketExecution,
     portfolio_config: PortfolioConfig,
     fits: &[BasketFit],
+    state_path: &Path,
 ) -> Result<(), String> {
     info!(
         universe = %universe_path.display(),
         fit_artifact = %fit_artifact_path.display(),
+        state_path = %state_path.display(),
         execution = execution.label(),
         "========== BASKET LIVE RUNNER =========="
     );
@@ -116,8 +117,31 @@ pub async fn run_basket_live(
         return Err("no valid baskets in fit artifact".to_string());
     }
 
-    let mut engine = BasketEngine::new(fits);
-    info!(baskets = engine.num_baskets(), "basket engine initialized");
+    let expected_ids: std::collections::HashSet<String> =
+        fits.iter().filter(|f| f.valid).map(|f| f.candidate.id()).collect();
+    let state_exists = state_path.exists();
+    let mut engine = if state_exists {
+        let loaded = BasketEngine::load_state(state_path)?;
+        let loaded_ids: std::collections::HashSet<String> =
+            loaded.iter_params().map(|(id, _)| id.clone()).collect();
+        if loaded_ids != expected_ids {
+            return Err(format!(
+                "state snapshot basket set mismatch: snapshot={}, artifact={}",
+                loaded_ids.len(),
+                expected_ids.len()
+            ));
+        }
+        info!(
+            baskets = loaded.num_baskets(),
+            state_path = %state_path.display(),
+            "loaded basket engine state snapshot"
+        );
+        loaded
+    } else {
+        let fresh = BasketEngine::new(fits);
+        info!(baskets = fresh.num_baskets(), "basket engine initialized from frozen fits");
+        fresh
+    };
 
     // 2. Seed current_notionals from Alpaca positions (startup reconciliation).
     //    Without this, a restart with live open positions would trigger
@@ -134,6 +158,17 @@ pub async fn run_basket_live(
         }
         Some(mode) => seed_current_notionals_from_alpaca(alpaca, mode).await?,
     };
+    if execution.alpaca_mode().is_some() && !state_exists && !current_notionals.is_empty() {
+        error!(
+            state_path = %state_path.display(),
+            broker_positions = current_notionals.len(),
+            "broker has open positions but no basket state snapshot was found"
+        );
+        return Err(format!(
+            "open broker positions found but no basket state snapshot exists at {}",
+            state_path.display()
+        ));
+    }
 
     // 3. Subscribe to all universe symbols over WebSocket.
     let mut bar_rx = stream::start_bar_stream(&alpaca.api_key, &alpaca.api_secret, &symbols).await;
@@ -282,6 +317,19 @@ pub async fn run_basket_live(
                         execution,
                     )
                     .await;
+                    if let Err(e) = engine.save_state(state_path) {
+                        error!(
+                            error = %e,
+                            state_path = %state_path.display(),
+                            "failed to persist basket engine state after session close"
+                        );
+                        return Err(e);
+                    }
+                    info!(
+                        date = %today,
+                        state_path = %state_path.display(),
+                        "persisted basket engine state after session close"
+                    );
                 }
             }
             _ = &mut ctrl_c => {

--- a/engine/crates/runner/src/main.rs
+++ b/engine/crates/runner/src/main.rs
@@ -162,6 +162,10 @@ struct StreamArgs {
     /// Frozen basket fit artifact. Defaults to `<universe>.fits.json`.
     #[arg(long)]
     fit_artifact: Option<PathBuf>,
+
+    /// Persisted basket engine runtime state. Defaults to `<fit-artifact>.state.json`.
+    #[arg(long)]
+    state_path: Option<PathBuf>,
 }
 
 /// Args for replay (adds date range).
@@ -493,6 +497,10 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
         .fit_artifact
         .clone()
         .unwrap_or_else(|| basket_fits::default_fit_artifact_path(&universe_path));
+    let state_path = args
+        .state_path
+        .clone()
+        .unwrap_or_else(|| basket_fits::default_live_state_path(&fit_artifact_path));
 
     // Parse execution mode. Default = noop (shadow).
     // Extra safety: `paper live` must come from `Command::Live` (real-money path),
@@ -599,6 +607,7 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
         execution,
         portfolio_config,
         &fit_artifact.fits,
+        &state_path,
     )
     .await
     {


### PR DESCRIPTION
## Summary
- persist basket engine state after each processed session close
- reload state on startup when it matches the frozen fit artifact basket set
- fail closed if the broker already has open positions but there is no matching basket state snapshot
- tighten `BasketEngine::load_state()` validation so malformed snapshots are rejected
- derive a default state path from the fit artifact path

## Why
The live runner was still starting the basket engine flat after every restart even when the broker already had exposure. That breaks the long/short state machine and can produce incorrect flips or liquidation behavior on the next close. This PR makes restart state explicit instead of reconstructing it implicitly.

## Validation
- `cargo test -p basket-engine -p openquant-runner -- --nocapture`
