### PR TITLE
Use share inventory for basket live reconciliation

### DIFF
--- a/engine/crates/basket-engine/src/lib.rs
+++ b/engine/crates/basket-engine/src/lib.rs
@@ -11,8 +11,8 @@ mod state;
 pub use engine::{BasketEngine, BasketParams, EngineSnapshot};
 pub use intent::{PositionIntent, TransitionReason};
 pub use portfolio::{
-    aggregate_positions, basket_to_legs, diff_to_orders, LegNotional, OrderIntent, OrderReason,
-    PortfolioConfig, Side,
+    aggregate_positions, basket_to_legs, diff_to_orders, target_shares_from_notionals,
+    LegNotional, OrderIntent, OrderReason, PortfolioConfig, Side,
 };
 pub use state::BasketState;
 

--- a/engine/crates/basket-engine/src/portfolio.rs
+++ b/engine/crates/basket-engine/src/portfolio.rs
@@ -144,19 +144,31 @@ pub struct OrderIntent {
 pub fn target_shares_from_notionals(
     target: &HashMap<String, f64>,
     prices: &HashMap<String, f64>,
-) -> HashMap<String, i64> {
+) -> Result<HashMap<String, i64>, String> {
     let mut shares = HashMap::new();
+    let mut invalid_symbols = Vec::new();
     for (symbol, target_notional) in target {
         let price = match prices.get(symbol) {
             Some(&p) if p.is_finite() && p > 0.0 => p,
-            _ => continue,
+            _ => {
+                invalid_symbols.push(symbol.clone());
+                continue;
+            }
         };
         let qty = (target_notional / price).round() as i64;
         if qty != 0 {
             shares.insert(symbol.clone(), qty);
         }
     }
-    shares
+    if invalid_symbols.is_empty() {
+        Ok(shares)
+    } else {
+        invalid_symbols.sort();
+        Err(format!(
+            "missing or invalid close for target share conversion: {}",
+            invalid_symbols.join(", ")
+        ))
+    }
 }
 
 /// Compute orders needed to move from current shares to target shares.
@@ -295,8 +307,18 @@ mod tests {
         prices.insert("AMD".to_string(), 100.0);
         prices.insert("NVDA".to_string(), 200.0);
 
-        let shares = target_shares_from_notionals(&target, &prices);
+        let shares = target_shares_from_notionals(&target, &prices).unwrap();
         assert_eq!(shares.get("AMD"), Some(&30));
         assert_eq!(shares.get("NVDA"), Some(&-10));
+    }
+
+    #[test]
+    fn test_target_shares_from_notionals_rejects_invalid_price() {
+        let mut target: HashMap<String, f64> = HashMap::new();
+        target.insert("AMD".to_string(), 3000.0);
+
+        let prices: HashMap<String, f64> = HashMap::new();
+        let err = target_shares_from_notionals(&target, &prices).unwrap_err();
+        assert!(err.contains("AMD"));
     }
 }

--- a/engine/crates/basket-engine/src/portfolio.rs
+++ b/engine/crates/basket-engine/src/portfolio.rs
@@ -140,14 +140,29 @@ pub struct OrderIntent {
     pub reason: OrderReason,
 }
 
-/// Compute orders needed to move from current to target positions.
-///
-/// Takes current notionals, target notionals, and current prices.
-/// Returns the orders needed to reach target.
-pub fn diff_to_orders(
-    current: &HashMap<String, f64>,
+/// Convert target notionals into whole-share targets using current prices.
+pub fn target_shares_from_notionals(
     target: &HashMap<String, f64>,
     prices: &HashMap<String, f64>,
+) -> HashMap<String, i64> {
+    let mut shares = HashMap::new();
+    for (symbol, target_notional) in target {
+        let price = match prices.get(symbol) {
+            Some(&p) if p.is_finite() && p > 0.0 => p,
+            _ => continue,
+        };
+        let qty = (target_notional / price).round() as i64;
+        if qty != 0 {
+            shares.insert(symbol.clone(), qty);
+        }
+    }
+    shares
+}
+
+/// Compute orders needed to move from current shares to target shares.
+pub fn diff_to_orders(
+    current: &HashMap<String, i64>,
+    target: &HashMap<String, i64>,
 ) -> Vec<OrderIntent> {
     let mut orders = Vec::new();
 
@@ -157,30 +172,19 @@ pub fn diff_to_orders(
     all_symbols.dedup();
 
     for symbol in all_symbols {
-        let current_notional = current.get(symbol).copied().unwrap_or(0.0);
-        let target_notional = target.get(symbol).copied().unwrap_or(0.0);
-        let delta = target_notional - current_notional;
-
-        if delta.abs() < 1.0 {
-            continue; // Skip tiny deltas
-        }
-
-        let price = match prices.get(symbol) {
-            Some(&p) if p.is_finite() && p > 0.0 => p,
-            _ => continue, // Skip if no valid price
-        };
-
-        let qty = (delta.abs() / price).round() as u32;
-        if qty == 0 {
+        let current_qty = current.get(symbol).copied().unwrap_or(0);
+        let target_qty = target.get(symbol).copied().unwrap_or(0);
+        let delta = target_qty - current_qty;
+        if delta == 0 {
             continue;
         }
 
-        let side = if delta > 0.0 { Side::Buy } else { Side::Sell };
+        let side = if delta > 0 { Side::Buy } else { Side::Sell };
 
         orders.push(OrderIntent {
             symbol: symbol.clone(),
             side,
-            qty,
+            qty: delta.unsigned_abs() as u32,
             reason: OrderReason::Aggregated,
         });
     }
@@ -261,18 +265,14 @@ mod tests {
 
     #[test]
     fn test_diff_to_orders() {
-        let mut current: HashMap<String, f64> = HashMap::new();
-        current.insert("AMD".to_string(), 5000.0);
+        let mut current: HashMap<String, i64> = HashMap::new();
+        current.insert("AMD".to_string(), 50);
 
-        let mut target: HashMap<String, f64> = HashMap::new();
-        target.insert("AMD".to_string(), 3000.0);
-        target.insert("NVDA".to_string(), 2000.0);
+        let mut target: HashMap<String, i64> = HashMap::new();
+        target.insert("AMD".to_string(), 30);
+        target.insert("NVDA".to_string(), 10);
 
-        let mut prices: HashMap<String, f64> = HashMap::new();
-        prices.insert("AMD".to_string(), 100.0);
-        prices.insert("NVDA".to_string(), 200.0);
-
-        let orders = diff_to_orders(&current, &target, &prices);
+        let orders = diff_to_orders(&current, &target);
 
         assert_eq!(orders.len(), 2);
         // AMD: 3000 - 5000 = -2000, sell 20 shares
@@ -283,5 +283,20 @@ mod tests {
         let nvda_order = orders.iter().find(|o| o.symbol == "NVDA").unwrap();
         assert_eq!(nvda_order.side, Side::Buy);
         assert_eq!(nvda_order.qty, 10);
+    }
+
+    #[test]
+    fn test_target_shares_from_notionals() {
+        let mut target: HashMap<String, f64> = HashMap::new();
+        target.insert("AMD".to_string(), 3000.0);
+        target.insert("NVDA".to_string(), -2000.0);
+
+        let mut prices: HashMap<String, f64> = HashMap::new();
+        prices.insert("AMD".to_string(), 100.0);
+        prices.insert("NVDA".to_string(), 200.0);
+
+        let shares = target_shares_from_notionals(&target, &prices);
+        assert_eq!(shares.get("AMD"), Some(&30));
+        assert_eq!(shares.get("NVDA"), Some(&-10));
     }
 }

--- a/engine/crates/basket-engine/src/portfolio.rs
+++ b/engine/crates/basket-engine/src/portfolio.rs
@@ -84,7 +84,19 @@ pub fn basket_to_legs(params: &BasketParams, position: i8, notional: f64) -> Vec
 pub fn aggregate_positions(
     engine: &BasketEngine,
     config: &PortfolioConfig,
-) -> HashMap<String, f64> {
+) -> Result<HashMap<String, f64>, String> {
+    let active_count = engine
+        .iter_params()
+        .filter_map(|(basket_id, _)| engine.get_state(basket_id))
+        .filter(|s| s.position != 0)
+        .count();
+    if active_count > config.n_active_baskets {
+        return Err(format!(
+            "active basket cap exceeded: active={}, configured_cap={}",
+            active_count, config.n_active_baskets
+        ));
+    }
+
     let notional_per_basket = config.notional_per_basket();
     let mut symbol_notionals: HashMap<String, f64> = HashMap::new();
 
@@ -104,7 +116,7 @@ pub fn aggregate_positions(
         }
     }
 
-    symbol_notionals
+    Ok(symbol_notionals)
 }
 
 /// Order side.
@@ -209,6 +221,9 @@ pub fn diff_to_orders(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::DailyBar;
+    use basket_picker::{BasketCandidate, BasketFit, BertramResult};
+    use chrono::NaiveDate;
 
     fn make_test_params() -> BasketParams {
         BasketParams {
@@ -225,6 +240,37 @@ mod tests {
                 half_life_days: 13.51,
             },
             threshold_k: 1.25,
+        }
+    }
+
+    fn make_test_fit(target: &str, peers: &[&str]) -> BasketFit {
+        BasketFit {
+            candidate: BasketCandidate {
+                target: target.to_string(),
+                members: peers.iter().map(|s| s.to_string()).collect(),
+                sector: "test".to_string(),
+                fit_date: NaiveDate::from_ymd_opt(2026, 4, 20).unwrap(),
+            },
+            ou: Some(basket_picker::OuFit {
+                a: 0.0,
+                b: 0.95,
+                kappa: 12.92,
+                mu: 0.0,
+                sigma: 0.01,
+                sigma_eq: 0.032,
+                half_life_days: 13.51,
+            }),
+            bertram: Some(BertramResult {
+                a: -0.04,
+                m: 0.04,
+                k: 1.25,
+                expected_return_rate: 0.1,
+                expected_trade_length_days: 10.0,
+                sigma_cont: 0.05,
+            }),
+            threshold_k: 1.25,
+            valid: true,
+            reject_reason: None,
         }
     }
 
@@ -320,5 +366,29 @@ mod tests {
         let prices: HashMap<String, f64> = HashMap::new();
         let err = target_shares_from_notionals(&target, &prices).unwrap_err();
         assert!(err.contains("AMD"));
+    }
+
+    #[test]
+    fn test_aggregate_positions_rejects_cap_breach() {
+        let fit_a = make_test_fit("AAA", &["BBB", "CCC"]);
+        let fit_b = make_test_fit("DDD", &["EEE", "FFF"]);
+        let mut engine = BasketEngine::new(&[fit_a.clone(), fit_b.clone()]);
+
+        let bars = vec![
+            DailyBar { symbol: "AAA".to_string(), date: NaiveDate::from_ymd_opt(2026, 4, 21).unwrap(), close: 90.0 },
+            DailyBar { symbol: "BBB".to_string(), date: NaiveDate::from_ymd_opt(2026, 4, 21).unwrap(), close: 100.0 },
+            DailyBar { symbol: "CCC".to_string(), date: NaiveDate::from_ymd_opt(2026, 4, 21).unwrap(), close: 100.0 },
+            DailyBar { symbol: "DDD".to_string(), date: NaiveDate::from_ymd_opt(2026, 4, 21).unwrap(), close: 90.0 },
+            DailyBar { symbol: "EEE".to_string(), date: NaiveDate::from_ymd_opt(2026, 4, 21).unwrap(), close: 100.0 },
+            DailyBar { symbol: "FFF".to_string(), date: NaiveDate::from_ymd_opt(2026, 4, 21).unwrap(), close: 100.0 },
+        ];
+        engine.on_bars(&bars);
+
+        let config = PortfolioConfig {
+            capital: 100_000.0,
+            leverage: 4.0,
+            n_active_baskets: 1,
+        };
+        assert!(aggregate_positions(&engine, &config).is_err());
     }
 }

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -296,7 +296,7 @@ pub async fn run_basket_live(
                             date = %today,
                             symbols_expected,
                             buffered_days = day_closes.len(),
-                            current_notionals = current_notionals.len(),
+                            current_shares = current_shares.len(),
                             "session close grace elapsed on weekday with zero buffered closes"
                         );
                         return Err(format!(
@@ -344,7 +344,7 @@ pub async fn run_basket_live(
                         &mut current_shares,
                         execution,
                     )
-                    .await;
+                    .await?;
                     if let Err(e) = engine.save_state(state_path) {
                         error!(
                             error = %e,
@@ -410,10 +410,10 @@ async fn process_session_close(
     portfolio_config: &PortfolioConfig,
     current_shares: &mut HashMap<String, i64>,
     execution: BasketExecution,
-) {
+) -> Result<(), String> {
     if closes.is_empty() {
         warn!(date = %date, "no RTH closes buffered for session — skipping engine");
-        return;
+        return Ok(());
     }
 
     // Build DailyBar slice for BasketEngine.
@@ -440,7 +440,14 @@ async fn process_session_close(
 
     // Portfolio layer: target notionals across symbols, then diff to orders.
     let target_notionals = aggregate_positions(engine, portfolio_config);
-    let target_shares = target_shares_from_notionals(&target_notionals, closes);
+    let target_shares = target_shares_from_notionals(&target_notionals, closes).map_err(|e| {
+        error!(
+            date = %date,
+            error = %e,
+            "unable to price target notionals into share targets"
+        );
+        e
+    })?;
 
     // Summary of the notional plan before we diff — this is where yesterday's
     // $340K-on-$100K problem was invisible. Emit gross long, gross short,
@@ -470,7 +477,7 @@ async fn process_session_close(
     let orders = diff_to_orders(current_shares, &target_shares);
     if orders.is_empty() {
         info!(date = %date, "no orders to emit — targets already match current");
-        return;
+        return Ok(());
     }
 
     // Distribution of order notionals — flags the "one leg $30K, rest $200"
@@ -574,6 +581,7 @@ async fn process_session_close(
             "some orders failed; current_shares preserves prior values for failed legs"
         );
     }
+    Ok(())
 }
 
 /// Summarize a `target_notionals` map into (gross_long, gross_short, max_abs,

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -25,7 +25,8 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use basket_engine::{
-    aggregate_positions, diff_to_orders, BasketEngine, DailyBar, OrderIntent, PortfolioConfig, PositionIntent, Side,
+    aggregate_positions, diff_to_orders, target_shares_from_notionals, BasketEngine, DailyBar,
+    OrderIntent, PortfolioConfig, PositionIntent, Side,
 };
 use basket_picker::{load_universe, BasketFit};
 use chrono::{DateTime, Datelike, NaiveDate, Utc, Weekday};
@@ -145,7 +146,7 @@ pub async fn run_basket_live(
         fresh
     };
 
-    // 2. Seed current_notionals from Alpaca positions (startup reconciliation).
+    // 2. Seed current_shares from Alpaca positions (startup reconciliation).
     //    Without this, a restart with live open positions would trigger
     //    target-minus-zero deltas, flooding Alpaca with duplicate orders.
     //    Noop skips this (no Alpaca account needed for shadow mode).
@@ -153,17 +154,17 @@ pub async fn run_basket_live(
     //    we refuse to start. Trading from an empty notional map would diff
     //    targets against zero and flood Alpaca with duplicate orders against
     //    already-open broker positions, potentially double-sizing every leg.
-    let mut current_notionals = match execution.alpaca_mode() {
+    let mut current_shares = match execution.alpaca_mode() {
         None => {
             info!("noop mode — skipping startup position reconciliation");
             HashMap::new()
         }
-        Some(mode) => seed_current_notionals_from_alpaca(alpaca, mode).await?,
+        Some(mode) => seed_current_shares_from_alpaca(alpaca, mode).await?,
     };
-    if execution.alpaca_mode().is_some() && !state_exists && !current_notionals.is_empty() {
+    if execution.alpaca_mode().is_some() && !state_exists && !current_shares.is_empty() {
         error!(
             state_path = %state_path.display(),
-            broker_positions = current_notionals.len(),
+            broker_positions = current_shares.len(),
             "broker has open positions but no basket state snapshot was found"
         );
         return Err(format!(
@@ -267,7 +268,7 @@ pub async fn run_basket_live(
                     in_rth,
                     past_close,
                     processed_today = processed_sessions.contains(&today),
-                    current_notionals = current_notionals.len(),
+                    current_shares = current_shares.len(),
                     last_bar_age_s,
                     "BAR_LOOP heartbeat"
                 );
@@ -340,7 +341,7 @@ pub async fn run_basket_live(
                         today,
                         &closes_for_day,
                         &portfolio_config,
-                        &mut current_notionals,
+                        &mut current_shares,
                         execution,
                     )
                     .await;
@@ -378,25 +379,25 @@ pub async fn run_basket_live(
 /// Returns `Err` on any fetch failure; the caller must treat this as fatal for
 /// paper/live execution (trading from an empty notional map would double-size
 /// every already-open leg on the first session).
-async fn seed_current_notionals_from_alpaca(
+async fn seed_current_shares_from_alpaca(
     alpaca: &AlpacaClient,
     mode: ExecutionMode,
-) -> Result<HashMap<String, f64>, String> {
+) -> Result<HashMap<String, i64>, String> {
     let positions = alpaca.get_positions(mode).await.map_err(|e| {
         format!(
             "startup position reconciliation failed — refusing to trade without a \
              trusted notional map (fetch error: {e})"
         )
     })?;
-    let notionals: HashMap<String, f64> = positions
+    let shares: HashMap<String, i64> = positions
         .into_iter()
-        .map(|(sym, (qty, avg_entry))| (sym, qty * avg_entry))
+        .map(|(sym, (qty, _avg_entry))| (sym, qty.round() as i64))
         .collect();
     info!(
-        n_positions = notionals.len(),
-        "seeded current_notionals from Alpaca open positions"
+        n_positions = shares.len(),
+        "seeded current_shares from Alpaca open positions"
     );
-    Ok(notionals)
+    Ok(shares)
 }
 
 /// Run the engine for one session close and dispatch orders.
@@ -407,7 +408,7 @@ async fn process_session_close(
     date: NaiveDate,
     closes: &HashMap<String, f64>,
     portfolio_config: &PortfolioConfig,
-    current_notionals: &mut HashMap<String, f64>,
+    current_shares: &mut HashMap<String, i64>,
     execution: BasketExecution,
 ) {
     if closes.is_empty() {
@@ -439,6 +440,7 @@ async fn process_session_close(
 
     // Portfolio layer: target notionals across symbols, then diff to orders.
     let target_notionals = aggregate_positions(engine, portfolio_config);
+    let target_shares = target_shares_from_notionals(&target_notionals, closes);
 
     // Summary of the notional plan before we diff — this is where yesterday's
     // $340K-on-$100K problem was invisible. Emit gross long, gross short,
@@ -455,7 +457,7 @@ async fn process_session_close(
     info!(
         date = %date,
         targets = target_notionals.len(),
-        currents = current_notionals.len(),
+        current_positions = current_shares.len(),
         gross_long = %format!("{:.0}", gross_long),
         gross_short = %format!("{:.0}", gross_short),
         gross_notional = %format!("{:.0}", gross_long + gross_short.abs()),
@@ -465,7 +467,7 @@ async fn process_session_close(
         "target notionals summary"
     );
 
-    let orders = diff_to_orders(current_notionals, &target_notionals, closes);
+    let orders = diff_to_orders(current_shares, &target_shares);
     if orders.is_empty() {
         info!(date = %date, "no orders to emit — targets already match current");
         return;
@@ -493,11 +495,7 @@ async fn process_session_close(
     );
 
     // Track which symbols were successfully adjusted so we only update
-    // `current_notionals` for legs that actually executed. This matters
-    // when `diff_to_orders` skipped symbols (missing prices) or when
-    // Alpaca rejected orders — blindly syncing to target would desync
-    // internal state from the broker's view and prevent future corrective
-    // orders.
+    // `current_shares` for legs that actually executed.
     let mut successfully_adjusted: std::collections::HashSet<String> = Default::default();
 
     match execution.alpaca_mode() {
@@ -543,36 +541,16 @@ async fn process_session_close(
         }
     }
 
-    // Reconcile current_notionals against what actually executed.
-    //
-    // We MUST iterate the union of `current_notionals ∪ target_notionals`
-    // — not just targets — so symbols dropped from the target set (e.g.,
-    // a basket that fully exited) are cleared after a successful close.
-    // Iterating only targets leaves the old notional in place, and
-    // `diff_to_orders` then emits another close order for it next session
-    // (current=X, target=0 → close X), producing repeat liquidation attempts.
-    //
-    // `diff_to_orders` emits an order exactly when BOTH |delta| >= 1.0 AND
-    // price is finite+positive. So "in orders" ≡ "was adjustable this session".
-    //
-    // Per symbol, we update as follows:
-    //   - in successfully_adjusted
-    //       target present → set current to target
-    //       target absent  → remove (position closed)
-    //   - in orders but not adjusted      → order failed; keep prior notional
-    //   - not in orders + price valid
-    //       target present → set current to target (delta was negligible)
-    //       target absent  → remove (position effectively zero)
-    //   - not in orders + price missing   → keep prior notional (can't tell)
+    // Reconcile current_shares against what actually executed.
     let orders_by_symbol: std::collections::HashSet<&str> =
         orders.iter().map(|o| o.symbol.as_str()).collect();
     let mut all_symbols: std::collections::HashSet<String> =
-        current_notionals.keys().cloned().collect();
-    all_symbols.extend(target_notionals.keys().cloned());
+        current_shares.keys().cloned().collect();
+    all_symbols.extend(target_shares.keys().cloned());
     let mut drift_count = 0usize;
     for sym in all_symbols {
-        let target_opt = target_notionals.get(&sym).copied();
-        let apply_target = |current: &mut HashMap<String, f64>| match target_opt {
+        let target_opt = target_shares.get(&sym).copied();
+        let apply_target = |current: &mut HashMap<String, i64>| match target_opt {
             Some(t) => {
                 current.insert(sym.clone(), t);
             }
@@ -581,28 +559,19 @@ async fn process_session_close(
             }
         };
         if successfully_adjusted.contains(&sym) {
-            apply_target(current_notionals);
+            apply_target(current_shares);
         } else if orders_by_symbol.contains(sym.as_str()) {
-            // Order was emitted but did not succeed → preserve prior notional.
+            // Order was emitted but did not succeed → preserve prior shares.
             drift_count += 1;
         } else {
-            // No order emitted this session: either delta was below threshold
-            // (price valid) or price was missing.
-            let has_price = closes
-                .get(&sym)
-                .map(|p| p.is_finite() && *p > 0.0)
-                .unwrap_or(false);
-            if has_price {
-                apply_target(current_notionals);
-            }
-            // else: price missing — keep prior notional.
+            apply_target(current_shares);
         }
     }
     if drift_count > 0 {
         warn!(
             drift_count,
             total_orders = orders.len(),
-            "some orders failed; current_notionals preserves prior values for failed legs"
+            "some orders failed; current_shares preserves prior values for failed legs"
         );
     }
 }

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -439,7 +439,17 @@ async fn process_session_close(
     }
 
     // Portfolio layer: target notionals across symbols, then diff to orders.
-    let target_notionals = aggregate_positions(engine, portfolio_config);
+    let target_notionals = match aggregate_positions(engine, portfolio_config) {
+        Ok(n) => n,
+        Err(e) => {
+            error!(
+                error = %e,
+                configured_cap = portfolio_config.n_active_baskets,
+                "basket portfolio construction rejected by active-basket cap"
+            );
+            return Err(e);
+        }
+    };
     let target_shares = target_shares_from_notionals(&target_notionals, closes).map_err(|e| {
         error!(
             date = %date,


### PR DESCRIPTION
## Summary
- convert the basket live path from pseudo-notional reconciliation to real share inventory
- seed startup holdings from broker share quantities instead of `qty * avg_entry_price`
- derive target shares from target notionals using the current close snapshot, then diff share-to-share
- update the basket portfolio helpers and tests accordingly

## Why
The live runner was previously comparing target notionals against a map that started as cost-basis notionals from Alpaca and later got overwritten with model target notionals. That mixes incompatible meanings in the same state variable and makes restart / rebalance behavior unreliable. This PR makes the reconciliation layer operate in shares end to end.

## Validation
- `cargo test -p basket-engine -p openquant-runner -- --nocapture`
