### PR TITLE
Fix replay leakage: walk-forward fit + drop --fit-artifact / --leverage

### DIFF
--- a/engine/crates/runner/src/basket_fits.rs
+++ b/engine/crates/runner/src/basket_fits.rs
@@ -10,7 +10,14 @@ use crate::basket_live::{align_basket_history, collect_symbols, load_warmup_clos
 
 const FIT_ARTIFACT_SCHEMA: &str = "basket_fit_artifact";
 const FIT_ARTIFACT_VERSION: &str = "v1";
-const WARMUP_DAYS: i64 = 90;
+// 180 calendar days ≈ 126 trading days. The validator needs at least
+// `residual_window_days = 60` aligned spread points (target + all peers
+// present on the same day). Tight bounds (90 cal days ≈ 62 trading days)
+// fall below that minimum after alignment drops any day with a single
+// missing symbol — which is what made replay's auto-fit reject all 49
+// baskets at first run. Doubling the budget is cheap and removes the
+// edge case entirely.
+const WARMUP_DAYS: i64 = 180;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BasketFitArtifact {
@@ -45,6 +52,22 @@ pub fn build_live_fit_artifact(
     let universe = load_universe(universe_path)?;
     let symbols = collect_symbols(&universe);
     let closes = load_warmup_closes(bars_dir, &symbols, WARMUP_DAYS)?;
+    build_live_fit_artifact_from_inputs(&universe, &closes)
+}
+
+/// Build a fit artifact using data **strictly before** `as_of`.
+///
+/// Used by the replay path so the fit can't peek at data it's about to
+/// trade against. `as_of` should be the replay window's `--start` date.
+pub fn build_replay_fit_artifact_as_of(
+    universe_path: &Path,
+    bars_dir: &Path,
+    as_of: chrono::NaiveDate,
+) -> Result<BasketFitArtifact, String> {
+    let universe = load_universe(universe_path)?;
+    let symbols = collect_symbols(&universe);
+    let closes =
+        crate::basket_live::load_warmup_closes_as_of(bars_dir, &symbols, WARMUP_DAYS, as_of)?;
     build_live_fit_artifact_from_inputs(&universe, &closes)
 }
 

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -279,7 +279,6 @@ pub async fn run_basket_live(
     clock: &impl Clock,
     session_trigger: &mut impl SessionTrigger,
     universe_path: &Path,
-    fit_artifact_path: &Path,
     state_path: &Path,
     bars_dir: &Path,
     execution: BasketExecution,
@@ -296,10 +295,10 @@ pub async fn run_basket_live(
 
     info!(
         universe = %universe_path.display(),
-        fit_artifact = %fit_artifact_path.display(),
         state_path = %state_path.display(),
         bars_dir = %bars_dir.display(),
         execution = execution.label(),
+        n_fits = fits.len(),
         "========== BASKET LIVE RUNNER =========="
     );
     portfolio_config.validate()?;
@@ -333,6 +332,22 @@ pub async fn run_basket_live(
         "loaded basket fits"
     );
     if valid_count == 0 {
+        // Tally rejection reasons so the operator can see WHY all
+        // baskets failed — vital when replay's auto-fit produces 0
+        // valid fits and you don't know whether it's a data window
+        // problem, a numerical fit problem, or a config problem.
+        let mut reasons: std::collections::BTreeMap<String, usize> =
+            std::collections::BTreeMap::new();
+        for f in fits {
+            let reason = f
+                .reject_reason
+                .clone()
+                .unwrap_or_else(|| "unknown".to_string());
+            *reasons.entry(reason).or_insert(0) += 1;
+        }
+        for (reason, count) in &reasons {
+            error!(reason = %reason, count, "fit rejected");
+        }
         return Err("no valid baskets in fit artifact".to_string());
     }
 
@@ -1158,6 +1173,20 @@ pub(crate) fn load_warmup_closes(
     load_daily_closes(bars_dir, symbols, window_days, today.pred_opt())
 }
 
+/// Same as [`load_warmup_closes`] but with an explicit "as-of" cutoff.
+///
+/// Used by the replay path to build a fit using data **strictly before**
+/// the replay window, so the fit can't peek at the data it's about to
+/// trade against.
+pub(crate) fn load_warmup_closes_as_of(
+    bars_dir: &Path,
+    symbols: &[String],
+    window_days: i64,
+    as_of: NaiveDate,
+) -> Result<HashMap<String, Vec<(NaiveDate, f64)>>, String> {
+    load_daily_closes(bars_dir, symbols, window_days, as_of.pred_opt())
+}
+
 fn load_daily_closes(
     bars_dir: &Path,
     symbols: &[String],
@@ -1189,7 +1218,14 @@ fn load_daily_closes_with_timestamps(
 ) -> Result<HashMap<String, Vec<(NaiveDate, i64, f64)>>, String> {
     use arrow::array::{Array, Float64Array, TimestampMicrosecondArray};
     use std::collections::BTreeMap;
-    let cutoff = Utc::now().date_naive() - chrono::Duration::days(window_days);
+    // The window anchor is the most recent date the caller wants to
+    // include — `max_day_inclusive` if provided (replay's "as-of"
+    // cutoff), or "today" otherwise (live warm-up). The lower bound
+    // is `anchor - window_days`. Anchoring on `Utc::now()` here would
+    // make `as_of`-based callers fail silently when their requested
+    // window doesn't overlap "now − window_days" (#306 finding).
+    let anchor = max_day_inclusive.unwrap_or_else(|| Utc::now().date_naive());
+    let cutoff = anchor - chrono::Duration::days(window_days);
 
     let mut out = HashMap::new();
     for symbol in symbols {

--- a/engine/crates/runner/src/main.rs
+++ b/engine/crates/runner/src/main.rs
@@ -202,10 +202,6 @@ struct ReplayArgs {
     #[arg(long)]
     bars_dir: Option<PathBuf>,
 
-    /// Frozen basket fit artifact (basket only). Defaults to `<universe>.fits.json`.
-    #[arg(long)]
-    fit_artifact: Option<PathBuf>,
-
     /// Persisted basket engine state (basket only). Defaults to an isolated
     /// path under `<data-dir>/replay/<universe-stem>.state.json` so replay
     /// never reads or writes the live default `.state.json`.
@@ -215,10 +211,6 @@ struct ReplayArgs {
     /// Starting capital for the simulated broker (basket only, default 10000).
     #[arg(long, default_value_t = 10_000.0)]
     capital: f64,
-
-    /// Leverage multiplier for the simulated broker (basket only, default 4.0).
-    #[arg(long, default_value_t = 4.0)]
-    leverage: f64,
 
     /// Max active baskets (basket only, default 5).
     #[arg(long, default_value_t = 5)]
@@ -595,7 +587,6 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
         &clock,
         &mut session_trigger,
         &universe_path,
-        &fit_artifact_path,
         &state_path,
         &bars_dir,
         execution,
@@ -1276,11 +1267,6 @@ async fn run_basket_replay_live_path(args: ReplayArgs) {
             })
     });
 
-    let fit_artifact_path = args
-        .fit_artifact
-        .clone()
-        .unwrap_or_else(|| basket_fits::default_fit_artifact_path(&universe_path));
-
     // Replay state isolation: never touch the live default state path.
     let state_path = args.state_path.clone().unwrap_or_else(|| {
         let stem = universe_path
@@ -1342,16 +1328,6 @@ async fn run_basket_replay_live_path(args: ReplayArgs) {
         std::process::exit(1);
     }
 
-    let portfolio_config = basket_engine::PortfolioConfig {
-        capital: args.capital,
-        leverage: args.leverage,
-        n_active_baskets: args.n_active_baskets,
-    };
-    if let Err(e) = portfolio_config.validate() {
-        error!(error = %e, "invalid portfolio config");
-        std::process::exit(1);
-    }
-
     let universe = match basket_picker::load_universe(&universe_path) {
         Ok(u) => u,
         Err(e) => {
@@ -1360,23 +1336,38 @@ async fn run_basket_replay_live_path(args: ReplayArgs) {
         }
     };
 
-    let fit_artifact = match basket_fits::load_fit_artifact(&fit_artifact_path, &universe) {
-        Ok(a) => a,
-        Err(e) => {
-            error!(
-                error = %e,
-                fit_artifact = %fit_artifact_path.display(),
-                "failed to load frozen basket fit artifact"
-            );
-            error!(
-                "build it first with: openquant-runner freeze-basket-fits --universe {} --bars-dir {} --out {}",
-                universe_path.display(),
-                bars_dir.display(),
-                fit_artifact_path.display()
-            );
-            std::process::exit(1);
-        }
+    // Leverage comes from the universe TOML (`strategy.leverage_assumed`).
+    // Replay must use the same leverage the strategy was designed against;
+    // that's a config value, not a CLI knob.
+    let portfolio_config = basket_engine::PortfolioConfig {
+        capital: args.capital,
+        leverage: universe.strategy.leverage_assumed,
+        n_active_baskets: args.n_active_baskets,
     };
+    if let Err(e) = portfolio_config.validate() {
+        error!(error = %e, "invalid portfolio config");
+        std::process::exit(1);
+    }
+
+    // Walk-forward fit: build the basket fit using data STRICTLY BEFORE
+    // the replay window (`--start`). Without this, replay leaks future
+    // information into the fit and produces fantasy Sharpe numbers
+    // (#306 finding: a fit that overlapped the replay window by ~40%
+    // produced Sharpe 10.66; with strict OOS data the same window
+    // dropped to a realistic single-digit number).
+    info!(
+        as_of = %start,
+        residual_window_days = universe.strategy.residual_window_days,
+        "building replay fit from data strictly before --start"
+    );
+    let fit_artifact =
+        match basket_fits::build_replay_fit_artifact_as_of(&universe_path, &bars_dir, start) {
+            Ok(a) => a,
+            Err(e) => {
+                error!(error = %e, "failed to build replay fit artifact");
+                std::process::exit(1);
+            }
+        };
 
     let symbols: Vec<String> = {
         let mut s: Vec<String> = universe
@@ -1392,7 +1383,6 @@ async fn run_basket_replay_live_path(args: ReplayArgs) {
     info!(
         universe = %universe_path.display(),
         bars_dir = %bars_dir.display(),
-        fit_artifact = %fit_artifact_path.display(),
         state_path = %state_path.display(),
         start = %start,
         end = %end,
@@ -1437,7 +1427,6 @@ async fn run_basket_replay_live_path(args: ReplayArgs) {
         &clock,
         &mut session_trigger,
         &universe_path,
-        &fit_artifact_path,
         &state_path,
         &bars_dir,
         execution,


### PR DESCRIPTION
Closes part of #306. Refs #305.

## What was wrong

The previous replay path used a single **frozen fit artifact** computed from data through \"now\" (Apr 24, 2026). Replaying any window inside that 60-day fit period produced **fantasy Sharpe numbers** — Q1 2026 came back at **Sharpe 10.66** because ~40% of the replay window was inside the fit's training data. The model already \"knew\" Q1 2026's spreads when it was being asked to trade them.

## Walk-forward fix

\`replay --engine basket\` now **always auto-builds** its fit using data strictly before \`--start\`. The fit physically cannot see the data it's about to trade against.

| Q1 2026 | Sharpe | Cum return | Max DD | Notes |
|---|---|---|---|---|
| Before fix (leaky) | **10.66** | +104% | 2.06% | Fit overlapped replay window |
| After fix (walk-forward) | **3.24** | +27.7% | 6.26% | Fit cut at 2025-12-31 |

3.3× correction. Sharpe 3.24 is now in the same ballpark as quant-lab's full-sample Sharpe 2.80 baseline.

## Changes

- New \`basket_fits::build_replay_fit_artifact_as_of(as_of)\` — builds a fit using data strictly before \`as_of\`.
- New \`basket_live::load_warmup_closes_as_of(as_of)\` helper.
- **Bug fix** in \`load_daily_closes_with_timestamps\`: the lower-bound cutoff was anchored on \`Utc::now()\` while accepting \`max_day_inclusive\` for the upper bound. For replay's as-of cutoff this produced an empty intersection. Now anchors on \`max_day_inclusive\` when provided.
- \`WARMUP_DAYS\` bumped 90 → 180 calendar days. Validator needs ≥ 60 aligned spread points; 90 cal-days ≈ 62 trading days fell below the minimum after alignment dropped any day with a missing symbol. 180 cal-days ≈ 126 trading days is comfortable.
- When \`valid_count == 0\`, now logs per-reason rejection tallies so we see WHY fits failed instead of staring at \"no valid baskets in fit artifact\" blind.

## CLI cleanup

- **Drop \`--fit-artifact\`** from \`replay --engine basket\`. The replay path auto-fits; a stale frozen artifact would leak. Flag still exists on \`live\`/\`paper\` (those expect a curated artifact).
- **Drop \`--leverage\`** from \`replay --engine basket\`. Duplicates \`universe.strategy.leverage_assumed = 4.0\`. Replay must use the same leverage the strategy was designed against — that's config, not a CLI knob.
- \`run_basket_live\`: drop \`fit_artifact_path\` parameter (was only used for one info-log line).

## Q1 2026 walk-forward verification

\`\`\`
cum_return = +27.7%
ann_return = +108%
sharpe     = 3.24
max_dd     = 6.26%
daily_mean = +43 bps
daily_std  = +211 bps
divergence = 0
sessions   = 61
\`\`\`

## Test plan

- [x] \`cargo clippy --workspace -- -D warnings\` green
- [x] \`cargo test --workspace\` green
- [x] \`cargo fmt --all -- --check\` green
- [x] All 52 runner unit tests pass
- [x] End-to-end smoke run on Q1 2026 verified Sharpe dropped from 10.66 → 3.24 with fit cut at 2025-12-31

## Follow-ups

- True multi-refit walk-forward (refit every N sessions during replay) — currently the fit is built once at \`--start\` and used for the entire window. For long replays (1yr+) we'll want refit every 60 days. Filing as a separate ticket.
- Re-run Q3 2024 with walk-forward (the prior 0.62 Sharpe used a 21-month-stale frozen fit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)