### PR TITLE
Fix replay session-close race (SharedCloses leak)

### DIFF
--- a/engine/crates/runner/src/basket_journal.rs
+++ b/engine/crates/runner/src/basket_journal.rs
@@ -190,7 +190,10 @@ impl BasketJournal {
     }
 
     pub fn record_run(&self, rec: &BasketRunRecord<'_>) -> Result<(), String> {
-        let conn = self.conn.lock().map_err(|_| "basket journal mutex poisoned".to_string())?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|_| "basket journal mutex poisoned".to_string())?;
         conn.execute(
             "INSERT OR REPLACE INTO basket_runs (
                 run_id, started_at_utc, execution_mode, universe_path, fit_artifact_path,
@@ -219,7 +222,10 @@ impl BasketJournal {
     }
 
     pub fn record_session_close(&self, rec: &BasketSessionCloseRecord<'_>) -> Result<(), String> {
-        let conn = self.conn.lock().map_err(|_| "basket journal mutex poisoned".to_string())?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|_| "basket journal mutex poisoned".to_string())?;
         conn.execute(
             "INSERT INTO basket_session_closes (
                 run_id, trading_day, status, closes_received, symbols_expected,
@@ -289,7 +295,10 @@ impl BasketJournal {
     }
 
     pub fn record_order_event(&self, rec: &BasketOrderEvent<'_>) -> Result<(), String> {
-        let conn = self.conn.lock().map_err(|_| "basket journal mutex poisoned".to_string())?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|_| "basket journal mutex poisoned".to_string())?;
         conn.execute(
             "INSERT INTO basket_order_events (
                 run_id, trading_day, seq, symbol, side, requested_qty, intended_notional,
@@ -415,7 +424,9 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM basket_runs", [], |r| r.get(0))
             .unwrap();
         let sessions: i64 = conn
-            .query_row("SELECT COUNT(*) FROM basket_session_closes", [], |r| r.get(0))
+            .query_row("SELECT COUNT(*) FROM basket_session_closes", [], |r| {
+                r.get(0)
+            })
             .unwrap();
         let orders: i64 = conn
             .query_row("SELECT COUNT(*) FROM basket_order_events", [], |r| r.get(0))

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -733,6 +733,21 @@ pub async fn run_basket_live(
                         last_processed = ?last_processed_trading_day,
                         "persisted basket engine state after session close"
                     );
+                    // Ack to the session trigger that this session is
+                    // FULLY processed — fills, EOD valuation, state
+                    // save are all done. Replay's
+                    // `BarDrivenSessionTrigger` uses this to release
+                    // the bar emitter, which has been blocked from
+                    // overwriting `SharedCloses` with the next day's
+                    // prices while we ran. Live's
+                    // `IntervalSessionTrigger` no-ops the ack.
+                    //
+                    // Failure paths above (the `?` operators on
+                    // process_session_close and save_state) skip
+                    // this ack on purpose: the runner will exit, the
+                    // trigger's `done_tx` drops, and the emitter
+                    // sees `None` from `done_rx.recv()` and unwinds.
+                    session_trigger.ack_session_processed().await;
                 }
             }
             _ = &mut ctrl_c => {

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -38,11 +38,11 @@ use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use tracing::{debug, error, info, warn};
 
 use crate::alpaca::ExecutionMode;
-use crate::basket_journal::{
-    serialize_shares_map, serialize_string_vec, BasketJournal, BasketOrderEvent,
-    BasketRunRecord, BasketSessionCloseRecord,
-};
 use crate::bar_source::BarSource;
+use crate::basket_journal::{
+    serialize_shares_map, serialize_string_vec, BasketJournal, BasketOrderEvent, BasketRunRecord,
+    BasketSessionCloseRecord,
+};
 use crate::broker::Broker;
 use crate::clock::Clock;
 use crate::market_session;
@@ -431,7 +431,10 @@ pub async fn run_basket_live(
     };
     let run_id = format!(
         "{}-{}",
-        execution.label().to_ascii_lowercase().replace([' ', '(', ')'], "-"),
+        execution
+            .label()
+            .to_ascii_lowercase()
+            .replace([' ', '(', ')'], "-"),
         now.timestamp_millis()
     );
     info!(
@@ -656,7 +659,27 @@ pub async fn run_basket_live(
                         break;
                     }
                 };
-                if !processed_sessions.contains(&today) {
+                // EVERY session_event MUST end with `ack_session_processed`
+                // so the bar emitter (blocked on `done_rx.recv()` after
+                // `session_tx.send(date)`) can resume. Skipping the ack
+                // — even on dedup or non-trading days — hangs replay
+                // forever (codex review on PR #322). The labeled block
+                // gives every short-circuit path a single fall-through
+                // point. The only paths that can skip the ack are the
+                // `return Err(...)` failures below: those drop the
+                // trigger, the emitter sees `None` from
+                // `done_rx.recv()`, and the run unwinds cleanly.
+                'session: {
+                    if processed_sessions.contains(&today) {
+                        // Resume case (state on disk had this date): the
+                        // emitter still drives session_tx for D, so we
+                        // must still ack.
+                        info!(
+                            date = %today,
+                            "session-close event for already-processed date — acknowledging without rerun"
+                        );
+                        break 'session;
+                    }
                     let closes_for_day = day_closes.remove(&today).unwrap_or_default();
                     if closes_for_day.is_empty() {
                         if !market_session::is_trading_day(today) {
@@ -665,7 +688,7 @@ pub async fn run_basket_live(
                                 "session close grace elapsed on non-trading day with zero buffered closes — marking processed"
                             );
                             processed_sessions.insert(today);
-                            continue;
+                            break 'session;
                         }
                         error!(
                             date = %today,
@@ -733,22 +756,13 @@ pub async fn run_basket_live(
                         last_processed = ?last_processed_trading_day,
                         "persisted basket engine state after session close"
                     );
-                    // Ack to the session trigger that this session is
-                    // FULLY processed — fills, EOD valuation, state
-                    // save are all done. Replay's
-                    // `BarDrivenSessionTrigger` uses this to release
-                    // the bar emitter, which has been blocked from
-                    // overwriting `SharedCloses` with the next day's
-                    // prices while we ran. Live's
-                    // `IntervalSessionTrigger` no-ops the ack.
-                    //
-                    // Failure paths above (the `?` operators on
-                    // process_session_close and save_state) skip
-                    // this ack on purpose: the runner will exit, the
-                    // trigger's `done_tx` drops, and the emitter
-                    // sees `None` from `done_rx.recv()` and unwinds.
-                    session_trigger.ack_session_processed().await;
                 }
+                // Replay's `BarDrivenSessionTrigger` uses this to
+                // release the bar emitter, which has been blocked
+                // from overwriting `SharedCloses` with the next day's
+                // prices while we ran. Live's
+                // `IntervalSessionTrigger` no-ops the ack.
+                session_trigger.ack_session_processed().await;
             }
             _ = &mut ctrl_c => {
                 info!(
@@ -1322,7 +1336,11 @@ async fn process_session_close(
                     journal.record_session_close(&BasketSessionCloseRecord {
                         run_id,
                         trading_day: date,
-                        status: if failed_orders == 0 { "submitted" } else { "partial_failure" },
+                        status: if failed_orders == 0 {
+                            "submitted"
+                        } else {
+                            "partial_failure"
+                        },
                         closes_received: closes.len(),
                         symbols_expected: closes.len(),
                         active_baskets: plan.active_baskets,

--- a/engine/crates/runner/src/parquet_bar_source.rs
+++ b/engine/crates/runner/src/parquet_bar_source.rs
@@ -190,7 +190,7 @@ async fn emit_loop(
     end: NaiveDate,
     symbols: &[String],
     bar_tx: mpsc::Sender<StreamBar>,
-    channels: ReplayChannels,
+    mut channels: ReplayChannels,
     closes: SharedCloses,
 ) -> Result<(), String> {
     info!(
@@ -270,10 +270,22 @@ async fn emit_loop(
         let bar_date = market_session::trading_day_utc(dt_open);
 
         // If we've crossed a date boundary, signal the previous date's
-        // session close (after the consumer has drained the channel).
+        // session close, then BLOCK on the consumer's ack before
+        // resuming. The ack is the gate that keeps `SharedCloses`
+        // frozen at prev_date's last close while the consumer's
+        // `process_session_close` fills + record_eod read prices.
+        // Without this gate, every emitter advance below would
+        // overwrite SharedCloses with the next day's prices and
+        // races would land fills at prices the engine never saw.
         if let Some(prev_date) = current_date {
             if bar_date != prev_date {
-                drain_then_signal(&bar_tx, &channels.session_tx, prev_date).await;
+                drain_signal_and_wait_ack(
+                    &bar_tx,
+                    &channels.session_tx,
+                    &mut channels.done_rx,
+                    prev_date,
+                )
+                .await;
             }
         }
         current_date = Some(bar_date);
@@ -310,9 +322,18 @@ async fn emit_loop(
         bars_emitted += 1;
     }
 
-    // Final session: signal close for the last date.
+    // Final session: signal close for the last date AND wait for the
+    // consumer's ack so the final session's fills + record_eod
+    // happen against the last day's snapshot, not a half-overwritten
+    // SharedCloses.
     if let Some(last_date) = current_date {
-        drain_then_signal(&bar_tx, &channels.session_tx, last_date).await;
+        drain_signal_and_wait_ack(
+            &bar_tx,
+            &channels.session_tx,
+            &mut channels.done_rx,
+            last_date,
+        )
+        .await;
     }
 
     info!(bars_emitted, "replay emit loop drained");
@@ -321,14 +342,27 @@ async fn emit_loop(
     Ok(())
 }
 
-/// Wait for the bar channel to drain, then signal the session-close
-/// trigger for `date`. The `select! { biased; ... }` on the consumer
-/// side already prefers bars over session events, but explicitly
-/// waiting until the channel is empty makes the ordering invariant
-/// independent of consumer-side biasing.
-async fn drain_then_signal(
+/// Wait for the bar channel to drain, signal the session-close trigger
+/// for `date`, then BLOCK until the consumer acks "session-close fully
+/// processed."
+///
+/// The ack closes a race that produced ~$15 cash drift across
+/// otherwise-identical replay runs (#321 investigation). Pre-fix:
+/// after `session_tx.send(D)` the emitter immediately advanced and
+/// overwrote `SharedCloses` with bars from D+1; the consumer's
+/// `process_session_close` for D then read those D+1 prices on
+/// fills. Different tokio scheduling produced different drift
+/// per run.
+///
+/// Post-fix: the emitter blocks on `done_rx.recv()` until the
+/// consumer signals (via `BarDrivenSessionTrigger::ack_session_processed`)
+/// that fills + EOD valuation are complete against the day's
+/// snapshot. Until then `SharedCloses` is guaranteed to hold
+/// exactly D's last-RTH-bar closes.
+async fn drain_signal_and_wait_ack(
     bar_tx: &mpsc::Sender<StreamBar>,
     session_tx: &mpsc::Sender<NaiveDate>,
+    done_rx: &mut mpsc::Receiver<()>,
     date: NaiveDate,
 ) {
     while bar_tx.capacity() < bar_tx.max_capacity() {
@@ -337,6 +371,13 @@ async fn drain_then_signal(
     }
     if let Err(e) = session_tx.send(date).await {
         debug!(error = %e, "session-close signal dropped (consumer gone)");
+        return;
+    }
+    // Block on the ack. `None` means the consumer dropped its sender —
+    // either Ctrl+C / panic / replay exit. Either way there's no point
+    // continuing to emit bars; let the emit loop unwind.
+    if done_rx.recv().await.is_none() {
+        debug!("session-done ack channel closed; consumer has exited");
     }
 }
 

--- a/engine/crates/runner/src/replay_clock.rs
+++ b/engine/crates/runner/src/replay_clock.rs
@@ -51,13 +51,32 @@ impl Clock for BarDrivenClock {
 ///
 /// Returns `None` when the channel is closed by the bar source — that
 /// is `basket_live`'s exit condition for replay.
+///
+/// `done_tx` is the back-channel the consumer signals on after it
+/// finishes `process_session_close` + `record_eod` for the just-
+/// returned date. The bar source's emit loop blocks on the
+/// corresponding receiver after each `session_tx.send`, so
+/// `SharedCloses` cannot be overwritten with the next day's bars
+/// until the consumer's fills and EOD valuation are done. This
+/// closes the race that produced ~$15 cash drift across replay
+/// runs (#321 investigation).
 pub struct BarDrivenSessionTrigger {
     rx: mpsc::Receiver<NaiveDate>,
+    done_tx: mpsc::Sender<()>,
 }
 
 impl SessionTrigger for BarDrivenSessionTrigger {
     async fn next(&mut self) -> Option<NaiveDate> {
         self.rx.recv().await
+    }
+
+    async fn ack_session_processed(&mut self) {
+        // Tell the bar emitter "session-close fully done — you may
+        // resume advancing SharedCloses." Channel cap=1 so the send
+        // is a strict handshake; the emitter is awaiting the recv
+        // and a second send would only happen after the next
+        // session_tx.send.
+        let _ = self.done_tx.send(()).await;
     }
 }
 
@@ -68,6 +87,14 @@ impl SessionTrigger for BarDrivenSessionTrigger {
 pub(crate) struct ReplayChannels {
     pub clock_tx: watch::Sender<DateTime<Utc>>,
     pub session_tx: mpsc::Sender<NaiveDate>,
+    /// Receiver the bar emitter awaits on after each `session_tx.send`.
+    /// The consumer (basket_live) signals via
+    /// `BarDrivenSessionTrigger::ack_session_processed` once
+    /// `process_session_close` + `record_eod` are complete. Until then
+    /// the emitter MUST NOT advance — every advance writes the next
+    /// day's prices into the broker-shared `SharedCloses`, which would
+    /// race with the consumer's fills.
+    pub done_rx: mpsc::Receiver<()>,
 }
 
 pub(crate) fn make_replay_clock_and_trigger(
@@ -75,12 +102,76 @@ pub(crate) fn make_replay_clock_and_trigger(
 ) -> (BarDrivenClock, BarDrivenSessionTrigger, ReplayChannels) {
     let (clock_tx, clock_rx) = watch::channel(initial_time);
     let (session_tx, session_rx) = mpsc::channel(8);
+    // cap=1: each session-close is a strict handshake. The emitter
+    // sends `session_tx.send(date)`, then awaits `done_rx.recv()`.
+    // The consumer pulls `session_rx`, processes the close, then
+    // sends to `done_tx`. A larger buffer would allow the emitter
+    // to race ahead which is exactly what we're trying to prevent.
+    let (done_tx, done_rx) = mpsc::channel::<()>(1);
     (
         BarDrivenClock { rx: clock_rx },
-        BarDrivenSessionTrigger { rx: session_rx },
+        BarDrivenSessionTrigger {
+            rx: session_rx,
+            done_tx,
+        },
         ReplayChannels {
             clock_tx,
             session_tx,
+            done_rx,
         },
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    /// `BarDrivenSessionTrigger::ack_session_processed` must end up on
+    /// `ReplayChannels::done_rx`. This is the back-channel that gates
+    /// the bar emitter from advancing past a session-close until the
+    /// consumer's fills + EOD valuation are done. If the wiring breaks,
+    /// emit_loop blocks forever on the missing ack and the race
+    /// (#321) silently comes back.
+    #[tokio::test]
+    async fn ack_drives_done_channel() {
+        let initial = Utc.with_ymd_and_hms(2026, 1, 2, 14, 30, 0).unwrap();
+        let (_clock, mut trigger, mut channels) = make_replay_clock_and_trigger(initial);
+
+        // Pre-ack: nothing is on the done channel.
+        assert!(
+            channels.done_rx.try_recv().is_err(),
+            "done channel should be empty before first ack"
+        );
+
+        // Consumer signals done → emitter should observe it.
+        trigger.ack_session_processed().await;
+        let received = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            channels.done_rx.recv(),
+        )
+        .await
+        .expect("ack should arrive within the test timeout");
+        assert_eq!(received, Some(()), "exactly one ack per call");
+
+        // After consume, channel is empty again.
+        assert!(
+            channels.done_rx.try_recv().is_err(),
+            "done channel should be drained after the receiver pulled it"
+        );
+    }
+
+    /// If the consumer (`ReplayChannels::done_rx`) is dropped, the
+    /// trigger's `ack_session_processed` swallows the send error
+    /// rather than panicking. emit_loop's `done_rx.recv()` will
+    /// return `None` instead, which is the documented "consumer gone,
+    /// unwind" path.
+    #[tokio::test]
+    async fn ack_does_not_panic_when_emitter_gone() {
+        let initial = Utc.with_ymd_and_hms(2026, 1, 2, 14, 30, 0).unwrap();
+        let (_clock, mut trigger, channels) = make_replay_clock_and_trigger(initial);
+        drop(channels); // simulate emitter task exiting / panicking
+        // Should not panic.
+        trigger.ack_session_processed().await;
+    }
 }

--- a/engine/crates/runner/src/replay_clock.rs
+++ b/engine/crates/runner/src/replay_clock.rs
@@ -146,12 +146,10 @@ mod tests {
 
         // Consumer signals done → emitter should observe it.
         trigger.ack_session_processed().await;
-        let received = tokio::time::timeout(
-            std::time::Duration::from_secs(1),
-            channels.done_rx.recv(),
-        )
-        .await
-        .expect("ack should arrive within the test timeout");
+        let received =
+            tokio::time::timeout(std::time::Duration::from_secs(1), channels.done_rx.recv())
+                .await
+                .expect("ack should arrive within the test timeout");
         assert_eq!(received, Some(()), "exactly one ack per call");
 
         // After consume, channel is empty again.
@@ -171,7 +169,7 @@ mod tests {
         let initial = Utc.with_ymd_and_hms(2026, 1, 2, 14, 30, 0).unwrap();
         let (_clock, mut trigger, channels) = make_replay_clock_and_trigger(initial);
         drop(channels); // simulate emitter task exiting / panicking
-        // Should not panic.
+                        // Should not panic.
         trigger.ack_session_processed().await;
     }
 }

--- a/engine/crates/runner/src/session_trigger.rs
+++ b/engine/crates/runner/src/session_trigger.rs
@@ -29,6 +29,22 @@ pub trait SessionTrigger: Send + Sync {
     /// date that just closed, or `None` if no further sessions will
     /// arrive (replay exhausted).
     async fn next(&mut self) -> Option<NaiveDate>;
+
+    /// Acknowledge that the consumer has fully finished processing the
+    /// session returned by the most recent `next()` call (engine
+    /// `on_bars`, fills, EOD valuation, state save).
+    ///
+    /// Replay implementations use this as a back-pressure signal to
+    /// the bar emitter — the emitter MUST NOT advance past the
+    /// just-closed session's last bar (and overwrite `SharedCloses`
+    /// with the next day's prices) until the consumer's fills are
+    /// done against the day's snapshot. Without this gate, the
+    /// emitter races the consumer at session-close, and fills can
+    /// land at next-day prices the engine never saw.
+    ///
+    /// Live implementations no-op — there is no shared mutable price
+    /// state between a wall-clock trigger and the broker.
+    async fn ack_session_processed(&mut self) {}
 }
 
 /// Production trigger — polls the clock on a 30s wall-clock interval.


### PR DESCRIPTION
## Summary

Replay had a session-close race that produced ~$15 cash drift between identical runs, varying with tokio scheduling. Smoke matrix on FAANG / 2025-07-01..2025-07-03 (3-day window):

| matrix | distinct outputs | example drift |
|---|---|---|
| pre-fix sequential ×3 | 2 | Sharpe -6.55 vs -10.70 |
| pre-fix parallel ×3 | 2 | cash $14.49 |
| **post-fix all 6** | **1** | byte-identical (md5 ×6) |

## Cause

`SimulatedBroker.fill_price()` reads `SharedCloses` at fill time, but the bar emitter task keeps writing to `SharedCloses` while the consumer awaits inside `process_session_close` (seed_current_shares, place_order, the 30s post-submit reconciliation sleep). Each `.await` is a yield point where the emitter advances and overwrites `SharedCloses` with bars from the *next* day. Fills then land at prices the engine never saw.

The simulated_broker docstring already claimed the intended contract — "Fills happen at the latest known close … the close from the bar that triggered the session-close cycle" — but the implementation didn't enforce it across yield points.

## Fix

Add a back-channel `done_rx` from the consumer to the bar emitter:

- `SessionTrigger::ack_session_processed(&mut self)` — new trait method, default no-op for live's `IntervalSessionTrigger`. `BarDrivenSessionTrigger` overrides to send `()` on a cap=1 mpsc channel.
- `parquet_bar_source::emit_loop` calls the renamed `drain_signal_and_wait_ack` at every date-cross AND at replay exhaustion. The emitter now blocks on `done_rx.recv()` after each `session_tx.send(date)`, so `SharedCloses` stays frozen at D's last close until the consumer signals "fills + record_eod + save_state are all done."
- `basket_live`'s session_event arm calls `session_trigger.ack_session_processed().await` after `engine.save_state_with_day(...)` succeeds. Failure paths (the `?` operators) skip the ack on purpose: the runner exits, `done_tx` drops, the emitter sees `None` from `done_rx.recv()` and unwinds cleanly.

## Live impact

None. The default `ack_session_processed` is a no-op, and only `BarDrivenSessionTrigger` (replay-only) overrides it. Live/paper uses `IntervalSessionTrigger` on the wall-clock path — no behavior change.

## Test plan

- [x] `replay_clock::tests::ack_drives_done_channel` — pins the ack→done_rx wiring so a future refactor can't silently regress the race.
- [x] `replay_clock::tests::ack_does_not_panic_when_emitter_gone` — consumer-survives-emitter-exit invariant.
- [x] All existing 55 runner unit tests still pass.
- [x] 6-run smoke matrix (3 sequential + 3 parallel) on FAANG / Q3-start-3-day window: all byte-identical.
- [ ] CI: cargo fmt --check, cargo clippy -D warnings, cargo test --workspace.

## Why this matters

Found while investigating issue #321 (decision-time / snapshot-robustness experiment). Without this fix, the experiment's 4-variant Sharpe comparison is dominated by ~3-4 Sharpe-points of replay noise, swamping any real offset effect. With it, replay is bit-exact reproducible — sequential and parallel.

This bug also retroactively adds a noise floor to **every existing autoresearch result** that ran through this code path (the entire monetization-matrix sweep, λ-sweeps, etc.). The signal in those experiments is real, but quoted Sharpes have ≥0.5 of noise we didn't know about until now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)