### PR TITLE
runner: add paper-safe leadership overlay for basket mode

### DIFF
--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -25,7 +25,7 @@
 //!   - `Paper`: paper-api.alpaca.markets (paper money).
 //!   - `Live`: api.alpaca.markets (real money). Gated behind explicit opt-in.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
@@ -107,6 +107,7 @@ impl StartupPhase {
 pub struct BasketRunOptions {
     pub fit_artifact_path: Option<PathBuf>,
     pub journal_path: Option<PathBuf>,
+    pub leadership_overlay: Option<LeadershipOverlayConfig>,
 }
 
 // Grace period after session close before firing the engine. Lets
@@ -123,6 +124,187 @@ enum StartupStateSource {
     Snapshot,
     BrokerReconciled,
     Fresh,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LeadershipOverlayMode {
+    SuppressShorts,
+    ReplaceWithLongOnly,
+}
+
+#[derive(Debug, Clone)]
+pub struct LeadershipOverlayConfig {
+    pub sectors: Vec<String>,
+    pub ret5d_threshold: f64,
+    pub breadth5d_threshold: f64,
+    pub mode: LeadershipOverlayMode,
+    pub long_only_leverage: f64,
+}
+
+#[derive(Debug, Clone, Default)]
+struct SectorLeadershipSnapshot {
+    active_sectors: HashSet<String>,
+}
+
+#[derive(Debug, Clone)]
+struct SectorLeadershipTracker {
+    config: LeadershipOverlayConfig,
+    sector_members: HashMap<String, Vec<String>>,
+    prev_closes: Option<HashMap<String, f64>>,
+    sector_returns: HashMap<String, VecDeque<f64>>,
+    sector_breadths: HashMap<String, VecDeque<f64>>,
+    last_snapshot: SectorLeadershipSnapshot,
+}
+
+impl SectorLeadershipTracker {
+    fn new(config: LeadershipOverlayConfig, sector_members: HashMap<String, Vec<String>>) -> Self {
+        let mut sector_returns = HashMap::new();
+        let mut sector_breadths = HashMap::new();
+        for sector in &config.sectors {
+            sector_returns.insert(sector.clone(), VecDeque::with_capacity(5));
+            sector_breadths.insert(sector.clone(), VecDeque::with_capacity(5));
+        }
+        Self {
+            config,
+            sector_members,
+            prev_closes: None,
+            sector_returns,
+            sector_breadths,
+            last_snapshot: SectorLeadershipSnapshot::default(),
+        }
+    }
+
+    fn active_sectors_for_today(&self) -> &HashSet<String> {
+        &self.last_snapshot.active_sectors
+    }
+
+    fn active_symbols_for_today(&self) -> Vec<String> {
+        let mut symbols: Vec<String> = self
+            .last_snapshot
+            .active_sectors
+            .iter()
+            .filter_map(|sector| self.sector_members.get(sector))
+            .flat_map(|members| members.iter().cloned())
+            .collect();
+        symbols.sort();
+        symbols.dedup();
+        symbols
+    }
+
+    fn observe_close_snapshot(&mut self, closes: &HashMap<String, f64>) {
+        let Some(prev) = &self.prev_closes else {
+            self.prev_closes = Some(closes.clone());
+            return;
+        };
+        let mut next_active = HashSet::new();
+        for sector in &self.config.sectors {
+            let Some(members) = self.sector_members.get(sector) else {
+                continue;
+            };
+            let mut rets = Vec::new();
+            let mut up = 0usize;
+            let mut total = 0usize;
+            for symbol in members {
+                let Some(&close) = closes.get(symbol) else {
+                    continue;
+                };
+                let Some(&prev_close) = prev.get(symbol) else {
+                    continue;
+                };
+                if !close.is_finite()
+                    || !prev_close.is_finite()
+                    || close <= 0.0
+                    || prev_close <= 0.0
+                {
+                    continue;
+                }
+                let ret = close / prev_close - 1.0;
+                rets.push(ret);
+                total += 1;
+                if ret > 0.0 {
+                    up += 1;
+                }
+            }
+            if rets.is_empty() || total == 0 {
+                continue;
+            }
+            let ew_ret = rets.iter().sum::<f64>() / rets.len() as f64;
+            let breadth = up as f64 / total as f64;
+            let hist_rets = self.sector_returns.entry(sector.clone()).or_default();
+            let hist_breadths = self.sector_breadths.entry(sector.clone()).or_default();
+            hist_rets.push_back(ew_ret);
+            hist_breadths.push_back(breadth);
+            while hist_rets.len() > 5 {
+                hist_rets.pop_front();
+            }
+            while hist_breadths.len() > 5 {
+                hist_breadths.pop_front();
+            }
+            if hist_rets.len() == 5 && hist_breadths.len() == 5 {
+                let ret5d = hist_rets.iter().fold(1.0_f64, |acc, r| acc * (1.0 + r)) - 1.0;
+                let breadth5d = hist_breadths.iter().sum::<f64>() / hist_breadths.len() as f64;
+                if ret5d > self.config.ret5d_threshold
+                    && breadth5d > self.config.breadth5d_threshold
+                {
+                    next_active.insert(sector.clone());
+                }
+            }
+        }
+        self.last_snapshot = SectorLeadershipSnapshot {
+            active_sectors: next_active,
+        };
+        self.prev_closes = Some(closes.clone());
+    }
+}
+
+fn basket_sector(basket_id: &str) -> &str {
+    basket_id.split(':').next().unwrap_or(basket_id)
+}
+
+fn apply_leadership_short_suppression(
+    engine: &mut basket_engine::BasketEngine,
+    active_sectors: &HashSet<String>,
+) -> Vec<String> {
+    if active_sectors.is_empty() {
+        return Vec::new();
+    }
+    let mut suppressed = Vec::new();
+    for (basket_id, _params) in engine.iter_params() {
+        if !active_sectors.contains(basket_sector(basket_id)) {
+            continue;
+        }
+        let Some(state) = engine.get_state(basket_id) else {
+            continue;
+        };
+        if state.position < 0 {
+            suppressed.push(basket_id.clone());
+        }
+    }
+    if !suppressed.is_empty() {
+        engine.flatten_baskets(&suppressed);
+    }
+    suppressed
+}
+
+fn leadership_long_only_notionals(
+    closes: &HashMap<String, f64>,
+    symbols: &[String],
+    capital: f64,
+    leverage: f64,
+) -> HashMap<String, f64> {
+    let active_symbols: Vec<&String> = symbols
+        .iter()
+        .filter(|symbol| matches!(closes.get(*symbol), Some(price) if price.is_finite() && *price > 0.0))
+        .collect();
+    if active_symbols.is_empty() || !capital.is_finite() || !leverage.is_finite() || leverage <= 0.0
+    {
+        return HashMap::new();
+    }
+    let per_symbol = capital * leverage / active_symbols.len() as f64;
+    active_symbols
+        .into_iter()
+        .map(|symbol| (symbol.clone(), per_symbol))
+        .collect()
 }
 
 async fn preflight_account_check(broker: &impl Broker, mode: ExecutionMode) -> Result<(), String> {
@@ -339,6 +521,11 @@ pub async fn run_basket_live(
     );
 
     let symbols = collect_symbols(&universe);
+    let sector_members: HashMap<String, Vec<String>> = universe
+        .sectors
+        .iter()
+        .map(|(name, sector)| (name.clone(), sector.members.clone()))
+        .collect();
     info!(
         symbols = symbols.len(),
         fits = fits.len(),
@@ -398,6 +585,23 @@ pub async fn run_basket_live(
             &current_shares,
             execution.alpaca_mode().is_some(),
         )?;
+    let mut leadership_tracker = options
+        .leadership_overlay
+        .clone()
+        .map(|cfg| SectorLeadershipTracker::new(cfg, sector_members));
+    if let Some(cfg) = options.leadership_overlay.as_ref() {
+        info!(
+            sectors = ?cfg.sectors,
+            ret5d_threshold = cfg.ret5d_threshold,
+            breadth5d_threshold = cfg.breadth5d_threshold,
+            mode = match cfg.mode {
+                LeadershipOverlayMode::SuppressShorts => "suppress_shorts",
+                LeadershipOverlayMode::ReplaceWithLongOnly => "replace_with_long_only",
+            },
+            long_only_leverage = cfg.long_only_leverage,
+            "leadership_overlay ENABLED — replay may alter basket behavior in flagged sectors"
+        );
+    }
 
     let startup_phase = classify_startup_phase(now, last_processed_trading_day, CLOSE_GRACE_MIN);
     let journal = match options.journal_path.as_deref() {
@@ -476,8 +680,20 @@ pub async fn run_basket_live(
             execution,
             journal.as_ref(),
             run_id.as_str(),
+            leadership_tracker
+                .as_ref()
+                .map(|t| t.active_sectors_for_today().clone())
+                .unwrap_or_default(),
+            leadership_tracker
+                .as_ref()
+                .map(|t| t.active_symbols_for_today())
+                .unwrap_or_default(),
+            options.leadership_overlay.as_ref(),
         )
         .await?;
+        if let Some(tracker) = leadership_tracker.as_mut() {
+            tracker.observe_close_snapshot(&catchup_closes);
+        }
         // Hook for replay's daily-equity time series. Noop on AlpacaClient.
         broker.record_eod(today).await;
         last_processed_trading_day = Some(today);
@@ -719,8 +935,20 @@ pub async fn run_basket_live(
                         execution,
                         journal.as_ref(),
                         run_id.as_str(),
+                        leadership_tracker
+                            .as_ref()
+                            .map(|t| t.active_sectors_for_today().clone())
+                            .unwrap_or_default(),
+                        leadership_tracker
+                            .as_ref()
+                            .map(|t| t.active_symbols_for_today())
+                            .unwrap_or_default(),
+                        options.leadership_overlay.as_ref(),
                     )
                     .await?;
+                    if let Some(tracker) = leadership_tracker.as_mut() {
+                        tracker.observe_close_snapshot(&closes_for_day);
+                    }
                     // Hook for replay's daily-equity time series.
                     // Noop on AlpacaClient.
                     broker.record_eod(today).await;
@@ -1010,6 +1238,9 @@ async fn process_session_close(
     execution: BasketExecution,
     journal: Option<&BasketJournal>,
     run_id: &str,
+    leadership_active_sectors: HashSet<String>,
+    leadership_long_symbols: Vec<String>,
+    leadership_overlay: Option<&LeadershipOverlayConfig>,
 ) -> Result<(), String> {
     debug_assert!(
         portfolio_config.validate().is_ok(),
@@ -1042,6 +1273,22 @@ async fn process_session_close(
         log_intent(intent);
     }
 
+    if matches!(
+        leadership_overlay.map(|cfg| cfg.mode),
+        Some(LeadershipOverlayMode::SuppressShorts)
+    ) {
+        let suppressed_baskets =
+            apply_leadership_short_suppression(engine, &leadership_active_sectors);
+        if !suppressed_baskets.is_empty() {
+            info!(
+                date = %date,
+                leadership_active_sectors = ?leadership_active_sectors,
+                suppressed_baskets = ?suppressed_baskets,
+                "leadership short suppression flattened active shorts in flagged sectors"
+            );
+        }
+    }
+
     let allowed_symbols: Vec<String> = closes.keys().cloned().collect();
     if let Some(mode) = execution.alpaca_mode() {
         *current_shares = seed_current_shares_from_alpaca(broker, mode, &allowed_symbols).await?;
@@ -1056,8 +1303,23 @@ async fn process_session_close(
     // Portfolio layer: apply active-basket admission first, then convert
     // admitted target notionals to target shares.
     let plan = plan_portfolio(engine, portfolio_config);
-    let target_notionals = plan.symbol_notionals;
-    if !plan.excluded_baskets.is_empty() {
+    let using_long_replacement = matches!(
+        leadership_overlay.map(|cfg| cfg.mode),
+        Some(LeadershipOverlayMode::ReplaceWithLongOnly)
+    ) && !leadership_long_symbols.is_empty();
+    let target_notionals = if using_long_replacement {
+        leadership_long_only_notionals(
+            closes,
+            &leadership_long_symbols,
+            portfolio_config.capital,
+            leadership_overlay
+                .map(|cfg| cfg.long_only_leverage)
+                .unwrap_or(1.0),
+        )
+    } else {
+        plan.symbol_notionals.clone()
+    };
+    if !using_long_replacement && !plan.excluded_baskets.is_empty() {
         engine.flatten_baskets(&plan.excluded_baskets);
     }
     let target_shares = target_shares_from_notionals(&target_notionals, closes)?;
@@ -1082,6 +1344,14 @@ async fn process_session_close(
     let target_positions_len = target_shares.len();
     info!(
         date = %date,
+        leadership_mode = match leadership_overlay.map(|cfg| cfg.mode) {
+            Some(LeadershipOverlayMode::SuppressShorts) => "suppress_shorts",
+            Some(LeadershipOverlayMode::ReplaceWithLongOnly) if using_long_replacement => "replace_with_long_only",
+            Some(LeadershipOverlayMode::ReplaceWithLongOnly) => "replace_with_long_only_inactive",
+            None => "disabled",
+        },
+        leadership_sectors_active = ?leadership_active_sectors,
+        leadership_symbols_active = leadership_long_symbols.len(),
         targets = target_notionals.len(),
         target_positions = target_shares.len(),
         current_positions = current_shares.len(),
@@ -1108,7 +1378,7 @@ async fn process_session_close(
             admitted = plan.selected_baskets.len(),
             excluded = plan.excluded_baskets.len(),
             excluded_sample = ?plan.excluded_baskets.iter().take(10).collect::<Vec<_>>(),
-            "active-basket cap excluded baskets from the target portfolio"
+            "active-basket cap excluded baskets from the baseline target portfolio"
         );
     } else {
         info!(
@@ -1954,6 +2224,90 @@ mod tests {
         let shares = target_shares_from_notionals(&notionals, &closes).unwrap();
         assert_eq!(shares.get("AMD").copied(), Some(50.0));
         assert_eq!(shares.get("NVDA").copied(), Some(-12.0));
+    }
+
+    #[test]
+    fn test_apply_leadership_short_suppression_flattens_only_flagged_shorts() {
+        let fits = make_test_fits();
+        let mut engine = BasketEngine::new(&fits);
+        let states = HashMap::from([
+            (
+                fits[0].candidate.id(),
+                basket_engine::BasketState {
+                    position: -1,
+                    ..Default::default()
+                },
+            ),
+            (
+                fits[1].candidate.id(),
+                basket_engine::BasketState {
+                    position: 1,
+                    ..Default::default()
+                },
+            ),
+        ]);
+        engine.apply_states(states).unwrap();
+        let suppressed =
+            apply_leadership_short_suppression(&mut engine, &HashSet::from(["chips".to_string()]));
+        assert_eq!(suppressed.len(), 1);
+        assert_eq!(basket_sector(&suppressed[0]), "chips");
+        assert_eq!(
+            engine.get_state(&fits[0].candidate.id()).unwrap().position,
+            0
+        );
+        assert_eq!(
+            engine.get_state(&fits[1].candidate.id()).unwrap().position,
+            1
+        );
+    }
+
+    #[test]
+    fn test_sector_leadership_tracker_activates_lagged_sector_flag() {
+        let config = LeadershipOverlayConfig {
+            sectors: vec!["chips".to_string()],
+            ret5d_threshold: 0.02,
+            breadth5d_threshold: 0.55,
+            mode: LeadershipOverlayMode::SuppressShorts,
+            long_only_leverage: 1.0,
+        };
+        let mut tracker = SectorLeadershipTracker::new(
+            config,
+            HashMap::from([(
+                "chips".to_string(),
+                vec!["AMD".to_string(), "NVDA".to_string(), "INTC".to_string()],
+            )]),
+        );
+        let days = [
+            [100.0, 100.0, 100.0],
+            [101.0, 101.0, 100.0],
+            [102.0, 102.0, 101.0],
+            [103.0, 103.0, 102.0],
+            [104.0, 104.0, 103.0],
+            [105.0, 105.0, 104.0],
+        ];
+        for day in days {
+            tracker.observe_close_snapshot(&HashMap::from([
+                ("AMD".to_string(), day[0]),
+                ("NVDA".to_string(), day[1]),
+                ("INTC".to_string(), day[2]),
+            ]));
+        }
+        assert!(tracker.active_sectors_for_today().contains("chips"));
+    }
+
+    #[test]
+    fn test_leadership_long_only_notionals_equal_weight_selected_symbols() {
+        let closes = HashMap::from([
+            ("AAPL".to_string(), 200.0),
+            ("NVDA".to_string(), 100.0),
+            ("XOM".to_string(), 50.0),
+        ]);
+        let symbols = vec!["AAPL".to_string(), "NVDA".to_string()];
+        let notionals = leadership_long_only_notionals(&closes, &symbols, 10_000.0, 2.0);
+        assert_eq!(notionals.len(), 2);
+        assert_eq!(notionals.get("AAPL").copied(), Some(10_000.0));
+        assert_eq!(notionals.get("NVDA").copied(), Some(10_000.0));
+        assert!(!notionals.contains_key("XOM"));
     }
 
     #[test]

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -257,6 +257,47 @@ impl SectorLeadershipTracker {
     }
 }
 
+fn previous_trading_day(mut day: NaiveDate) -> Option<NaiveDate> {
+    for _ in 0..10 {
+        day = day.pred_opt()?;
+        if market_session::is_trading_day(day) {
+            return Some(day);
+        }
+    }
+    None
+}
+
+fn warm_leadership_tracker(
+    tracker: &mut SectorLeadershipTracker,
+    bars_dir: &Path,
+    symbols: &[String],
+    today: NaiveDate,
+) -> Result<(), String> {
+    let Some(anchor_day) = previous_trading_day(today) else {
+        return Ok(());
+    };
+    let closes = load_daily_closes_with_timestamps(bars_dir, symbols, 12, Some(anchor_day))?;
+    let mut by_day: std::collections::BTreeMap<NaiveDate, HashMap<String, f64>> =
+        std::collections::BTreeMap::new();
+    for (symbol, series) in closes {
+        for (day, _ts_us, close) in series {
+            if day <= anchor_day && close.is_finite() && close > 0.0 {
+                by_day.entry(day).or_default().insert(symbol.clone(), close);
+            }
+        }
+    }
+    for closes_for_day in by_day.values() {
+        tracker.observe_close_snapshot(closes_for_day);
+    }
+    info!(
+        warm_days = by_day.len(),
+        anchor_day = %anchor_day,
+        active_sectors = ?tracker.active_sectors_for_today(),
+        "leadership tracker warmed from historical close snapshots"
+    );
+    Ok(())
+}
+
 fn basket_sector(basket_id: &str) -> &str {
     basket_id.split(':').next().unwrap_or(basket_id)
 }
@@ -589,6 +630,9 @@ pub async fn run_basket_live(
         .leadership_overlay
         .clone()
         .map(|cfg| SectorLeadershipTracker::new(cfg, sector_members));
+    if let Some(tracker) = leadership_tracker.as_mut() {
+        warm_leadership_tracker(tracker, bars_dir, &symbols, today)?;
+    }
     if let Some(cfg) = options.leadership_overlay.as_ref() {
         info!(
             sectors = ?cfg.sectors,
@@ -599,7 +643,7 @@ pub async fn run_basket_live(
                 LeadershipOverlayMode::ReplaceWithLongOnly => "replace_with_long_only",
             },
             long_only_leverage = cfg.long_only_leverage,
-            "leadership_overlay ENABLED — replay may alter basket behavior in flagged sectors"
+            "leadership_overlay ENABLED — run may alter basket behavior in flagged sectors"
         );
     }
 
@@ -1307,6 +1351,13 @@ async fn process_session_close(
         leadership_overlay.map(|cfg| cfg.mode),
         Some(LeadershipOverlayMode::ReplaceWithLongOnly)
     ) && !leadership_long_symbols.is_empty();
+    if using_long_replacement {
+        let basket_ids: Vec<String> = engine
+            .iter_params()
+            .map(|(basket_id, _)| basket_id.clone())
+            .collect();
+        engine.flatten_baskets(&basket_ids);
+    }
     let target_notionals = if using_long_replacement {
         leadership_long_only_notionals(
             closes,

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -271,11 +271,8 @@ fn warm_leadership_tracker(
     tracker: &mut SectorLeadershipTracker,
     bars_dir: &Path,
     symbols: &[String],
-    today: NaiveDate,
+    anchor_day: NaiveDate,
 ) -> Result<(), String> {
-    let Some(anchor_day) = previous_trading_day(today) else {
-        return Ok(());
-    };
     let closes = load_daily_closes_with_timestamps(bars_dir, symbols, 12, Some(anchor_day))?;
     let mut by_day: std::collections::BTreeMap<NaiveDate, HashMap<String, f64>> =
         std::collections::BTreeMap::new();
@@ -631,7 +628,14 @@ pub async fn run_basket_live(
         .clone()
         .map(|cfg| SectorLeadershipTracker::new(cfg, sector_members));
     if let Some(tracker) = leadership_tracker.as_mut() {
-        warm_leadership_tracker(tracker, bars_dir, &symbols, today)?;
+        let warm_anchor = if last_processed_trading_day == Some(today) {
+            Some(today)
+        } else {
+            previous_trading_day(today)
+        };
+        if let Some(anchor_day) = warm_anchor {
+            warm_leadership_tracker(tracker, bars_dir, &symbols, anchor_day)?;
+        }
     }
     if let Some(cfg) = options.leadership_overlay.as_ref() {
         info!(

--- a/engine/crates/runner/src/main.rs
+++ b/engine/crates/runner/src/main.rs
@@ -34,6 +34,7 @@ mod simulated_broker;
 mod stream;
 
 use alpaca::ExecutionMode;
+use basket_picker::Universe;
 use clap::Parser;
 use openquant_core::config::ConfigFile;
 use openquant_core::pairs::engine::PairsEngine;
@@ -165,6 +166,29 @@ struct StreamArgs {
     /// Defaults to `<data-dir>/journal/basket_live.sqlite3`.
     #[arg(long)]
     basket_journal_path: Option<PathBuf>,
+
+    /// Basket-only: optional sector list for the leadership overlay.
+    /// Disabled by default. Intended for paper/noop validation runs.
+    #[arg(long, value_delimiter = ',')]
+    leadership_overlay_sectors: Vec<String>,
+
+    /// Basket-only: activate the leadership overlay when the prior 5d
+    /// equal-weight sector return exceeds this threshold.
+    #[arg(long)]
+    leadership_ret5d_threshold: Option<f64>,
+
+    /// Basket-only: activate the leadership overlay when the prior 5d
+    /// average sector breadth exceeds this threshold.
+    #[arg(long)]
+    leadership_breadth5d_threshold: Option<f64>,
+
+    /// Basket-only: leadership overlay mode.
+    #[arg(long, value_enum)]
+    leadership_mode: Option<LeadershipModeArg>,
+
+    /// Basket-only: leverage for `replace_with_long_only` mode.
+    #[arg(long, default_value_t = 1.0)]
+    leadership_long_only_leverage: f64,
 }
 
 /// Args for replay (adds date range).
@@ -318,37 +342,98 @@ enum LeadershipModeArg {
 }
 
 fn build_leadership_overlay_config(
-    args: &ReplayArgs,
+    universe: &Universe,
+    sectors: &[String],
+    ret5d_threshold: Option<f64>,
+    breadth5d_threshold: Option<f64>,
+    mode: Option<LeadershipModeArg>,
+    long_only_leverage: f64,
 ) -> Option<basket_live::LeadershipOverlayConfig> {
-    if args.leadership_overlay_sectors.is_empty()
-        && args.leadership_ret5d_threshold.is_none()
-        && args.leadership_breadth5d_threshold.is_none()
-        && args.leadership_mode.is_none()
+    if sectors.is_empty()
+        && ret5d_threshold.is_none()
+        && breadth5d_threshold.is_none()
+        && mode.is_none()
     {
         return None;
     }
-    if args.leadership_overlay_sectors.is_empty()
-        || args.leadership_ret5d_threshold.is_none()
-        || args.leadership_breadth5d_threshold.is_none()
-        || args.leadership_mode.is_none()
+    if sectors.is_empty()
+        || ret5d_threshold.is_none()
+        || breadth5d_threshold.is_none()
+        || mode.is_none()
     {
         error!(
             "leadership overlay requires --leadership-overlay-sectors, --leadership-mode, and both threshold flags"
         );
         std::process::exit(2);
     }
+    let unknown: Vec<String> = sectors
+        .iter()
+        .filter(|sector| !universe.sectors.contains_key(sector.as_str()))
+        .cloned()
+        .collect();
+    if !unknown.is_empty() {
+        error!(unknown = ?unknown, "leadership overlay sectors are not in the basket universe");
+        std::process::exit(2);
+    }
+    let ret5d_threshold = ret5d_threshold.unwrap();
+    if !ret5d_threshold.is_finite() {
+        error!("leadership overlay ret5d threshold must be finite");
+        std::process::exit(2);
+    }
+    let breadth5d_threshold = breadth5d_threshold.unwrap();
+    if !breadth5d_threshold.is_finite() || !(0.0..=1.0).contains(&breadth5d_threshold) {
+        error!("leadership overlay breadth5d threshold must be finite and in [0, 1]");
+        std::process::exit(2);
+    }
+    if !long_only_leverage.is_finite() || long_only_leverage <= 0.0 {
+        error!("leadership overlay long-only leverage must be finite and > 0");
+        std::process::exit(2);
+    }
+    if long_only_leverage > universe.strategy.leverage_assumed + f64::EPSILON {
+        error!(
+            requested = long_only_leverage,
+            max_allowed = universe.strategy.leverage_assumed,
+            "leadership overlay leverage exceeds configured basket leverage"
+        );
+        std::process::exit(2);
+    }
     Some(basket_live::LeadershipOverlayConfig {
-        sectors: args.leadership_overlay_sectors.clone(),
-        ret5d_threshold: args.leadership_ret5d_threshold.unwrap(),
-        breadth5d_threshold: args.leadership_breadth5d_threshold.unwrap(),
-        mode: match args.leadership_mode.unwrap() {
+        sectors: sectors.to_vec(),
+        ret5d_threshold,
+        breadth5d_threshold,
+        mode: match mode.unwrap() {
             LeadershipModeArg::SuppressShorts => basket_live::LeadershipOverlayMode::SuppressShorts,
             LeadershipModeArg::ReplaceWithLongOnly => {
                 basket_live::LeadershipOverlayMode::ReplaceWithLongOnly
             }
         },
-        long_only_leverage: args.leadership_long_only_leverage,
+        long_only_leverage,
     })
+}
+
+fn leadership_overlay_fingerprint(cfg: &basket_live::LeadershipOverlayConfig) -> String {
+    let mode = match cfg.mode {
+        basket_live::LeadershipOverlayMode::SuppressShorts => "suppress",
+        basket_live::LeadershipOverlayMode::ReplaceWithLongOnly => "replace",
+    };
+    let sectors = cfg.sectors.join("-");
+    let ret = format!("{:.4}", cfg.ret5d_threshold).replace('.', "p");
+    let breadth = format!("{:.4}", cfg.breadth5d_threshold).replace('.', "p");
+    let lev = format!("{:.2}", cfg.long_only_leverage).replace('.', "p");
+    format!("leadership-{mode}-{sectors}-r{ret}-b{breadth}-l{lev}")
+}
+
+fn path_with_suffix(path: &std::path::Path, suffix: &str) -> PathBuf {
+    let parent = path.parent().map(PathBuf::from).unwrap_or_default();
+    let stem = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("artifact");
+    let ext = path.extension().and_then(|s| s.to_str());
+    match ext {
+        Some(ext) => parent.join(format!("{stem}.{suffix}.{ext}")),
+        None => parent.join(format!("{stem}.{suffix}")),
+    }
 }
 
 /// Extract the unique symbols (leg_a/leg_b) from a candidates JSON file.
@@ -548,10 +633,6 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
         .fit_artifact
         .clone()
         .unwrap_or_else(|| basket_fits::default_fit_artifact_path(&universe_path));
-    let state_path = args
-        .state_path
-        .clone()
-        .unwrap_or_else(|| basket_fits::default_live_state_path(&fit_artifact_path));
 
     // Parse execution mode. Default = noop (shadow).
     // Extra safety: `paper live` must come from `Command::Live` (real-money path),
@@ -575,7 +656,36 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
             std::process::exit(1);
         }
     };
-
+    let universe = match basket_picker::load_universe(&universe_path) {
+        Ok(u) => u,
+        Err(e) => {
+            error!(error = %e, "failed to load basket universe");
+            std::process::exit(1);
+        }
+    };
+    let portfolio_config = basket_engine::PortfolioConfig {
+        capital: args.capital,
+        leverage: universe.strategy.leverage_assumed,
+        n_active_baskets: args.n_active_baskets,
+    };
+    if let Err(e) = portfolio_config.validate() {
+        error!(error = %e, "invalid basket portfolio config");
+        std::process::exit(1);
+    }
+    let leadership_overlay = build_leadership_overlay_config(
+        &universe,
+        &args.leadership_overlay_sectors,
+        args.leadership_ret5d_threshold,
+        args.leadership_breadth5d_threshold,
+        args.leadership_mode,
+        args.leadership_long_only_leverage,
+    );
+    if leadership_overlay.is_some() && matches!(execution, basket_live::BasketExecution::Live) {
+        error!(
+            "leadership overlay is not enabled for real-money live execution; use paper/noop until explicitly promoted"
+        );
+        std::process::exit(1);
+    }
     let alpaca = match alpaca::AlpacaClient::from_env(&PathBuf::from(".env")) {
         Ok(c) => c,
         Err(e) => {
@@ -589,22 +699,14 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
     // diagnostics. Filter refresh to only the universe's symbols to avoid
     // touching unrelated SP500 names.
     if bars_dir.exists() {
-        let filter = match basket_picker::load_universe(&universe_path) {
-            Ok(u) => {
-                let mut syms: Vec<String> = u
-                    .sectors
-                    .values()
-                    .flat_map(|s| s.members.iter().cloned())
-                    .collect();
-                syms.sort();
-                syms.dedup();
-                Some(syms)
-            }
-            Err(e) => {
-                error!(error = %e, "failed to load universe for refresh filter");
-                std::process::exit(1);
-            }
-        };
+        let mut syms: Vec<String> = universe
+            .sectors
+            .values()
+            .flat_map(|s| s.members.iter().cloned())
+            .collect();
+        syms.sort();
+        syms.dedup();
+        let filter = Some(syms);
         let target = chrono::Utc::now().format("%Y-%m-%d").to_string();
         info!(
             target = target.as_str(),
@@ -622,23 +724,17 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
     } else {
         warn!(path = %bars_dir.display(), "quant-data dir not found — skipping refresh");
     }
-
-    let universe = match basket_picker::load_universe(&universe_path) {
-        Ok(u) => u,
-        Err(e) => {
-            error!(error = %e, "failed to load basket universe");
-            std::process::exit(1);
-        }
+    let overlay_fingerprint = leadership_overlay
+        .as_ref()
+        .map(leadership_overlay_fingerprint);
+    let state_path = match (&args.state_path, overlay_fingerprint.as_deref()) {
+        (Some(path), _) => path.clone(),
+        (None, Some(fp)) => path_with_suffix(
+            &basket_fits::default_live_state_path(&fit_artifact_path),
+            fp,
+        ),
+        (None, None) => basket_fits::default_live_state_path(&fit_artifact_path),
     };
-    let portfolio_config = basket_engine::PortfolioConfig {
-        capital: args.capital,
-        leverage: universe.strategy.leverage_assumed,
-        n_active_baskets: args.n_active_baskets,
-    };
-    if let Err(e) = portfolio_config.validate() {
-        error!(error = %e, "invalid basket portfolio config");
-        std::process::exit(1);
-    }
     // Self-healing fit artifact: if missing or out-of-sync with the universe
     // (frozen_at / version mismatch / candidate-set change), rebuild it from
     // the current parquet history. Eliminates the "build it first" step in
@@ -688,10 +784,13 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
     // the grace constant in sync with `basket_live::CLOSE_GRACE_MIN`.
     let clock = clock::SystemClock;
     let mut session_trigger = session_trigger::IntervalSessionTrigger::new(clock::SystemClock, 2);
-    let basket_journal_path = args
-        .basket_journal_path
-        .clone()
-        .unwrap_or_else(|| args.data_dir.join("journal").join("basket_live.sqlite3"));
+    let basket_journal_path = args.basket_journal_path.clone().unwrap_or_else(|| {
+        let base = args.data_dir.join("journal").join("basket_live.sqlite3");
+        match overlay_fingerprint.as_deref() {
+            Some(fp) => path_with_suffix(&base, fp),
+            None => base,
+        }
+    });
 
     if let Err(e) = basket_live::run_basket_live(
         &alpaca,
@@ -707,7 +806,7 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
         basket_live::BasketRunOptions {
             fit_artifact_path: Some(fit_artifact_path.clone()),
             journal_path: Some(basket_journal_path),
-            leadership_overlay: None,
+            leadership_overlay,
         },
     )
     .await
@@ -1466,6 +1565,15 @@ async fn run_basket_replay_live_path(args: ReplayArgs) {
         std::process::exit(1);
     }
 
+    let leadership_overlay = build_leadership_overlay_config(
+        &universe,
+        &args.leadership_overlay_sectors,
+        args.leadership_ret5d_threshold,
+        args.leadership_breadth5d_threshold,
+        args.leadership_mode,
+        args.leadership_long_only_leverage,
+    );
+
     // Walk-forward fit: build the basket fit using data STRICTLY BEFORE
     // the replay window (`--start`). Without this, replay leaks future
     // information into the fit and produces fantasy Sharpe numbers
@@ -1552,7 +1660,7 @@ async fn run_basket_replay_live_path(args: ReplayArgs) {
         basket_live::BasketRunOptions {
             fit_artifact_path: None,
             journal_path: None,
-            leadership_overlay: build_leadership_overlay_config(&args),
+            leadership_overlay,
         },
     )
     .await;

--- a/engine/crates/runner/src/main.rs
+++ b/engine/crates/runner/src/main.rs
@@ -259,6 +259,31 @@ struct ReplayArgs {
     #[arg(long)]
     report_tsv: Option<PathBuf>,
 
+    /// Replay-only: comma-delimited sector list for the leadership overlay.
+    #[arg(long, value_delimiter = ',')]
+    leadership_overlay_sectors: Vec<String>,
+
+    /// Replay-only: activate the sector-level leadership overlay when the
+    /// prior 5d equal-weight sector return exceeds this threshold.
+    #[arg(long)]
+    leadership_ret5d_threshold: Option<f64>,
+
+    /// Replay-only: activate the sector-level leadership overlay when the
+    /// prior 5d average sector breadth exceeds this threshold.
+    #[arg(long)]
+    leadership_breadth5d_threshold: Option<f64>,
+
+    /// Replay-only: leadership overlay mode.
+    /// `suppress_shorts` flattens and blocks shorts in flagged sectors.
+    /// `replace_with_long_only` swaps the basket book for a long-only book
+    /// over the currently flagged sector members.
+    #[arg(long, value_enum)]
+    leadership_mode: Option<LeadershipModeArg>,
+
+    /// Replay-only: leverage for `replace_with_long_only` mode.
+    #[arg(long, default_value_t = 1.0)]
+    leadership_long_only_leverage: f64,
+
     /// Resume replay from an existing state snapshot at `--state-path`
     /// instead of starting from empty engine + simulated broker state.
     /// Default: false (fresh start). When false, any existing state
@@ -284,6 +309,46 @@ struct BasketFitArgs {
     /// Output fit artifact path. Defaults to `<universe>.fits.json`.
     #[arg(long)]
     out: Option<PathBuf>,
+}
+
+#[derive(clap::ValueEnum, Debug, Clone, Copy)]
+enum LeadershipModeArg {
+    SuppressShorts,
+    ReplaceWithLongOnly,
+}
+
+fn build_leadership_overlay_config(
+    args: &ReplayArgs,
+) -> Option<basket_live::LeadershipOverlayConfig> {
+    if args.leadership_overlay_sectors.is_empty()
+        && args.leadership_ret5d_threshold.is_none()
+        && args.leadership_breadth5d_threshold.is_none()
+        && args.leadership_mode.is_none()
+    {
+        return None;
+    }
+    if args.leadership_overlay_sectors.is_empty()
+        || args.leadership_ret5d_threshold.is_none()
+        || args.leadership_breadth5d_threshold.is_none()
+        || args.leadership_mode.is_none()
+    {
+        error!(
+            "leadership overlay requires --leadership-overlay-sectors, --leadership-mode, and both threshold flags"
+        );
+        std::process::exit(2);
+    }
+    Some(basket_live::LeadershipOverlayConfig {
+        sectors: args.leadership_overlay_sectors.clone(),
+        ret5d_threshold: args.leadership_ret5d_threshold.unwrap(),
+        breadth5d_threshold: args.leadership_breadth5d_threshold.unwrap(),
+        mode: match args.leadership_mode.unwrap() {
+            LeadershipModeArg::SuppressShorts => basket_live::LeadershipOverlayMode::SuppressShorts,
+            LeadershipModeArg::ReplaceWithLongOnly => {
+                basket_live::LeadershipOverlayMode::ReplaceWithLongOnly
+            }
+        },
+        long_only_leverage: args.leadership_long_only_leverage,
+    })
 }
 
 /// Extract the unique symbols (leg_a/leg_b) from a candidates JSON file.
@@ -642,6 +707,7 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
         basket_live::BasketRunOptions {
             fit_artifact_path: Some(fit_artifact_path.clone()),
             journal_path: Some(basket_journal_path),
+            leadership_overlay: None,
         },
     )
     .await
@@ -1486,6 +1552,7 @@ async fn run_basket_replay_live_path(args: ReplayArgs) {
         basket_live::BasketRunOptions {
             fit_artifact_path: None,
             journal_path: None,
+            leadership_overlay: build_leadership_overlay_config(&args),
         },
     )
     .await;


### PR DESCRIPTION
## Summary
- add sector leadership overlay support to basket runner
- keep baseline behavior unchanged by default
- allow overlay on replay and paper/noop stream runs
- hard-block overlay for real-money live execution
- isolate overlay state/journal paths and warm overlay regime state on startup
- flatten basket engine state when long-only replacement takes over so persisted basket state stays coherent

## Validation
Replay results from the committed candidate on the real `main.rs` path:

- Q3 2025 baseline: `-4.48%`, Sharpe `-0.57`
- Q3 2025 overlay: `-3.00%`, Sharpe `+0.11`
- Q4 2025 baseline: `+2.89%`, Sharpe `+0.57`
- Q4 2025 overlay: `+52.55%`, Sharpe `+2.47`
- 2026 YTD baseline: `+3.36%`, Sharpe `+0.47`
- 2026 YTD overlay: `+82.96%`, Sharpe `+2.73`

April 2026 post-fix sanity:
- baseline remained near flat
- overlay remained strongly positive (`cum_return ~ +96.9%`, Sharpe `~9.47`) on the March warm-start replay

## Safety boundaries
- overlay is opt-in; baseline stream behavior is unchanged when no overlay flags are passed
- overlay paper/noop runs get isolated default state and journal paths via overlay fingerprinting
- real-money `live` rejects overlay flags at startup
- invalid overlay sectors / thresholds / leverage fail fast before the run starts

## Remaining review focus
- confirm the overlay-on paper defaults are acceptable operationally
- confirm the long-only replacement semantics are the right paper-trading behavior before any future live promotion
