### PR TITLE
[codex] Enforce basket portfolio admission caps

### DIFF
--- a/engine/crates/basket-engine/src/engine.rs
+++ b/engine/crates/basket-engine/src/engine.rs
@@ -404,6 +404,15 @@ impl BasketEngine {
         self.params.iter()
     }
 
+    /// Flatten a set of baskets so portfolio admission and engine state stay aligned.
+    pub fn flatten_baskets(&mut self, basket_ids: &[String]) {
+        for basket_id in basket_ids {
+            if let Some(state) = self.states.get_mut(basket_id) {
+                state.flatten();
+            }
+        }
+    }
+
     fn validate_snapshot(snapshot: &EngineSnapshot) -> Result<(), String> {
         let mut params = HashMap::new();
         for p in &snapshot.params {

--- a/engine/crates/basket-engine/src/lib.rs
+++ b/engine/crates/basket-engine/src/lib.rs
@@ -11,8 +11,8 @@ mod state;
 pub use engine::{BasketEngine, BasketParams, EngineSnapshot};
 pub use intent::{PositionIntent, TransitionReason};
 pub use portfolio::{
-    aggregate_positions, basket_to_legs, diff_to_orders, LegNotional, OrderIntent, OrderReason,
-    PortfolioConfig, Side,
+    aggregate_positions, basket_to_legs, diff_to_orders, plan_portfolio, LegNotional, OrderIntent,
+    OrderReason, PortfolioConfig, PortfolioPlan, Side,
 };
 pub use state::BasketState;
 

--- a/engine/crates/basket-engine/src/portfolio.rs
+++ b/engine/crates/basket-engine/src/portfolio.rs
@@ -1,6 +1,6 @@
 //! Portfolio aggregation and order generation.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
@@ -43,6 +43,19 @@ pub struct LegNotional {
     pub notional: f64,
 }
 
+/// Portfolio admission result after applying active-basket caps.
+#[derive(Debug, Clone)]
+pub struct PortfolioPlan {
+    /// Symbol-level target notionals for admitted baskets only.
+    pub symbol_notionals: HashMap<String, f64>,
+    /// Basket ids admitted into the portfolio target set.
+    pub selected_baskets: Vec<String>,
+    /// Active basket ids excluded by the cap.
+    pub excluded_baskets: Vec<String>,
+    /// Number of non-flat baskets seen before applying the cap.
+    pub active_baskets: usize,
+}
+
 /// Compute leg notionals for a basket position.
 ///
 /// For a basket with target and N peers:
@@ -80,15 +93,14 @@ pub fn basket_to_legs(params: &BasketParams, position: i8, notional: f64) -> Vec
     legs
 }
 
-/// Aggregate all basket positions into symbol-level notionals.
-pub fn aggregate_positions(
-    engine: &BasketEngine,
-    config: &PortfolioConfig,
-) -> HashMap<String, f64> {
+/// Aggregate all basket positions into symbol-level notionals after applying
+/// the configured active-basket cap.
+pub fn plan_portfolio(engine: &BasketEngine, config: &PortfolioConfig) -> PortfolioPlan {
     let notional_per_basket = config.notional_per_basket();
     let mut symbol_notionals: HashMap<String, f64> = HashMap::new();
+    let mut active: Vec<(String, f64)> = Vec::new();
 
-    for (basket_id, params) in engine.iter_params() {
+    for (basket_id, _params) in engine.iter_params() {
         let state = match engine.get_state(basket_id) {
             Some(s) => s,
             None => continue,
@@ -97,14 +109,57 @@ pub fn aggregate_positions(
         if state.position == 0 {
             continue;
         }
+        active.push((basket_id.clone(), state.last_z.unwrap_or(0.0).abs()));
+    }
 
+    active.sort_by(|(a_id, a_z), (b_id, b_z)| {
+        b_z.partial_cmp(a_z)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a_id.cmp(b_id))
+    });
+
+    let active_baskets = active.len();
+    let selected_baskets: Vec<String> = active
+        .iter()
+        .take(config.n_active_baskets)
+        .map(|(basket_id, _)| basket_id.clone())
+        .collect();
+    let excluded_baskets: Vec<String> = active
+        .iter()
+        .skip(config.n_active_baskets)
+        .map(|(basket_id, _)| basket_id.clone())
+        .collect();
+    let selected: HashSet<&str> = selected_baskets.iter().map(|s| s.as_str()).collect();
+
+    for (basket_id, params) in engine.iter_params() {
+        if !selected.contains(basket_id.as_str()) {
+            continue;
+        }
+        let state = match engine.get_state(basket_id) {
+            Some(s) => s,
+            None => continue,
+        };
         let legs = basket_to_legs(params, state.position, notional_per_basket);
         for leg in legs {
             *symbol_notionals.entry(leg.symbol).or_default() += leg.notional;
         }
     }
 
-    symbol_notionals
+    PortfolioPlan {
+        symbol_notionals,
+        selected_baskets,
+        excluded_baskets,
+        active_baskets,
+    }
+}
+
+/// Aggregate all basket positions into symbol-level notionals after applying
+/// active-basket admission.
+pub fn aggregate_positions(
+    engine: &BasketEngine,
+    config: &PortfolioConfig,
+) -> HashMap<String, f64> {
+    plan_portfolio(engine, config).symbol_notionals
 }
 
 /// Order side.
@@ -182,6 +237,9 @@ pub fn diff_to_orders(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::engine::BasketEngine;
+    use crate::DailyBar;
+    use chrono::NaiveDate;
 
     fn make_test_params() -> BasketParams {
         BasketParams {
@@ -199,6 +257,76 @@ mod tests {
             },
             threshold_k: 1.25,
         }
+    }
+
+    fn make_test_engine() -> BasketEngine {
+        let fit = basket_picker::BasketFit {
+            candidate: basket_picker::BasketCandidate {
+                sector: "semi".to_string(),
+                target: "AMD".to_string(),
+                members: vec!["NVDA".to_string(), "INTC".to_string()],
+                fit_date: NaiveDate::from_ymd_opt(2026, 4, 20).unwrap(),
+            },
+            valid: true,
+            ou: Some(basket_picker::OuFit {
+                a: 0.0,
+                b: 0.95,
+                kappa: 12.92,
+                mu: 0.0,
+                sigma: 0.01,
+                sigma_eq: 0.032,
+                half_life_days: 13.51,
+            }),
+            bertram: Some(basket_picker::BertramResult {
+                a: -0.04,
+                m: 0.04,
+                k: 1.25,
+                expected_return_rate: 0.1,
+                expected_trade_length_days: 5.0,
+                sigma_cont: 0.1,
+            }),
+            threshold_k: 1.25,
+            reject_reason: None,
+        };
+        let mut fit2 = fit.clone();
+        fit2.candidate.target = "MU".to_string();
+        fit2.candidate.members = vec!["QCOM".to_string(), "TXN".to_string()];
+        let mut engine = BasketEngine::new(&[fit, fit2]);
+        let date = NaiveDate::from_ymd_opt(2026, 4, 21).unwrap();
+        let bars = vec![
+            DailyBar {
+                symbol: "AMD".to_string(),
+                date,
+                close: 90.0,
+            },
+            DailyBar {
+                symbol: "NVDA".to_string(),
+                date,
+                close: 100.0,
+            },
+            DailyBar {
+                symbol: "INTC".to_string(),
+                date,
+                close: 100.0,
+            },
+            DailyBar {
+                symbol: "MU".to_string(),
+                date,
+                close: 110.0,
+            },
+            DailyBar {
+                symbol: "QCOM".to_string(),
+                date,
+                close: 100.0,
+            },
+            DailyBar {
+                symbol: "TXN".to_string(),
+                date,
+                close: 100.0,
+            },
+        ];
+        let _ = engine.on_bars(&bars);
+        engine
     }
 
     #[test]
@@ -268,5 +396,21 @@ mod tests {
         let nvda_order = orders.iter().find(|o| o.symbol == "NVDA").unwrap();
         assert_eq!(nvda_order.side, Side::Buy);
         assert_eq!(nvda_order.qty, 2000);
+    }
+
+    #[test]
+    fn test_plan_portfolio_enforces_active_basket_cap() {
+        let engine = make_test_engine();
+        let config = PortfolioConfig {
+            capital: 100_000.0,
+            leverage: 4.0,
+            n_active_baskets: 1,
+        };
+        let plan = plan_portfolio(&engine, &config);
+        assert_eq!(plan.active_baskets, 2);
+        assert_eq!(plan.selected_baskets.len(), 1);
+        assert_eq!(plan.excluded_baskets.len(), 1);
+        let gross: f64 = plan.symbol_notionals.values().map(|n| n.abs()).sum();
+        assert!((gross - config.notional_per_basket()).abs() < 1e-6);
     }
 }

--- a/engine/crates/basket-engine/src/portfolio.rs
+++ b/engine/crates/basket-engine/src/portfolio.rs
@@ -28,6 +28,26 @@ impl Default for PortfolioConfig {
 }
 
 impl PortfolioConfig {
+    /// Validate portfolio sizing inputs before live use.
+    pub fn validate(&self) -> Result<(), String> {
+        if !self.capital.is_finite() || self.capital <= 0.0 {
+            return Err(format!(
+                "portfolio capital must be positive, got {}",
+                self.capital
+            ));
+        }
+        if !self.leverage.is_finite() || self.leverage <= 0.0 {
+            return Err(format!(
+                "portfolio leverage must be positive, got {}",
+                self.leverage
+            ));
+        }
+        if self.n_active_baskets == 0 {
+            return Err("portfolio n_active_baskets must be at least 1".to_string());
+        }
+        Ok(())
+    }
+
     /// Notional per basket = (capital * leverage) / n_active_baskets.
     pub fn notional_per_basket(&self) -> f64 {
         (self.capital * self.leverage) / self.n_active_baskets as f64
@@ -336,7 +356,19 @@ mod tests {
             leverage: 4.0,
             n_active_baskets: 10,
         };
+        config.validate().unwrap();
         assert_eq!(config.notional_per_basket(), 40_000.0);
+    }
+
+    #[test]
+    fn test_portfolio_config_rejects_zero_active_baskets() {
+        let config = PortfolioConfig {
+            capital: 100_000.0,
+            leverage: 4.0,
+            n_active_baskets: 0,
+        };
+        let err = config.validate().unwrap_err();
+        assert!(err.contains("n_active_baskets"));
     }
 
     #[test]

--- a/engine/crates/basket-engine/src/state.rs
+++ b/engine/crates/basket-engine/src/state.rs
@@ -65,6 +65,13 @@ impl BasketState {
         self.entry_date = Some(date);
         self.entry_spread = Some(spread);
     }
+
+    /// Flatten the position while preserving diagnostics.
+    pub fn flatten(&mut self) {
+        self.position = 0;
+        self.entry_date = None;
+        self.entry_spread = None;
+    }
 }
 
 #[cfg(test)]
@@ -110,5 +117,16 @@ mod tests {
         assert_eq!(state.spread_history.len(), 60);
         assert_eq!(state.spread_history.front(), Some(&40.0));
         assert_eq!(state.spread_history.back(), Some(&99.0));
+    }
+
+    #[test]
+    fn test_flatten_clears_position_fields() {
+        let mut state = BasketState::new();
+        let date = NaiveDate::from_ymd_opt(2026, 4, 21).unwrap();
+        state.enter(1, date, 0.05);
+        state.flatten();
+        assert_eq!(state.position, 0);
+        assert_eq!(state.entry_date, None);
+        assert_eq!(state.entry_spread, None);
     }
 }

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use basket_engine::{
-    aggregate_positions, diff_to_orders, BasketEngine, DailyBar, OrderIntent, PortfolioConfig,
+    diff_to_orders, plan_portfolio, BasketEngine, DailyBar, OrderIntent, PortfolioConfig,
     PositionIntent, Side,
 };
 use basket_picker::{load_universe, BasketFit};
@@ -618,8 +618,10 @@ async fn process_session_close(
         );
     }
 
-    // Portfolio layer: target notionals across symbols, then convert to target shares.
-    let target_notionals = aggregate_positions(engine, portfolio_config);
+    // Portfolio layer: apply active-basket admission first, then convert
+    // admitted target notionals to target shares.
+    let plan = plan_portfolio(engine, portfolio_config);
+    let target_notionals = plan.symbol_notionals;
     let target_shares = target_shares_from_notionals(&target_notionals, closes)?;
 
     // Summary of the notional plan before we diff — this is where yesterday's
@@ -634,6 +636,8 @@ async fn process_session_close(
     } else {
         sorted_abs[sorted_abs.len() / 2]
     };
+    let gross_notional = gross_long + gross_short.abs();
+    let gross_cap = portfolio_config.capital * portfolio_config.leverage;
     info!(
         date = %date,
         targets = target_notionals.len(),
@@ -641,12 +645,38 @@ async fn process_session_close(
         current_positions = current_shares.len(),
         gross_long = %format!("{:.0}", gross_long),
         gross_short = %format!("{:.0}", gross_short),
-        gross_notional = %format!("{:.0}", gross_long + gross_short.abs()),
+        gross_notional = %format!("{:.0}", gross_notional),
+        gross_cap = %format!("{:.0}", gross_cap),
         net_notional = %format!("{:.0}", gross_long + gross_short),
         max_abs_leg = %format!("{:.0}", max_abs),
         median_abs_leg = %format!("{:.0}", median_abs),
         "target notionals summary"
     );
+    if gross_notional > gross_cap + 1.0 {
+        return Err(format!(
+            "target gross notional {:.2} exceeds configured cap {:.2}",
+            gross_notional, gross_cap
+        ));
+    }
+    if !plan.excluded_baskets.is_empty() {
+        warn!(
+            date = %date,
+            active_baskets = plan.active_baskets,
+            cap = portfolio_config.n_active_baskets,
+            admitted = plan.selected_baskets.len(),
+            excluded = plan.excluded_baskets.len(),
+            excluded_sample = ?plan.excluded_baskets.iter().take(10).collect::<Vec<_>>(),
+            "active-basket cap excluded baskets from the target portfolio"
+        );
+    } else {
+        info!(
+            date = %date,
+            active_baskets = plan.active_baskets,
+            cap = portfolio_config.n_active_baskets,
+            admitted = plan.selected_baskets.len(),
+            "portfolio admission completed without exclusions"
+        );
+    }
 
     let orders = diff_to_orders(current_shares, &target_shares);
     if orders.is_empty() {

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -622,6 +622,9 @@ async fn process_session_close(
     // admitted target notionals to target shares.
     let plan = plan_portfolio(engine, portfolio_config);
     let target_notionals = plan.symbol_notionals;
+    if !plan.excluded_baskets.is_empty() {
+        engine.flatten_baskets(&plan.excluded_baskets);
+    }
     let target_shares = target_shares_from_notionals(&target_notionals, closes)?;
 
     // Summary of the notional plan before we diff — this is where yesterday's

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -133,6 +133,7 @@ pub async fn run_basket_live(
         execution = execution.label(),
         "========== BASKET LIVE RUNNER =========="
     );
+    portfolio_config.validate()?;
 
     if execution == BasketExecution::Live {
         warn!("LIVE MODE — real-money orders will be placed on every EOD signal");


### PR DESCRIPTION
## What changed
- add a portfolio admission step in `basket-engine` that ranks non-flat baskets by `|last_z|` and admits only the top `n_active_baskets`
- generate target notionals only from the admitted basket set instead of sizing every active basket regardless of cap
- expose admission results so the live runner can log admitted vs excluded baskets
- add an explicit gross-notional hard cap check against `capital * leverage` before order generation
- add coverage for active-basket cap enforcement in `basket-engine`

## Why
The live basket path still had a core portfolio bug: if more baskets were active than `n_active_baskets`, it sized all of them anyway. That could exceed the configured portfolio budget even though the config implied a hard cap.

This PR makes the portfolio layer enforce the cap directly instead of relying on implicit operator discipline.

## Impact
- only the strongest active baskets are admitted into the target portfolio when the engine has more non-flat baskets than allowed
- excluded baskets are logged explicitly in the live runner
- gross target exposure now fails closed if it exceeds the configured capital/leverage budget

## Validation
- `cargo fmt --all`
- `cargo test -p basket-engine -p openquant-runner -- --nocapture`