### PR TITLE
docs: add basket overlay main-branch baseline

### DIFF
--- a/BASELINES.md
+++ b/BASELINES.md
@@ -1,6 +1,8 @@
 # Baselines
 
-Commit: `4e5e0f8` (metals-autoresearch branch)
+Commit notes:
+- metals / pairs references below were captured from earlier validation branches
+- basket overlay reference below is from merged `main` commit `facfa00b`
 
 ## Metals (--engine metals)
 
@@ -27,3 +29,19 @@ Commit: `e2ac6a3` (main)
 | Trades | Wins | Win Rate | Total bps | Avg bps |
 |--------|------|----------|-----------|---------|
 | 25 | 16 | 64% | +383.8 | +15.4 |
+
+## Basket (--engine basket)
+
+### Main branch reference (2026 YTD)
+
+Commit: `facfa00b` (main)
+
+Replay window: `2026-01-02` to `2026-04-30`
+
+The basket runner now supports an opt-in leadership overlay in paper/noop mode.
+Baseline behavior is unchanged unless overlay flags are passed.
+
+| Mode | Cum Return | Sharpe | Max DD | Trading Days |
+|------|------------|--------|--------|--------------|
+| Basket baseline | +3.36% | 0.47 | 21.5% | 82 |
+| Basket + leadership overlay (`faang,chips`) | +76.53% | 2.54 | 30.6% | 82 |


### PR DESCRIPTION
## Summary
- add merged `main` basket baseline reference to `BASELINES.md`
- document 2026 YTD baseline vs leadership overlay results from the post-merge `main` recheck
