### PR TITLE
[codex] Clean up basket live startup sequence

### DIFF
--- a/engine/crates/basket-engine/src/engine.rs
+++ b/engine/crates/basket-engine/src/engine.rs
@@ -5,6 +5,7 @@ use std::fs;
 use std::path::Path;
 
 use basket_picker::{BasketFit, OuFit};
+use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, trace, warn};
 
@@ -54,6 +55,10 @@ pub struct EngineSnapshot {
     pub params: Vec<BasketParams>,
     /// Per-basket runtime state.
     pub states: HashMap<String, BasketState>,
+    /// Last trading day that the runner fully processed. Optional so older
+    /// snapshots remain readable.
+    #[serde(default)]
+    pub last_processed_trading_day: Option<NaiveDate>,
 }
 
 /// The basket engine: manages state machines for all active baskets.
@@ -326,9 +331,19 @@ impl BasketEngine {
 
     /// Save engine state to a JSON file.
     pub fn save_state(&self, path: &Path) -> Result<(), String> {
+        self.save_state_with_day(path, None)
+    }
+
+    /// Save engine state plus the last fully processed trading day.
+    pub fn save_state_with_day(
+        &self,
+        path: &Path,
+        last_processed_trading_day: Option<NaiveDate>,
+    ) -> Result<(), String> {
         let snapshot = EngineSnapshot {
             params: self.params.values().cloned().collect(),
             states: self.states.clone(),
+            last_processed_trading_day,
         };
         let json = serde_json::to_string_pretty(&snapshot)
             .map_err(|e| format!("failed to serialize: {}", e))?;
@@ -367,6 +382,7 @@ impl BasketEngine {
         let snapshot = EngineSnapshot {
             params: self.params.values().cloned().collect(),
             states,
+            last_processed_trading_day: None,
         };
         Self::validate_snapshot(&snapshot)?;
         self.states = snapshot.states;

--- a/engine/crates/basket-engine/src/engine.rs
+++ b/engine/crates/basket-engine/src/engine.rs
@@ -336,11 +336,20 @@ impl BasketEngine {
         Ok(())
     }
 
-    /// Load engine state from a JSON file.
-    pub fn load_state(path: &Path) -> Result<Self, String> {
+    /// Load a raw engine snapshot without trusting persisted params as the
+    /// live source of truth. Callers that have a fresh fit artifact should
+    /// restore only runtime states onto current params.
+    pub fn load_snapshot(path: &Path) -> Result<EngineSnapshot, String> {
         let content = fs::read_to_string(path).map_err(|e| format!("failed to read: {}", e))?;
         let snapshot: EngineSnapshot =
             serde_json::from_str(&content).map_err(|e| format!("failed to parse: {}", e))?;
+        Self::validate_snapshot(&snapshot)?;
+        Ok(snapshot)
+    }
+
+    /// Load engine state from a JSON file.
+    pub fn load_state(path: &Path) -> Result<Self, String> {
+        let snapshot = Self::load_snapshot(path)?;
 
         let mut params = HashMap::new();
         for p in snapshot.params {
@@ -351,6 +360,17 @@ impl BasketEngine {
             params,
             states: snapshot.states,
         })
+    }
+
+    /// Replace runtime states while preserving the engine's current params.
+    pub fn apply_states(&mut self, states: HashMap<String, BasketState>) -> Result<(), String> {
+        let snapshot = EngineSnapshot {
+            params: self.params.values().cloned().collect(),
+            states,
+        };
+        Self::validate_snapshot(&snapshot)?;
+        self.states = snapshot.states;
+        Ok(())
     }
 
     /// Get the current state for a basket (for testing/diagnostics).
@@ -366,6 +386,26 @@ impl BasketEngine {
     /// Iterate over all basket params.
     pub fn iter_params(&self) -> impl Iterator<Item = (&String, &BasketParams)> {
         self.params.iter()
+    }
+
+    fn validate_snapshot(snapshot: &EngineSnapshot) -> Result<(), String> {
+        let mut params = HashMap::new();
+        for p in &snapshot.params {
+            params.insert(p.basket_id.clone(), p);
+        }
+        for basket_id in params.keys() {
+            if !snapshot.states.contains_key(basket_id) {
+                return Err(format!("missing runtime state for basket_id '{basket_id}'"));
+            }
+        }
+        for basket_id in snapshot.states.keys() {
+            if !params.contains_key(basket_id) {
+                return Err(format!(
+                    "runtime state present for unknown basket_id '{basket_id}'"
+                ));
+            }
+        }
+        Ok(())
     }
 }
 

--- a/engine/crates/runner/src/alpaca.rs
+++ b/engine/crates/runner/src/alpaca.rs
@@ -78,6 +78,17 @@ pub struct AlpacaOrder {
     pub qty: String,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct AlpacaAccount {
+    pub status: String,
+    pub buying_power: String,
+    pub equity: String,
+    #[serde(default)]
+    pub trading_blocked: bool,
+    #[serde(default)]
+    pub account_blocked: bool,
+}
+
 impl AlpacaClient {
     pub fn new(api_key: String, api_secret: String) -> Self {
         Self {
@@ -474,6 +485,38 @@ impl AlpacaClient {
 
         info!(positions = map.len(), "fetched Alpaca positions");
         Ok(map)
+    }
+
+    pub async fn get_account(&self, execution: ExecutionMode) -> Result<AlpacaAccount, String> {
+        let url = format!("{}/account", execution.trading_url());
+        let response = self
+            .http
+            .get(&url)
+            .header("APCA-API-KEY-ID", &self.api_key)
+            .header("APCA-API-SECRET-KEY", &self.api_secret)
+            .send()
+            .await
+            .map_err(|e| format!("account request failed: {e}"))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(format!("account API error {status}: {body}"));
+        }
+
+        let account: AlpacaAccount = response
+            .json()
+            .await
+            .map_err(|e| format!("account parse failed: {e}"))?;
+        info!(
+            status = account.status.as_str(),
+            buying_power = account.buying_power.as_str(),
+            equity = account.equity.as_str(),
+            trading_blocked = account.trading_blocked,
+            account_blocked = account.account_blocked,
+            "fetched Alpaca account"
+        );
+        Ok(account)
     }
 }
 

--- a/engine/crates/runner/src/basket_fits.rs
+++ b/engine/crates/runner/src/basket_fits.rs
@@ -30,6 +30,22 @@ pub fn default_fit_artifact_path(universe_path: &Path) -> PathBuf {
     universe_path.with_file_name(format!("{stem}.fits.json"))
 }
 
+pub fn default_live_state_path(fit_artifact_path: &Path) -> PathBuf {
+    let stem = fit_artifact_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("basket_fits");
+    fit_artifact_path.with_file_name(format!("{stem}.state.json"))
+}
+
+pub fn default_runner_state_path(state_path: &Path) -> PathBuf {
+    let stem = state_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("basket_state");
+    state_path.with_file_name(format!("{stem}.runner.json"))
+}
+
 pub fn build_live_fit_artifact(
     universe_path: &Path,
     bars_dir: &Path,
@@ -199,6 +215,24 @@ traded_targets = ["AAA"]
         assert_eq!(
             default_fit_artifact_path(path),
             PathBuf::from("config/basket_universe_v1.fits.json")
+        );
+    }
+
+    #[test]
+    fn test_default_live_state_path() {
+        let path = Path::new("config/basket_universe_v1.fits.json");
+        assert_eq!(
+            default_live_state_path(path),
+            PathBuf::from("config/basket_universe_v1.fits.state.json")
+        );
+    }
+
+    #[test]
+    fn test_default_runner_state_path() {
+        let path = Path::new("config/basket_universe_v1.fits.state.json");
+        assert_eq!(
+            default_runner_state_path(path),
+            PathBuf::from("config/basket_universe_v1.fits.state.runner.json")
         );
     }
 

--- a/engine/crates/runner/src/basket_fits.rs
+++ b/engine/crates/runner/src/basket_fits.rs
@@ -38,14 +38,6 @@ pub fn default_live_state_path(fit_artifact_path: &Path) -> PathBuf {
     fit_artifact_path.with_file_name(format!("{stem}.state.json"))
 }
 
-pub fn default_runner_state_path(state_path: &Path) -> PathBuf {
-    let stem = state_path
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("basket_state");
-    state_path.with_file_name(format!("{stem}.runner.json"))
-}
-
 pub fn build_live_fit_artifact(
     universe_path: &Path,
     bars_dir: &Path,
@@ -224,15 +216,6 @@ traded_targets = ["AAA"]
         assert_eq!(
             default_live_state_path(path),
             PathBuf::from("config/basket_universe_v1.fits.state.json")
-        );
-    }
-
-    #[test]
-    fn test_default_runner_state_path() {
-        let path = Path::new("config/basket_universe_v1.fits.state.json");
-        assert_eq!(
-            default_runner_state_path(path),
-            PathBuf::from("config/basket_universe_v1.fits.state.runner.json")
         );
     }
 

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -22,6 +22,7 @@
 //!   - `Live`: api.alpaca.markets (real money). Gated behind explicit opt-in.
 
 use std::collections::HashMap;
+use std::fs;
 use std::path::Path;
 
 use basket_engine::{
@@ -31,9 +32,11 @@ use basket_engine::{
 use basket_picker::{load_universe, BasketFit};
 use chrono::{DateTime, NaiveDate, Utc};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info, warn};
 
 use crate::alpaca::{AlpacaClient, ExecutionMode};
+use crate::basket_fits;
 use crate::market_session;
 use crate::stream;
 
@@ -69,6 +72,27 @@ impl BasketExecution {
     }
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct BasketRunnerState {
+    last_processed_trading_day: Option<NaiveDate>,
+}
+
+fn load_runner_state(path: &Path) -> Result<BasketRunnerState, String> {
+    if !path.exists() {
+        return Ok(BasketRunnerState::default());
+    }
+    let content = fs::read_to_string(path)
+        .map_err(|e| format!("read runner state {}: {e}", path.display()))?;
+    serde_json::from_str(&content)
+        .map_err(|e| format!("parse runner state {}: {e}", path.display()))
+}
+
+fn save_runner_state(path: &Path, state: &BasketRunnerState) -> Result<(), String> {
+    let content =
+        serde_json::to_string_pretty(state).map_err(|e| format!("serialize runner state: {e}"))?;
+    fs::write(path, content).map_err(|e| format!("write runner state {}: {e}", path.display()))
+}
+
 /// Run the basket live/paper loop.
 ///
 /// Returns on Ctrl+C or fatal error.
@@ -76,13 +100,21 @@ pub async fn run_basket_live(
     alpaca: &AlpacaClient,
     universe_path: &Path,
     fit_artifact_path: &Path,
+    state_path: &Path,
+    bars_dir: &Path,
     execution: BasketExecution,
     portfolio_config: PortfolioConfig,
     fits: &[BasketFit],
 ) -> Result<(), String> {
+    // Grace period after session close before firing the engine. Lets late-arriving
+    // 19:59 bars land in the buffer.
+    const CLOSE_GRACE_MIN: u32 = 2;
+
     info!(
         universe = %universe_path.display(),
         fit_artifact = %fit_artifact_path.display(),
+        state_path = %state_path.display(),
+        bars_dir = %bars_dir.display(),
         execution = execution.label(),
         "========== BASKET LIVE RUNNER =========="
     );
@@ -116,8 +148,44 @@ pub async fn run_basket_live(
         return Err("no valid baskets in fit artifact".to_string());
     }
 
-    let mut engine = BasketEngine::new(fits);
-    info!(baskets = engine.num_baskets(), "basket engine initialized");
+    let expected_ids: std::collections::HashSet<String> = fits
+        .iter()
+        .filter(|f| f.valid)
+        .map(|f| f.candidate.id())
+        .collect();
+    let state_exists = state_path.exists();
+    let mut engine = if state_exists {
+        let snapshot = BasketEngine::load_snapshot(state_path)?;
+        let loaded_ids: std::collections::HashSet<String> =
+            snapshot.states.keys().cloned().collect();
+        if loaded_ids != expected_ids {
+            return Err(format!(
+                "state snapshot basket set mismatch: snapshot={}, artifact={}",
+                loaded_ids.len(),
+                expected_ids.len()
+            ));
+        }
+        let mut fresh = BasketEngine::new(fits);
+        fresh.apply_states(snapshot.states)?;
+        info!(
+            baskets = fresh.num_baskets(),
+            state_path = %state_path.display(),
+            "loaded basket runtime state onto current fit artifact params"
+        );
+        fresh
+    } else {
+        let fresh = BasketEngine::new(fits);
+        info!(baskets = fresh.num_baskets(), "basket engine initialized");
+        fresh
+    };
+
+    let runner_state_path = basket_fits::default_runner_state_path(state_path);
+    let mut runner_state = load_runner_state(&runner_state_path)?;
+    info!(
+        runner_state_path = %runner_state_path.display(),
+        last_processed = ?runner_state.last_processed_trading_day,
+        "loaded basket runner state"
+    );
 
     // 2. Seed current_notionals from Alpaca positions (startup reconciliation).
     //    Without this, a restart with live open positions would trigger
@@ -127,13 +195,34 @@ pub async fn run_basket_live(
     //    we refuse to start. Trading from an empty notional map would diff
     //    targets against zero and flood Alpaca with duplicate orders against
     //    already-open broker positions, potentially double-sizing every leg.
+    let now = Utc::now();
+    let today = market_session::trading_day_utc(now);
+    let reference_day = market_session::latest_completed_trading_day_utc(now, CLOSE_GRACE_MIN);
+    let reference_closes = load_close_snapshot_for_day(bars_dir, &symbols, reference_day)?;
+    info!(
+        reference_day = %reference_day,
+        symbols = reference_closes.len(),
+        "loaded completed close snapshot for startup reconciliation"
+    );
+
     let mut current_notionals = match execution.alpaca_mode() {
         None => {
             info!("noop mode — skipping startup position reconciliation");
             HashMap::new()
         }
-        Some(mode) => seed_current_notionals_from_alpaca(alpaca, mode).await?,
+        Some(mode) => seed_current_notionals_from_alpaca(alpaca, mode, &reference_closes).await?,
     };
+    if execution.alpaca_mode().is_some() && !state_exists && !current_notionals.is_empty() {
+        error!(
+            state_path = %state_path.display(),
+            broker_positions = current_notionals.len(),
+            "broker has open positions but no basket state snapshot was found"
+        );
+        return Err(format!(
+            "open broker positions found but no basket state snapshot exists at {}",
+            state_path.display()
+        ));
+    }
 
     // 3. Subscribe to all universe symbols over WebSocket.
     let mut bar_rx = stream::start_bar_stream(&alpaca.api_key, &alpaca.api_secret, &symbols).await;
@@ -145,10 +234,41 @@ pub async fn run_basket_live(
     //    silently skip an entire session.
     let mut day_closes: HashMap<NaiveDate, HashMap<String, f64>> = HashMap::new();
     let mut processed_sessions: std::collections::HashSet<NaiveDate> = Default::default();
+    if runner_state.last_processed_trading_day == Some(today) {
+        processed_sessions.insert(today);
+    }
 
-    // Grace period after session close before firing the engine. Lets late-arriving
-    // 19:59 bars land in the buffer.
-    const CLOSE_GRACE_MIN: u32 = 2;
+    if market_session::is_trading_day(today)
+        && market_session::is_after_close_grace_utc(now, CLOSE_GRACE_MIN)
+        && runner_state.last_processed_trading_day != Some(today)
+    {
+        let catchup_closes = load_close_snapshot_for_day(bars_dir, &symbols, today)?;
+        info!(
+            date = %today,
+            symbols = catchup_closes.len(),
+            "startup is after close grace on an unprocessed trading day — running one catch-up close cycle"
+        );
+        process_session_close(
+            &mut engine,
+            alpaca,
+            today,
+            &catchup_closes,
+            &portfolio_config,
+            &mut current_notionals,
+            execution,
+        )
+        .await?;
+        engine.save_state(state_path)?;
+        runner_state.last_processed_trading_day = Some(today);
+        save_runner_state(&runner_state_path, &runner_state)?;
+        processed_sessions.insert(today);
+        info!(
+            date = %today,
+            state_path = %state_path.display(),
+            runner_state_path = %runner_state_path.display(),
+            "catch-up close cycle completed and startup state persisted"
+        );
+    }
 
     let mut tick = tokio::time::interval(std::time::Duration::from_secs(30));
     // Dedicated 60s heartbeat that summarizes buffer state. Separate from the
@@ -306,7 +426,16 @@ pub async fn run_basket_live(
                         &mut current_notionals,
                         execution,
                     )
-                    .await;
+                    .await?;
+                    engine.save_state(state_path)?;
+                    runner_state.last_processed_trading_day = Some(today);
+                    save_runner_state(&runner_state_path, &runner_state)?;
+                    info!(
+                        date = %today,
+                        state_path = %state_path.display(),
+                        runner_state_path = %runner_state_path.display(),
+                        "persisted basket engine and runner state after session close"
+                    );
                 }
             }
             _ = &mut ctrl_c => {
@@ -331,6 +460,7 @@ pub async fn run_basket_live(
 async fn seed_current_notionals_from_alpaca(
     alpaca: &AlpacaClient,
     mode: ExecutionMode,
+    reference_closes: &HashMap<String, f64>,
 ) -> Result<HashMap<String, f64>, String> {
     let positions = alpaca.get_positions(mode).await.map_err(|e| {
         format!(
@@ -340,13 +470,54 @@ async fn seed_current_notionals_from_alpaca(
     })?;
     let notionals: HashMap<String, f64> = positions
         .into_iter()
-        .map(|(sym, (qty, avg_entry))| (sym, qty * avg_entry))
+        .map(|(sym, (qty, avg_entry))| {
+            let mark = reference_closes
+                .get(&sym)
+                .copied()
+                .filter(|p| p.is_finite() && *p > 0.0)
+                .unwrap_or(avg_entry);
+            (sym, qty * mark)
+        })
         .collect();
     info!(
         n_positions = notionals.len(),
-        "seeded current_notionals from Alpaca open positions"
+        reference_symbols = reference_closes.len(),
+        "seeded current_notionals from Alpaca open positions using completed-close marks"
     );
     Ok(notionals)
+}
+
+fn load_close_snapshot_for_day(
+    bars_dir: &Path,
+    symbols: &[String],
+    day: NaiveDate,
+) -> Result<HashMap<String, f64>, String> {
+    let closes = load_warmup_closes(bars_dir, symbols, 10)?;
+    let mut snapshot = HashMap::new();
+    let mut missing = Vec::new();
+    for symbol in symbols {
+        match closes.get(symbol).and_then(|series| {
+            series
+                .iter()
+                .find_map(|(d, c)| if *d == day { Some(*c) } else { None })
+        }) {
+            Some(close) if close.is_finite() && close > 0.0 => {
+                snapshot.insert(symbol.clone(), close);
+            }
+            _ => missing.push(symbol.clone()),
+        }
+    }
+    if missing.is_empty() {
+        Ok(snapshot)
+    } else {
+        missing.sort();
+        Err(format!(
+            "close snapshot incomplete for {}: missing {} symbols (sample: {})",
+            day,
+            missing.len(),
+            missing.into_iter().take(10).collect::<Vec<_>>().join(", ")
+        ))
+    }
 }
 
 /// Run the engine for one session close and dispatch orders.
@@ -359,10 +530,10 @@ async fn process_session_close(
     portfolio_config: &PortfolioConfig,
     current_notionals: &mut HashMap<String, f64>,
     execution: BasketExecution,
-) {
+) -> Result<(), String> {
     if closes.is_empty() {
         warn!(date = %date, "no RTH closes buffered for session — skipping engine");
-        return;
+        return Ok(());
     }
 
     // Build DailyBar slice for BasketEngine.
@@ -418,7 +589,7 @@ async fn process_session_close(
     let orders = diff_to_orders(current_notionals, &target_notionals, closes);
     if orders.is_empty() {
         info!(date = %date, "no orders to emit — targets already match current");
-        return;
+        return Ok(());
     }
 
     // Distribution of order notionals — flags the "one leg $30K, rest $200"
@@ -555,6 +726,7 @@ async fn process_session_close(
             "some orders failed; current_notionals preserves prior values for failed legs"
         );
     }
+    Ok(())
 }
 
 /// Summarize a `target_notionals` map into (gross_long, gross_short, max_abs,

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -93,6 +93,44 @@ fn save_runner_state(path: &Path, state: &BasketRunnerState) -> Result<(), Strin
     fs::write(path, content).map_err(|e| format!("write runner state {}: {e}", path.display()))
 }
 
+async fn preflight_account_check(alpaca: &AlpacaClient, mode: ExecutionMode) -> Result<(), String> {
+    let account = alpaca.get_account(mode).await?;
+    let buying_power = account.buying_power.parse::<f64>().unwrap_or(0.0);
+    if account.status != "ACTIVE" {
+        return Err(format!(
+            "Alpaca account not ACTIVE: status={}",
+            account.status
+        ));
+    }
+    if account.trading_blocked || account.account_blocked {
+        return Err(format!(
+            "Alpaca account blocked: trading_blocked={}, account_blocked={}",
+            account.trading_blocked, account.account_blocked
+        ));
+    }
+    if !buying_power.is_finite() || buying_power <= 0.0 {
+        return Err(format!(
+            "Alpaca buying power is not positive: {}",
+            account.buying_power
+        ));
+    }
+    Ok(())
+}
+
+async fn wait_for_stream_health(
+    bar_rx: &mut tokio::sync::mpsc::Receiver<stream::StreamBar>,
+    timeout_secs: u64,
+) -> Result<Option<stream::StreamBar>, String> {
+    match tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), bar_rx.recv()).await {
+        Ok(Some(bar)) => Ok(Some(bar)),
+        Ok(None) => Err("stream closed before first startup bar arrived".to_string()),
+        Err(_) => Err(format!(
+            "stream health gate timed out after {}s without any live bar",
+            timeout_secs
+        )),
+    }
+}
+
 /// Run the basket live/paper loop.
 ///
 /// Returns on Ctrl+C or fatal error.
@@ -121,6 +159,9 @@ pub async fn run_basket_live(
 
     if execution == BasketExecution::Live {
         warn!("LIVE MODE — real-money orders will be placed on every EOD signal");
+    }
+    if let Some(mode) = execution.alpaca_mode() {
+        preflight_account_check(alpaca, mode).await?;
     }
 
     // 1. Load universe + frozen fit artifact.
@@ -224,11 +265,7 @@ pub async fn run_basket_live(
         ));
     }
 
-    // 3. Subscribe to all universe symbols over WebSocket.
-    let mut bar_rx = stream::start_bar_stream(&alpaca.api_key, &alpaca.api_secret, &symbols).await;
-    info!("subscribed to Alpaca 1-min bar stream");
-
-    // 4. Bar loop: buffer per (symbol, date) → last RTH bar.
+    // 3. Bar loop: buffer per (symbol, date) → last RTH bar.
     //    Engine is triggered by a wall-clock timer (not by `symbols[0]`'s 19:59 bar
     //    arrival) so that no single symbol becoming a data source-of-failure can
     //    silently skip an entire session.
@@ -268,6 +305,34 @@ pub async fn run_basket_live(
             runner_state_path = %runner_state_path.display(),
             "catch-up close cycle completed and startup state persisted"
         );
+    }
+
+    // 4. Subscribe to all universe symbols over WebSocket.
+    let mut bar_rx = stream::start_bar_stream(&alpaca.api_key, &alpaca.api_secret, &symbols).await;
+    info!("subscribed to Alpaca 1-min bar stream");
+
+    if market_session::is_trading_day(today) && market_session::is_rth_utc(now) {
+        if let Some(startup_bar) = wait_for_stream_health(&mut bar_rx, 90).await? {
+            let bar_open_ts_ms = startup_bar.timestamp - 60_000;
+            if let Some(dt) = DateTime::<Utc>::from_timestamp_millis(bar_open_ts_ms) {
+                if market_session::is_rth_utc(dt)
+                    && startup_bar.close.is_finite()
+                    && startup_bar.close > 0.0
+                {
+                    let date = market_session::trading_day_utc(dt);
+                    day_closes
+                        .entry(date)
+                        .or_default()
+                        .insert(startup_bar.symbol.clone(), startup_bar.close);
+                    info!(
+                        symbol = startup_bar.symbol.as_str(),
+                        date = %date,
+                        close = startup_bar.close,
+                        "startup stream health gate passed"
+                    );
+                }
+            }
+        }
     }
 
     let mut tick = tokio::time::interval(std::time::Duration::from_secs(30));

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -533,14 +533,20 @@ fn load_close_snapshot_for_day(
     symbols: &[String],
     day: NaiveDate,
 ) -> Result<HashMap<String, f64>, String> {
-    let closes = load_daily_closes(bars_dir, symbols, 10, Some(day))?;
+    let closes = load_daily_closes_with_timestamps(bars_dir, symbols, 10, Some(day))?;
     let mut snapshot = HashMap::new();
     let mut missing = Vec::new();
+    let expected_last_bar_ts_us =
+        (market_session::close_timestamp_utc_for_day(day) - 60_000) * 1_000;
     for symbol in symbols {
         match closes.get(symbol).and_then(|series| {
-            series
-                .iter()
-                .find_map(|(d, c)| if *d == day { Some(*c) } else { None })
+            series.iter().find_map(|(d, ts_us, c)| {
+                if *d == day && *ts_us == expected_last_bar_ts_us {
+                    Some(*c)
+                } else {
+                    None
+                }
+            })
         }) {
             Some(close) if close.is_finite() && close > 0.0 => {
                 snapshot.insert(symbol.clone(), close);
@@ -850,6 +856,28 @@ fn load_daily_closes(
     window_days: i64,
     max_day_inclusive: Option<NaiveDate>,
 ) -> Result<HashMap<String, Vec<(NaiveDate, f64)>>, String> {
+    let closes =
+        load_daily_closes_with_timestamps(bars_dir, symbols, window_days, max_day_inclusive)?;
+    Ok(closes
+        .into_iter()
+        .map(|(symbol, series)| {
+            (
+                symbol,
+                series
+                    .into_iter()
+                    .map(|(date, _ts_us, close)| (date, close))
+                    .collect(),
+            )
+        })
+        .collect())
+}
+
+fn load_daily_closes_with_timestamps(
+    bars_dir: &Path,
+    symbols: &[String],
+    window_days: i64,
+    max_day_inclusive: Option<NaiveDate>,
+) -> Result<HashMap<String, Vec<(NaiveDate, i64, f64)>>, String> {
     use arrow::array::{Array, Float64Array, TimestampMicrosecondArray};
     use std::collections::BTreeMap;
     let cutoff = Utc::now().date_naive() - chrono::Duration::days(window_days);
@@ -919,7 +947,10 @@ fn load_daily_closes(
                     .or_insert((ts_us, px));
             }
         }
-        let series: Vec<(NaiveDate, f64)> = daily.into_iter().map(|(d, (_, c))| (d, c)).collect();
+        let series: Vec<(NaiveDate, i64, f64)> = daily
+            .into_iter()
+            .map(|(d, (ts_us, c))| (d, ts_us, c))
+            .collect();
         if !series.is_empty() {
             out.insert(symbol.clone(), series);
         }

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -22,7 +22,6 @@
 //!   - `Live`: api.alpaca.markets (real money). Gated behind explicit opt-in.
 
 use std::collections::HashMap;
-use std::fs;
 use std::path::Path;
 
 use basket_engine::{
@@ -32,11 +31,9 @@ use basket_engine::{
 use basket_picker::{load_universe, BasketFit};
 use chrono::{DateTime, NaiveDate, Utc};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info, warn};
 
 use crate::alpaca::{AlpacaClient, ExecutionMode};
-use crate::basket_fits;
 use crate::market_session;
 use crate::stream;
 
@@ -70,27 +67,6 @@ impl BasketExecution {
             Self::Live => "LIVE",
         }
     }
-}
-
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-struct BasketRunnerState {
-    last_processed_trading_day: Option<NaiveDate>,
-}
-
-fn load_runner_state(path: &Path) -> Result<BasketRunnerState, String> {
-    if !path.exists() {
-        return Ok(BasketRunnerState::default());
-    }
-    let content = fs::read_to_string(path)
-        .map_err(|e| format!("read runner state {}: {e}", path.display()))?;
-    serde_json::from_str(&content)
-        .map_err(|e| format!("parse runner state {}: {e}", path.display()))
-}
-
-fn save_runner_state(path: &Path, state: &BasketRunnerState) -> Result<(), String> {
-    let content =
-        serde_json::to_string_pretty(state).map_err(|e| format!("serialize runner state: {e}"))?;
-    fs::write(path, content).map_err(|e| format!("write runner state {}: {e}", path.display()))
 }
 
 async fn preflight_account_check(alpaca: &AlpacaClient, mode: ExecutionMode) -> Result<(), String> {
@@ -195,6 +171,7 @@ pub async fn run_basket_live(
         .map(|f| f.candidate.id())
         .collect();
     let state_exists = state_path.exists();
+    let mut last_processed_trading_day = None;
     let mut engine = if state_exists {
         let snapshot = BasketEngine::load_snapshot(state_path)?;
         let loaded_ids: std::collections::HashSet<String> =
@@ -206,11 +183,13 @@ pub async fn run_basket_live(
                 expected_ids.len()
             ));
         }
+        last_processed_trading_day = snapshot.last_processed_trading_day;
         let mut fresh = BasketEngine::new(fits);
         fresh.apply_states(snapshot.states)?;
         info!(
             baskets = fresh.num_baskets(),
             state_path = %state_path.display(),
+            last_processed = ?last_processed_trading_day,
             "loaded basket runtime state onto current fit artifact params"
         );
         fresh
@@ -219,14 +198,6 @@ pub async fn run_basket_live(
         info!(baskets = fresh.num_baskets(), "basket engine initialized");
         fresh
     };
-
-    let runner_state_path = basket_fits::default_runner_state_path(state_path);
-    let mut runner_state = load_runner_state(&runner_state_path)?;
-    info!(
-        runner_state_path = %runner_state_path.display(),
-        last_processed = ?runner_state.last_processed_trading_day,
-        "loaded basket runner state"
-    );
 
     // 2. Seed current_notionals from Alpaca positions (startup reconciliation).
     //    Without this, a restart with live open positions would trigger
@@ -271,13 +242,13 @@ pub async fn run_basket_live(
     //    silently skip an entire session.
     let mut day_closes: HashMap<NaiveDate, HashMap<String, f64>> = HashMap::new();
     let mut processed_sessions: std::collections::HashSet<NaiveDate> = Default::default();
-    if runner_state.last_processed_trading_day == Some(today) {
+    if last_processed_trading_day == Some(today) {
         processed_sessions.insert(today);
     }
 
     if market_session::is_trading_day(today)
         && market_session::is_after_close_grace_utc(now, CLOSE_GRACE_MIN)
-        && runner_state.last_processed_trading_day != Some(today)
+        && last_processed_trading_day != Some(today)
     {
         let catchup_closes = load_close_snapshot_for_day(bars_dir, &symbols, today)?;
         info!(
@@ -295,14 +266,13 @@ pub async fn run_basket_live(
             execution,
         )
         .await?;
-        engine.save_state(state_path)?;
-        runner_state.last_processed_trading_day = Some(today);
-        save_runner_state(&runner_state_path, &runner_state)?;
+        last_processed_trading_day = Some(today);
+        engine.save_state_with_day(state_path, last_processed_trading_day)?;
         processed_sessions.insert(today);
         info!(
             date = %today,
             state_path = %state_path.display(),
-            runner_state_path = %runner_state_path.display(),
+            last_processed = ?last_processed_trading_day,
             "catch-up close cycle completed and startup state persisted"
         );
     }
@@ -312,26 +282,33 @@ pub async fn run_basket_live(
     info!("subscribed to Alpaca 1-min bar stream");
 
     if market_session::is_trading_day(today) && market_session::is_rth_utc(now) {
-        if let Some(startup_bar) = wait_for_stream_health(&mut bar_rx, 90).await? {
-            let bar_open_ts_ms = startup_bar.timestamp - 60_000;
-            if let Some(dt) = DateTime::<Utc>::from_timestamp_millis(bar_open_ts_ms) {
-                if market_session::is_rth_utc(dt)
-                    && startup_bar.close.is_finite()
-                    && startup_bar.close > 0.0
-                {
-                    let date = market_session::trading_day_utc(dt);
-                    day_closes
-                        .entry(date)
-                        .or_default()
-                        .insert(startup_bar.symbol.clone(), startup_bar.close);
-                    info!(
-                        symbol = startup_bar.symbol.as_str(),
-                        date = %date,
-                        close = startup_bar.close,
-                        "startup stream health gate passed"
-                    );
+        match wait_for_stream_health(&mut bar_rx, 90).await {
+            Ok(Some(startup_bar)) => {
+                let bar_open_ts_ms = startup_bar.timestamp - 60_000;
+                if let Some(dt) = DateTime::<Utc>::from_timestamp_millis(bar_open_ts_ms) {
+                    if market_session::is_rth_utc(dt)
+                        && startup_bar.close.is_finite()
+                        && startup_bar.close > 0.0
+                    {
+                        let date = market_session::trading_day_utc(dt);
+                        day_closes
+                            .entry(date)
+                            .or_default()
+                            .insert(startup_bar.symbol.clone(), startup_bar.close);
+                        info!(
+                            symbol = startup_bar.symbol.as_str(),
+                            date = %date,
+                            close = startup_bar.close,
+                            "startup stream health gate passed"
+                        );
+                    }
                 }
             }
+            Ok(None) => {}
+            Err(e) => warn!(
+                error = e.as_str(),
+                "startup stream health gate did not observe a first bar; continuing"
+            ),
         }
     }
 
@@ -492,14 +469,13 @@ pub async fn run_basket_live(
                         execution,
                     )
                     .await?;
-                    engine.save_state(state_path)?;
-                    runner_state.last_processed_trading_day = Some(today);
-                    save_runner_state(&runner_state_path, &runner_state)?;
+                    last_processed_trading_day = Some(today);
+                    engine.save_state_with_day(state_path, last_processed_trading_day)?;
                     info!(
                         date = %today,
                         state_path = %state_path.display(),
-                        runner_state_path = %runner_state_path.display(),
-                        "persisted basket engine and runner state after session close"
+                        last_processed = ?last_processed_trading_day,
+                        "persisted basket engine state after session close"
                     );
                 }
             }
@@ -557,7 +533,7 @@ fn load_close_snapshot_for_day(
     symbols: &[String],
     day: NaiveDate,
 ) -> Result<HashMap<String, f64>, String> {
-    let closes = load_warmup_closes(bars_dir, symbols, 10)?;
+    let closes = load_daily_closes(bars_dir, symbols, 10, Some(day))?;
     let mut snapshot = HashMap::new();
     let mut missing = Vec::new();
     for symbol in symbols {
@@ -864,10 +840,19 @@ pub(crate) fn load_warmup_closes(
     symbols: &[String],
     window_days: i64,
 ) -> Result<HashMap<String, Vec<(NaiveDate, f64)>>, String> {
+    let today = Utc::now().date_naive();
+    load_daily_closes(bars_dir, symbols, window_days, today.pred_opt())
+}
+
+fn load_daily_closes(
+    bars_dir: &Path,
+    symbols: &[String],
+    window_days: i64,
+    max_day_inclusive: Option<NaiveDate>,
+) -> Result<HashMap<String, Vec<(NaiveDate, f64)>>, String> {
     use arrow::array::{Array, Float64Array, TimestampMicrosecondArray};
     use std::collections::BTreeMap;
     let cutoff = Utc::now().date_naive() - chrono::Duration::days(window_days);
-    let today = Utc::now().date_naive();
 
     let mut out = HashMap::new();
     for symbol in symbols {
@@ -915,8 +900,13 @@ pub(crate) fn load_warmup_closes(
                     continue;
                 }
                 let date = market_session::trading_day_utc(dt_utc);
-                if date < cutoff || date >= today {
+                if date < cutoff {
                     continue;
+                }
+                if let Some(max_day) = max_day_inclusive {
+                    if date > max_day {
+                        continue;
+                    }
                 }
                 daily
                     .entry(date)

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -110,6 +110,7 @@ async fn wait_for_stream_health(
 /// Run the basket live/paper loop.
 ///
 /// Returns on Ctrl+C or fatal error.
+#[allow(clippy::too_many_arguments)]
 pub async fn run_basket_live(
     alpaca: &AlpacaClient,
     universe_path: &Path,
@@ -872,6 +873,7 @@ fn load_daily_closes(
         .collect())
 }
 
+#[allow(clippy::type_complexity)]
 fn load_daily_closes_with_timestamps(
     bars_dir: &Path,
     symbols: &[String],

--- a/engine/crates/runner/src/main.rs
+++ b/engine/crates/runner/src/main.rs
@@ -162,6 +162,10 @@ struct StreamArgs {
     /// Frozen basket fit artifact. Defaults to `<universe>.fits.json`.
     #[arg(long)]
     fit_artifact: Option<PathBuf>,
+
+    /// Persisted basket engine state. Defaults to `<fit-artifact>.state.json`.
+    #[arg(long)]
+    state_path: Option<PathBuf>,
 }
 
 /// Args for replay (adds date range).
@@ -496,6 +500,10 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
         .fit_artifact
         .clone()
         .unwrap_or_else(|| basket_fits::default_fit_artifact_path(&universe_path));
+    let state_path = args
+        .state_path
+        .clone()
+        .unwrap_or_else(|| basket_fits::default_live_state_path(&fit_artifact_path));
 
     // Parse execution mode. Default = noop (shadow).
     // Extra safety: `paper live` must come from `Command::Live` (real-money path),
@@ -599,6 +607,8 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
         &alpaca,
         &universe_path,
         &fit_artifact_path,
+        &state_path,
+        &bars_dir,
         execution,
         portfolio_config,
         &fit_artifact.fits,

--- a/engine/crates/runner/src/market_session.rs
+++ b/engine/crates/runner/src/market_session.rs
@@ -39,6 +39,24 @@ pub fn is_trading_day(day: NaiveDate) -> bool {
     }
 }
 
+pub fn previous_trading_day(mut day: NaiveDate) -> NaiveDate {
+    loop {
+        day = day.pred_opt().expect("date before supported range");
+        if is_trading_day(day) {
+            return day;
+        }
+    }
+}
+
+pub fn latest_completed_trading_day_utc(dt_utc: DateTime<Utc>, grace_min: u32) -> NaiveDate {
+    let today = trading_day_utc(dt_utc);
+    if is_trading_day(today) && is_after_close_grace_utc(dt_utc, grace_min) {
+        today
+    } else {
+        previous_trading_day(today)
+    }
+}
+
 pub fn close_timestamp_utc_for_day(day: NaiveDate) -> i64 {
     let local = New_York
         .from_local_datetime(&day.and_time(RTH_CLOSE))
@@ -90,5 +108,20 @@ mod tests {
         assert!(!is_trading_day(holiday));
         assert!(is_trading_day(weekday));
         assert!(!is_trading_day(weekend));
+    }
+
+    #[test]
+    fn test_latest_completed_trading_day_before_and_after_close() {
+        let intraday = Utc.with_ymd_and_hms(2026, 12, 24, 18, 0, 0).unwrap();
+        let after_close = Utc.with_ymd_and_hms(2026, 12, 24, 22, 30, 0).unwrap();
+
+        assert_eq!(
+            latest_completed_trading_day_utc(intraday, 2),
+            NaiveDate::from_ymd_opt(2026, 12, 23).unwrap()
+        );
+        assert_eq!(
+            latest_completed_trading_day_utc(after_close, 2),
+            NaiveDate::from_ymd_opt(2026, 12, 24).unwrap()
+        );
     }
 }


### PR DESCRIPTION
## What changed
- harden basket startup state loading by restoring saved basket runtime states onto the current frozen fit artifact params instead of trusting persisted params wholesale
- persist `last_processed_trading_day` inside the same basket engine snapshot file so startup catch-up is idempotent with engine state
- run one same-day catch-up close cycle when the runner starts after close+grace on an unprocessed trading day
- require finalized close bars for that catch-up path instead of trusting a partial same-day parquet tail
- add simple startup readiness gates: Alpaca account preflight for paper/live and a first-bar stream health check during RTH

## Why
The live basket runner was improving in pieces, but startup was still too brittle:
- state restore could drift from the current fit artifact contract
- a post-close restart could miss the day entirely or replay it ambiguously
- paper/live startup had no account sanity gate
- the stream path had no minimal proof that live bars were actually flowing before waiting for the next close
- same-day catch-up needed to fail closed on incomplete local close data

This keeps the design close-driven and operationally simple: one command, deterministic startup, fail closed on ambiguity.

## Impact
- basket live can start at any time of day and establish a cleaner state for that trading day
- after-close startup now performs exactly one catch-up processing pass if today is a completed but unprocessed trading session
- that catch-up path only runs from finalized close bars
- paper/live startup fails early on blocked or unusable Alpaca accounts
- intraday startup waits for a first live RTH bar when available, but no longer aborts the whole runner on a transient stream delay

## Validation
- `cargo fmt --all`
- `cargo test -p basket-engine -p openquant-runner -- --nocapture`

## Commit split
1. `Harden basket startup state handling`
2. `Add basket startup readiness gates`
3. `Tighten basket startup persistence and catch-up`
4. `Require finalized close bars for startup catch-up`