### PR TITLE
Handle basket holidays in close gating

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1685,6 +1685,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nyse-holiday-cal"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "382dbb796eed7dbed8603bb577c3e5ce74caaff6dc74b528bc5e733c1d123ee6"
+dependencies = [
+ "chrono",
+ "lazy_static",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,6 +1774,7 @@ dependencies = [
  "chrono-tz",
  "clap",
  "futures-util",
+ "nyse-holiday-cal",
  "openquant-core",
  "pair-picker",
  "parquet",

--- a/engine/crates/runner/Cargo.toml
+++ b/engine/crates/runner/Cargo.toml
@@ -21,6 +21,7 @@ tracing-appender = "0.2"
 clap = { version = "4", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"
+nyse-holiday-cal = "0.2.5"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", features = ["json"] }
 tokio-tungstenite = { version = "0.24", features = ["native-tls"] }

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -29,7 +29,7 @@ use basket_engine::{
     PositionIntent, Side,
 };
 use basket_picker::{load_universe, validate, ValidatorConfig};
-use chrono::{DateTime, Datelike, NaiveDate, Utc, Weekday};
+use chrono::{DateTime, NaiveDate, Utc};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use tracing::{debug, error, info, warn};
 
@@ -272,10 +272,10 @@ pub async fn run_basket_live(
                 if past_close && !processed_sessions.contains(&today) {
                     let closes_for_day = day_closes.remove(&today).unwrap_or_default();
                     if closes_for_day.is_empty() {
-                        if matches!(today.weekday(), Weekday::Sat | Weekday::Sun) {
+                        if !market_session::is_trading_day(today) {
                             info!(
                                 date = %today,
-                                "session close grace elapsed on weekend — marking processed"
+                                "session close grace elapsed on non-trading day with zero buffered closes — marking processed"
                             );
                             processed_sessions.insert(today);
                             continue;
@@ -285,10 +285,10 @@ pub async fn run_basket_live(
                             symbols_expected,
                             buffered_days = day_closes.len(),
                             current_notionals = current_notionals.len(),
-                            "session close grace elapsed on weekday with zero buffered closes"
+                            "session close grace elapsed on trading day with zero buffered closes"
                         );
                         return Err(format!(
-                            "session close grace elapsed on weekday {today} but no RTH closes were buffered"
+                            "session close grace elapsed on trading day {today} but no RTH closes were buffered"
                         ));
                     }
                     // Log exactly which symbols' closes we have and, crucially,

--- a/engine/crates/runner/src/market_session.rs
+++ b/engine/crates/runner/src/market_session.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, NaiveDate, NaiveTime, TimeZone, Timelike, Utc};
 use chrono_tz::America::New_York;
+use nyse_holiday_cal::HolidayCal;
 
 const RTH_OPEN: NaiveTime = NaiveTime::from_hms_opt(9, 30, 0).expect("valid open");
 const RTH_CLOSE: NaiveTime = NaiveTime::from_hms_opt(16, 0, 0).expect("valid close");
@@ -23,6 +24,19 @@ pub fn is_rth_utc(dt_utc: DateTime<Utc>) -> bool {
 pub fn is_after_close_grace_utc(dt_utc: DateTime<Utc>, grace_min: u32) -> bool {
     let local = dt_utc.with_timezone(&New_York);
     session_minute(local) >= (RTH_CLOSE.hour() * 60 + RTH_CLOSE.minute() + grace_min)
+}
+
+pub fn is_trading_day(day: NaiveDate) -> bool {
+    match day.is_busday() {
+        Ok(open) => open,
+        Err(_) => {
+            tracing::warn!(
+                date = %day,
+                "NYSE holiday calendar out of range; falling back to weekday trading-day check"
+            );
+            !day.is_weekend()
+        }
+    }
 }
 
 pub fn close_timestamp_utc_for_day(day: NaiveDate) -> i64 {
@@ -65,5 +79,16 @@ mod tests {
                 .time(),
             NaiveTime::from_hms_opt(21, 0, 0).unwrap()
         );
+    }
+
+    #[test]
+    fn test_is_trading_day_handles_holiday_and_weekend() {
+        let holiday = NaiveDate::from_ymd_opt(2026, 12, 25).unwrap();
+        let weekday = NaiveDate::from_ymd_opt(2026, 12, 24).unwrap();
+        let weekend = NaiveDate::from_ymd_opt(2026, 12, 26).unwrap();
+
+        assert!(!is_trading_day(holiday));
+        assert!(is_trading_day(weekday));
+        assert!(!is_trading_day(weekend));
     }
 }


### PR DESCRIPTION
## Summary
- add an NYSE trading-day helper to the shared market-session module
- treat holiday/no-session dates as non-trading days instead of fatal zero-close incidents
- keep the fail-closed path for real trading days with missing close data

## Testing
- cargo test -p openquant-runner -- --nocapture
- cargo test -p openquant-runner market_session::tests::test_is_trading_day_handles_holiday_and_weekend -- --nocapture