### PR TITLE
[#294c-1] Inject Clock and SessionTrigger into run_basket_live

### DIFF
--- a/engine/crates/runner/Cargo.toml
+++ b/engine/crates/runner/Cargo.toml
@@ -31,3 +31,4 @@ parquet = { version = "54", features = ["arrow"] }
 
 [dev-dependencies]
 tempfile = "3"
+tokio = { version = "1", features = ["full", "test-util"] }

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -37,7 +37,9 @@ use tracing::{debug, error, info, warn};
 use crate::alpaca::ExecutionMode;
 use crate::bar_source::BarSource;
 use crate::broker::Broker;
+use crate::clock::Clock;
 use crate::market_session;
+use crate::session_trigger::SessionTrigger;
 use crate::stream;
 
 /// Execution mode for basket live/paper.
@@ -271,6 +273,8 @@ fn classify_startup_phase(
 pub async fn run_basket_live(
     broker: &impl Broker,
     bar_source: &impl BarSource,
+    clock: &impl Clock,
+    session_trigger: &mut impl SessionTrigger,
     universe_path: &Path,
     fit_artifact_path: &Path,
     state_path: &Path,
@@ -281,6 +285,10 @@ pub async fn run_basket_live(
 ) -> Result<(), String> {
     // Grace period after session close before firing the engine. Lets late-arriving
     // final-RTH-minute bars land in the buffer.
+    //
+    // The `clock` and `session_trigger` parameters MUST agree on this value:
+    // `IntervalSessionTrigger` is constructed with the same constant in
+    // `main.rs`. If they diverge, replay/live cadence drifts.
     const CLOSE_GRACE_MIN: u32 = 2;
 
     info!(
@@ -367,7 +375,7 @@ pub async fn run_basket_live(
     //    we refuse to start. Trading from an empty share map would diff
     //    targets against zero and flood Alpaca with duplicate orders against
     //    already-open broker positions, potentially double-sizing every leg.
-    let now = Utc::now();
+    let now = clock.now();
     let today = market_session::trading_day_utc(now);
     let mut current_shares = match execution.alpaca_mode() {
         None => {
@@ -474,10 +482,9 @@ pub async fn run_basket_live(
         }
     }
 
-    let mut tick = tokio::time::interval(std::time::Duration::from_secs(30));
-    // Dedicated 60s heartbeat that summarizes buffer state. Separate from the
-    // 30s wall-clock tick so we get clean one-per-minute INFO lines
-    // regardless of how often the close-firing check runs.
+    // Dedicated 60s heartbeat that summarizes buffer state. The session-close
+    // schedule is owned by `session_trigger` (see `SessionTrigger` trait); the
+    // heartbeat is observability only.
     let mut heartbeat = tokio::time::interval(std::time::Duration::from_secs(60));
     heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     // Skip first fire so we don't heartbeat with zero data.
@@ -536,7 +543,7 @@ pub async fn run_basket_live(
                 // this goes silent while `stream heartbeat` shows activity,
                 // the channel is backed up or the RTH filter is rejecting
                 // everything.
-                let now = Utc::now();
+                let now = clock.now();
                 let today = market_session::trading_day_utc(now);
                 let in_rth = market_session::is_rth_utc(now);
                 let past_close = market_session::is_after_close_grace_utc(now, CLOSE_GRACE_MIN);
@@ -560,14 +567,16 @@ pub async fn run_basket_live(
                 );
                 bars_processed_window = 0;
             }
-            _ = tick.tick() => {
-                // Wall-clock trigger: if we are past session close + grace for a
-                // given date and haven't processed it yet, fire now — regardless
-                // of which symbols' final-RTH bars landed.
-                let now = Utc::now();
-                let today = market_session::trading_day_utc(now);
-                let past_close = market_session::is_after_close_grace_utc(now, CLOSE_GRACE_MIN);
-                if past_close && !processed_sessions.contains(&today) {
+            today = session_trigger.next() => {
+                // Session-close trigger: the trigger has determined that
+                // `today` is past session close + grace. Live uses
+                // `IntervalSessionTrigger` (30s wall-clock poll); replay
+                // (#294c-2) will use a bar-driven trigger so cadence
+                // follows simulated time. The trigger dedups internally,
+                // so `today` is yielded at most once; `processed_sessions`
+                // is the persisted-state dedup that catches restarts
+                // after a session was already processed.
+                if !processed_sessions.contains(&today) {
                     let closes_for_day = day_closes.remove(&today).unwrap_or_default();
                     if closes_for_day.is_empty() {
                         if !market_session::is_trading_day(today) {

--- a/engine/crates/runner/src/clock.rs
+++ b/engine/crates/runner/src/clock.rs
@@ -1,0 +1,27 @@
+//! Clock abstraction for the basket live loop.
+//!
+//! [`SystemClock`] returns wall time and is used in production. A
+//! `BarDrivenClock` (#294c-2) will return time derived from the latest
+//! emitted bar's timestamp, so replay can advance simulated time as fast
+//! as the parquet bar source emits.
+
+use chrono::{DateTime, Utc};
+
+/// Abstraction over "what time is it".
+///
+/// Live and paper use [`SystemClock`]. Replay (#294c-2) will use a
+/// bar-timestamp-driven clock so heartbeats, catch-up logic, and
+/// past-close detection all see the simulated wall time instead of the
+/// host's wall time.
+pub trait Clock: Send + Sync {
+    fn now(&self) -> DateTime<Utc>;
+}
+
+/// Production clock — returns `Utc::now()`.
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> DateTime<Utc> {
+        Utc::now()
+    }
+}

--- a/engine/crates/runner/src/main.rs
+++ b/engine/crates/runner/src/main.rs
@@ -21,10 +21,12 @@ mod basket_fits;
 mod basket_live;
 mod basket_runner;
 mod broker;
+mod clock;
 mod earnings;
 mod market_session;
 mod pair_picker_service;
 pub mod refresh;
+mod session_trigger;
 mod stream;
 
 use alpaca::ExecutionMode;
@@ -598,9 +600,17 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
     let bar_source =
         bar_source::AlpacaBarSource::new(alpaca.api_key.clone(), alpaca.api_secret.clone());
 
+    // Live/paper use wall-clock time and a 30s polling session trigger.
+    // Replay (#294c-2) will swap these for bar-driven equivalents. Keep
+    // the grace constant in sync with `basket_live::CLOSE_GRACE_MIN`.
+    let clock = clock::SystemClock;
+    let mut session_trigger = session_trigger::IntervalSessionTrigger::new(clock::SystemClock, 2);
+
     if let Err(e) = basket_live::run_basket_live(
         &alpaca,
         &bar_source,
+        &clock,
+        &mut session_trigger,
         &universe_path,
         &fit_artifact_path,
         &state_path,

--- a/engine/crates/runner/src/session_trigger.rs
+++ b/engine/crates/runner/src/session_trigger.rs
@@ -1,0 +1,118 @@
+//! Session-close trigger abstraction for the basket live loop.
+//!
+//! [`IntervalSessionTrigger`] polls the clock on a 30s interval and yields
+//! the trading date once it crosses session close + grace. A
+//! `BarDrivenSessionTrigger` (#294c-2) will fire when an emitted bar's
+//! timestamp crosses the same boundary, so replay drives session-close
+//! cadence off bar timestamps instead of wall-clock ticks.
+
+use chrono::NaiveDate;
+
+use crate::clock::Clock;
+use crate::market_session;
+
+/// Abstraction over "when should we run the session-close cycle, and for
+/// which trading date."
+///
+/// Implementations are responsible for dedup — each trading date must be
+/// yielded at most once. The consumer in [`crate::basket_live`] still
+/// maintains its own `processed_sessions` set against persisted state, so
+/// duplicate yields are filtered there too, but the trigger is the
+/// primary scheduler.
+pub trait SessionTrigger: Send + Sync {
+    /// Block until the next session-close event. Returns the trading
+    /// date that just closed.
+    async fn next(&mut self) -> NaiveDate;
+}
+
+/// Production trigger — polls the clock on a 30s wall-clock interval.
+///
+/// Matches the pre-#298 behavior in `basket_live`: if the clock is past
+/// session close + grace for a date that hasn't been yielded yet, fire
+/// for that date.
+pub struct IntervalSessionTrigger<C: Clock> {
+    clock: C,
+    interval: tokio::time::Interval,
+    grace_minutes: u32,
+    last_yielded: Option<NaiveDate>,
+}
+
+impl<C: Clock> IntervalSessionTrigger<C> {
+    pub fn new(clock: C, grace_minutes: u32) -> Self {
+        Self {
+            clock,
+            interval: tokio::time::interval(std::time::Duration::from_secs(30)),
+            grace_minutes,
+            last_yielded: None,
+        }
+    }
+}
+
+impl<C: Clock> SessionTrigger for IntervalSessionTrigger<C> {
+    async fn next(&mut self) -> NaiveDate {
+        loop {
+            self.interval.tick().await;
+            let now = self.clock.now();
+            let today = market_session::trading_day_utc(now);
+            if market_session::is_after_close_grace_utc(now, self.grace_minutes)
+                && self.last_yielded != Some(today)
+            {
+                self.last_yielded = Some(today);
+                return today;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, TimeZone, Utc};
+    use std::sync::{Arc, Mutex};
+
+    /// Test clock whose returned time is settable from outside.
+    struct FakeClock {
+        now: Arc<Mutex<DateTime<Utc>>>,
+    }
+
+    impl FakeClock {
+        fn new(initial: DateTime<Utc>) -> (Self, Arc<Mutex<DateTime<Utc>>>) {
+            let cell = Arc::new(Mutex::new(initial));
+            (FakeClock { now: cell.clone() }, cell)
+        }
+    }
+
+    impl Clock for FakeClock {
+        fn now(&self) -> DateTime<Utc> {
+            *self.now.lock().unwrap()
+        }
+    }
+
+    /// `IntervalSessionTrigger` should fire each trading date at most once.
+    /// Two `.next()` calls inside the same session must not both resolve.
+    #[tokio::test(start_paused = true)]
+    async fn dedupes_same_date() {
+        // 21:00 UTC on a Friday — past 20:00 close + 2min grace, in RTH window.
+        let (clock, cell) = FakeClock::new(Utc.with_ymd_and_hms(2026, 4, 24, 21, 0, 0).unwrap());
+        let mut trig = IntervalSessionTrigger::new(clock, 2);
+
+        let first = trig.next().await;
+        assert_eq!(first, chrono::NaiveDate::from_ymd_opt(2026, 4, 24).unwrap());
+
+        // Same wall time → second call must NOT immediately resolve.
+        // Use timeout to assert it's pending.
+        let result = tokio::time::timeout(std::time::Duration::from_secs(120), trig.next()).await;
+        assert!(
+            result.is_err(),
+            "second .next() should not resolve while still on the same date"
+        );
+
+        // Advance to the next trading day past close+grace → should fire.
+        *cell.lock().unwrap() = Utc.with_ymd_and_hms(2026, 4, 27, 21, 0, 0).unwrap();
+        let second = trig.next().await;
+        assert_eq!(
+            second,
+            chrono::NaiveDate::from_ymd_opt(2026, 4, 27).unwrap()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

First of three PRs implementing #294 (replay through the live code path). Codex's review (https://github.com/kumargu/OpenQuant/issues/294#issuecomment-4318488895) flagged that replay needs more than the two seams we already have (\`Broker\`, \`BarSource\`) — today \`run_basket_live\` drives session-close cadence off a real \`tokio::time::interval(30s)\`, and \"now\" off \`Utc::now()\`. If \`ParquetBarSource\` drains a year of bars in seconds, no close ever fires.

This PR adds the two missing injection points so replay (#299) can swap them out.

### Changes

- **\`clock.rs\`** — \`Clock\` trait + \`SystemClock\` impl. Replaces the three direct \`Utc::now()\` calls inside \`run_basket_live\` and its heartbeat block. The two helper functions (\`load_warmup_closes\`, \`load_daily_closes_with_timestamps\`) used by the one-shot \`freeze-basket-fits\` tool are intentionally left as-is — they're not in the live runtime call graph.
- **\`session_trigger.rs\`** — \`SessionTrigger\` trait + \`IntervalSessionTrigger\` impl. The trigger owns 30s polling + dedup of yielded dates. \`basket_live\`'s \`processed_sessions\` set is kept as the **persisted-state** dedup (defends against restart after a session was already processed and its state was saved); the trigger's \`last_yielded\` is the **scheduling** dedup. Two distinct concerns, two distinct sets of state.
- **\`basket_live.rs\`** — \`run_basket_live\` now takes \`&impl Clock\` and \`&mut impl SessionTrigger\`. The select-loop \`_ = tick.tick()\` arm is now \`today = session_trigger.next() => { ... }\`. Heartbeat (60s observability) ticker stays untouched.
- **\`main.rs\`** — live/paper construct \`SystemClock\` + \`IntervalSessionTrigger::new(SystemClock, 2)\`. CLI surface unchanged.

### What's NOT in this PR

- \`BarDrivenClock\` / \`BarDrivenSessionTrigger\` (those are #299)
- \`SimulatedBroker\` / \`ParquetBarSource\` (#299)
- Deleting \`basket_runner::run_basket_replay\` (#300)

### Behavior

No paper/live behavior change. The 30s polling cadence, 2-min grace period, and dedup semantics are preserved exactly.

## Test plan

- [x] \`cargo clippy --workspace -- -D warnings\` green
- [x] \`cargo test --workspace\` green
- [x] \`cargo fmt --all -- --check\` green
- [x] New unit test \`session_trigger::tests::dedupes_same_date\` verifies \`IntervalSessionTrigger\` yields a date once and refuses to re-yield while still on the same date, then fires when the clock advances to the next trading day
- [ ] Smoke test: run \`paper --engine basket\` for a few minutes and confirm log stream is structurally identical to pre-#298 (TBD on next paper window — out of scope for this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)