### PR TITLE
runner: add rule-v1 basket overlay picker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ engine/target/
 data/bar_cache*/
 data/journal/
 data/paper_trades/
+data/replay/
 
 # Generated basket fit/state artifacts
 config/*.fits.json

--- a/BASELINES.md
+++ b/BASELINES.md
@@ -1,47 +1,55 @@
 # Baselines
 
-Commit notes:
-- metals / pairs references below were captured from earlier validation branches
-- basket overlay reference below is from merged `main` commit `facfa00b`
+This file tracks current, reproducible benchmark references. Older branch
+experiments and stale pre-picker basket numbers were removed because they are
+not reliable yardsticks for the current basket engine.
 
-## Metals (--engine metals)
+## Basket Overlay Picker
 
-Replay: `2025-07-01` to `2026-03-28`
+Current basket leadership work should be judged against fixed mechanism
+benchmarks, not baseline alone. The basket core remains the foundation; the
+rule picker is evaluated as a conservative allocator among:
 
-| Trades | Wins | Win Rate | Total bps | Avg bps |
-|--------|------|----------|-----------|---------|
-| 66 | 46 | 70% | +4904.2 | +74.3 |
+- basket core only
+- basket core + `suppress_shorts`
+- basket core + `add_capped_long_sleeve`
 
-## S&P 500 (--engine snp500)
+Replay command:
 
-### Q1 2026
+```bash
+scripts/run_basket_overlay_benchmark.py --prefix overlay_bench_spare_budget
+```
 
-Replay: `2026-01-02` to `2026-03-28`
+Shared replay settings:
 
-| Trades | Wins | Win Rate | Total bps | Avg bps |
-|--------|------|----------|-----------|---------|
-| 22 | 17 | 77% | +353.5 | +16.1 |
+- sectors: `faang,chips`
+- leadership on threshold: `ret5d >= 0.02`
+- leadership breadth threshold: `breadth5d >= 0.56`
+- long-only sleeve budget: `leadership_long_only_leverage = 1.0`
+- capital: `10000`
+- active basket cap: `5`
 
-### Main branch reference (Q1 2026)
+| Window | Baseline | Fixed suppress | Fixed sleeve | Rule v1 | Best fixed | Rule v1 vs best fixed |
+|--------|----------|----------------|--------------|---------|------------|-----------------------|
+| wide Q3 2025 | -4.19%, DD 17.09% | -2.22%, DD 19.57% | +10.51%, DD 12.08% | +13.02%, DD 12.08% | Fixed sleeve | +2.52%, DD +0.00% |
+| wide Q4 2025 | -5.00%, DD 13.09% | -5.00%, DD 13.09% | -2.17%, DD 10.95% | +4.42%, DD 7.25% | Fixed sleeve | +6.60%, DD -3.70% |
+| wide 2026 YTD | -9.20%, DD 15.85% | -9.20%, DD 15.85% | +42.87%, DD 7.33% | +42.87%, DD 7.33% | Fixed sleeve | +0.00%, DD +0.00% |
+| strong Q1 2025 | +27.05%, DD 3.37% | +33.74%, DD 2.57% | +8.12%, DD 9.52% | +38.42%, DD 2.48% | Fixed suppress | +4.68%, DD -0.08% |
 
-Commit: `e2ac6a3` (main)
+## Acceptance Notes
 
-| Trades | Wins | Win Rate | Total bps | Avg bps |
-|--------|------|----------|-----------|---------|
-| 25 | 16 | 64% | +383.8 | +15.4 |
+The rule picker should continue to clear these bars before promotion:
 
-## Basket (--engine basket)
+- do not degrade the best fixed mechanism materially in strong leadership windows
+- do not beat baseline by merely taking more drawdown
+- preserve basket-core behavior when leadership is absent
+- keep replay outputs deterministic and restart-stable
+- record picker decisions so regressions can be attributed to mode selection,
+  not guessed from PnL alone
 
-### Main branch reference (2026 YTD)
+Current validation:
 
-Commit: `facfa00b` (main)
-
-Replay window: `2026-01-02` to `2026-04-30`
-
-The basket runner now supports an opt-in leadership overlay in paper/noop mode.
-Baseline behavior is unchanged unless overlay flags are passed.
-
-| Mode | Cum Return | Sharpe | Max DD | Trading Days |
-|------|------------|--------|--------|--------------|
-| Basket baseline | +3.36% | 0.47 | 21.5% | 82 |
-| Basket + leadership overlay (`faang,chips`) | +76.53% | 2.54 | 30.6% | 82 |
+```bash
+cargo test -p openquant-runner
+python3 -m py_compile scripts/run_basket_overlay_benchmark.py
+```

--- a/engine/crates/basket-engine/src/engine.rs
+++ b/engine/crates/basket-engine/src/engine.rs
@@ -62,6 +62,7 @@ pub struct EngineSnapshot {
 }
 
 /// The basket engine: manages state machines for all active baskets.
+#[derive(Clone)]
 pub struct BasketEngine {
     /// Per-basket parameters (frozen after construction).
     params: HashMap<String, BasketParams>,

--- a/engine/crates/runner/src/basket_journal.rs
+++ b/engine/crates/runner/src/basket_journal.rs
@@ -88,12 +88,31 @@ CREATE TABLE IF NOT EXISTS basket_order_events (
     created_at_utc TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS basket_picker_decisions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT NOT NULL,
+    trading_day TEXT NOT NULL,
+    picker_id TEXT NOT NULL,
+    mode TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    active_sectors_json TEXT NOT NULL,
+    active_symbols_json TEXT NOT NULL,
+    leadership_short_conflict_ratio REAL NOT NULL,
+    strategy_return_20d REAL NOT NULL,
+    strategy_drawdown_20d REAL NOT NULL,
+    baseline_scale_if_sleeve REAL NOT NULL,
+    sleeve_leverage_scale REAL NOT NULL DEFAULT 1.0,
+    created_at_utc TEXT NOT NULL
+);
+
 CREATE INDEX IF NOT EXISTS idx_basket_session_closes_run_day
     ON basket_session_closes(run_id, trading_day);
 CREATE INDEX IF NOT EXISTS idx_basket_order_events_run_day
     ON basket_order_events(run_id, trading_day);
 CREATE INDEX IF NOT EXISTS idx_basket_order_events_symbol
     ON basket_order_events(symbol);
+CREATE INDEX IF NOT EXISTS idx_basket_picker_decisions_run_day
+    ON basket_picker_decisions(run_id, trading_day);
 ";
 
 #[derive(Clone)]
@@ -170,6 +189,21 @@ pub struct BasketOrderEvent<'a> {
     pub broker_status: Option<&'a str>,
     pub submission_status: &'a str,
     pub error_text: Option<&'a str>,
+}
+
+pub struct BasketPickerDecisionRecord<'a> {
+    pub run_id: &'a str,
+    pub trading_day: NaiveDate,
+    pub picker_id: &'a str,
+    pub mode: &'a str,
+    pub reason: &'a str,
+    pub active_sectors_json: String,
+    pub active_symbols_json: String,
+    pub leadership_short_conflict_ratio: f64,
+    pub strategy_return_20d: f64,
+    pub strategy_drawdown_20d: f64,
+    pub baseline_scale_if_sleeve: f64,
+    pub sleeve_leverage_scale: f64,
 }
 
 impl BasketJournal {
@@ -325,6 +359,42 @@ impl BasketJournal {
         .map_err(|e| format!("insert basket order event: {e}"))?;
         Ok(())
     }
+
+    pub fn record_picker_decision(
+        &self,
+        rec: &BasketPickerDecisionRecord<'_>,
+    ) -> Result<(), String> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|_| "basket journal mutex poisoned".to_string())?;
+        conn.execute(
+            "INSERT INTO basket_picker_decisions (
+                run_id, trading_day, picker_id, mode, reason,
+                active_sectors_json, active_symbols_json,
+                leadership_short_conflict_ratio, strategy_return_20d,
+                strategy_drawdown_20d, baseline_scale_if_sleeve,
+                sleeve_leverage_scale, created_at_utc
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+            params![
+                rec.run_id,
+                rec.trading_day.to_string(),
+                rec.picker_id,
+                rec.mode,
+                rec.reason,
+                rec.active_sectors_json,
+                rec.active_symbols_json,
+                rec.leadership_short_conflict_ratio,
+                rec.strategy_return_20d,
+                rec.strategy_drawdown_20d,
+                rec.baseline_scale_if_sleeve,
+                rec.sleeve_leverage_scale,
+                Utc::now().to_rfc3339(),
+            ],
+        )
+        .map_err(|e| format!("insert basket picker decision: {e}"))?;
+        Ok(())
+    }
 }
 
 pub fn serialize_string_vec(values: &[String]) -> String {
@@ -380,6 +450,22 @@ mod tests {
             })
             .unwrap();
         journal
+            .record_picker_decision(&BasketPickerDecisionRecord {
+                run_id: "run-1",
+                trading_day: NaiveDate::from_ymd_opt(2026, 4, 28).unwrap(),
+                picker_id: "rule_v1",
+                mode: "baseline",
+                reason: "no_leadership",
+                active_sectors_json: "[]".to_string(),
+                active_symbols_json: "[]".to_string(),
+                leadership_short_conflict_ratio: 0.0,
+                strategy_return_20d: 0.0,
+                strategy_drawdown_20d: 0.0,
+                baseline_scale_if_sleeve: 1.0,
+                sleeve_leverage_scale: 1.0,
+            })
+            .unwrap();
+        journal
             .record_session_close(&BasketSessionCloseRecord {
                 run_id: "run-1",
                 trading_day: NaiveDate::from_ymd_opt(2026, 4, 28).unwrap(),
@@ -431,8 +517,14 @@ mod tests {
         let orders: i64 = conn
             .query_row("SELECT COUNT(*) FROM basket_order_events", [], |r| r.get(0))
             .unwrap();
+        let decisions: i64 = conn
+            .query_row("SELECT COUNT(*) FROM basket_picker_decisions", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
         assert_eq!(runs, 1);
         assert_eq!(sessions, 1);
         assert_eq!(orders, 1);
+        assert_eq!(decisions, 1);
     }
 }

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -1993,7 +1993,12 @@ async fn process_session_close(
         );
         engine.flatten_baskets(&engine_flatten_baskets);
     }
-    let target_shares = target_shares_from_notionals(&target_notionals, closes)?;
+    let mut target_shares = target_shares_from_notionals(&target_notionals, closes)?;
+    trim_target_shares_to_gross_cap(
+        &mut target_shares,
+        closes,
+        effective_portfolio_config.capital * effective_portfolio_config.leverage,
+    );
 
     // Summary of the notional plan before we diff — this is where yesterday's
     // $340K-on-$100K problem was invisible. Emit gross long, gross short,
@@ -2486,6 +2491,54 @@ fn target_shares_from_notionals(
     }
 }
 
+fn trim_target_shares_to_gross_cap(
+    target_shares: &mut HashMap<String, f64>,
+    closes: &HashMap<String, f64>,
+    gross_cap: f64,
+) {
+    if !gross_cap.is_finite() || gross_cap <= 0.0 {
+        target_shares.clear();
+        return;
+    }
+
+    loop {
+        let current_gross: f64 = target_shares
+            .iter()
+            .filter_map(|(symbol, shares)| closes.get(symbol).map(|price| shares.abs() * price))
+            .sum();
+        if current_gross <= gross_cap + 1.0 {
+            break;
+        }
+
+        let Some((symbol_to_trim, _)) = target_shares
+            .iter()
+            .filter_map(|(symbol, shares)| {
+                closes
+                    .get(symbol)
+                    .filter(|price| price.is_finite() && **price > 0.0 && shares.abs() >= 1.0)
+                    .map(|price| (symbol.clone(), shares.abs() * price))
+            })
+            .max_by(|(lhs_symbol, lhs_notional), (rhs_symbol, rhs_notional)| {
+                lhs_notional
+                    .partial_cmp(rhs_notional)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| lhs_symbol.cmp(rhs_symbol))
+            })
+        else {
+            break;
+        };
+
+        let remove_symbol = {
+            let shares = target_shares.get_mut(&symbol_to_trim).unwrap();
+            *shares -= shares.signum();
+            shares.abs() < 1.0
+        };
+        if remove_symbol {
+            target_shares.remove(&symbol_to_trim);
+        }
+    }
+}
+
 /// Summarize a `target_notionals` map into (gross_long, gross_short, max_abs,
 /// sorted_abs). `gross_short` is returned as a negative number.
 fn summarize_notionals(targets: &HashMap<String, f64>) -> (f64, f64, f64, Vec<f64>) {
@@ -2899,6 +2952,28 @@ mod tests {
         let shares = target_shares_from_notionals(&notionals, &closes).unwrap();
         assert_eq!(shares.get("AMD").copied(), Some(50.0));
         assert_eq!(shares.get("NVDA").copied(), Some(-12.0));
+    }
+
+    #[test]
+    fn test_trim_target_shares_to_gross_cap_reduces_rounded_overshoot() {
+        let mut shares = HashMap::from([
+            ("AAA".to_string(), 2.0),
+            ("BBB".to_string(), 2.0),
+            ("CCC".to_string(), -2.0),
+        ]);
+        let closes = HashMap::from([
+            ("AAA".to_string(), 100.0),
+            ("BBB".to_string(), 100.0),
+            ("CCC".to_string(), 100.0),
+        ]);
+
+        trim_target_shares_to_gross_cap(&mut shares, &closes, 500.0);
+
+        let gross: f64 = shares
+            .iter()
+            .map(|(symbol, qty)| qty.abs() * closes.get(symbol).unwrap())
+            .sum();
+        assert!(gross <= 501.0, "gross remained too large: {gross}");
     }
 
     #[test]

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -30,7 +30,8 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use basket_engine::{
-    plan_portfolio, BasketEngine, DailyBar, OrderIntent, PortfolioConfig, PositionIntent, Side,
+    plan_portfolio, BasketEngine, DailyBar, OrderIntent, PortfolioConfig, PortfolioPlan,
+    PositionIntent, Side,
 };
 use basket_picker::{load_universe, BasketFit};
 use chrono::{DateTime, NaiveDate, Utc};
@@ -532,6 +533,21 @@ fn baseline_scale_if_sleeve(
     let sleeve_budget = (cfg.long_only_leverage * portfolio_config.capital).min(gross_cap);
     let baseline_budget = (gross_cap - sleeve_budget).max(0.0);
     (baseline_budget / baseline_gross).clamp(0.0, 1.0)
+}
+
+fn engine_flatten_baskets_for_plan(
+    plan: &PortfolioPlan,
+    suppressed_baskets: &[String],
+    using_long_replacement: bool,
+) -> Vec<String> {
+    if using_long_replacement {
+        return Vec::new();
+    }
+    let mut basket_ids = suppressed_baskets.to_vec();
+    basket_ids.extend(plan.excluded_baskets.iter().cloned());
+    basket_ids.sort();
+    basket_ids.dedup();
+    basket_ids
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -1097,14 +1113,18 @@ pub async fn run_basket_live(
             off_breadth5d_threshold = cfg.off_breadth5d_threshold,
             persistence_days = cfg.persistence_days,
             min_hold_days = cfg.min_hold_days,
-            mode = match cfg.mode {
+            configured_overlay_mode = match cfg.mode {
                 BasketOverlayMode::Baseline => "baseline",
                 BasketOverlayMode::SuppressShorts => "suppress_shorts",
                 BasketOverlayMode::ReplaceWithLongOnly => "replace_with_long_only",
                 BasketOverlayMode::AddCappedLongSleeve => "add_capped_long_sleeve",
             },
+            configured_picker = match options.overlay_picker {
+                BasketOverlayPickerKind::Fixed => "fixed",
+                BasketOverlayPickerKind::RuleV1 => "rule_v1",
+            },
             long_only_leverage = cfg.long_only_leverage,
-            "leadership_overlay ENABLED — run may alter basket behavior in flagged sectors"
+            "leadership overlay configured; runtime mode may still be chosen by picker"
         );
     }
     let mut overlay_picker = BasketOverlayPickerHandle::from_kind(
@@ -1832,7 +1852,6 @@ async fn process_session_close(
         &effective_portfolio_config,
         leadership_overlay,
     );
-    let baseline_excluded_baskets = baseline_plan.excluded_baskets.clone();
     let picker_decision = overlay_picker.decide(&baseline_features);
     let leadership_active_sectors = &picker_decision.active_sectors;
     let leadership_long_symbols = &picker_decision.long_symbols;
@@ -1963,13 +1982,16 @@ async fn process_session_close(
             "leadership overlay transformed baseline basket portfolio"
         );
     }
-    let engine_excluded_baskets = if suppressed_baskets.is_empty() {
-        &plan.excluded_baskets
-    } else {
-        &baseline_excluded_baskets
-    };
-    if !using_long_replacement && !engine_excluded_baskets.is_empty() {
-        engine.flatten_baskets(engine_excluded_baskets);
+    let engine_flatten_baskets =
+        engine_flatten_baskets_for_plan(&plan, &suppressed_baskets, using_long_replacement);
+    if !engine_flatten_baskets.is_empty() {
+        info!(
+            date = %date,
+            picker_mode = picker_decision.mode.as_str(),
+            flattened_baskets = ?engine_flatten_baskets,
+            "flattening engine state to match executed basket plan"
+        );
+        engine.flatten_baskets(&engine_flatten_baskets);
     }
     let target_shares = target_shares_from_notionals(&target_notionals, closes)?;
 
@@ -2943,6 +2965,46 @@ mod tests {
             baseline_scale_if_sleeve(&baseline_notionals, &portfolio_config, Some(&overlay));
 
         assert!((scale - 0.75).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_engine_flatten_baskets_for_plan_includes_suppressed_and_replanned_exclusions() {
+        let plan = PortfolioPlan {
+            symbol_notionals: HashMap::new(),
+            selected_baskets: vec!["admitted".to_string()],
+            excluded_baskets: vec!["cap_excluded".to_string(), "suppressed".to_string()],
+            active_baskets: 3,
+        };
+
+        let flattened = engine_flatten_baskets_for_plan(
+            &plan,
+            &["suppressed".to_string(), "other_suppressed".to_string()],
+            false,
+        );
+
+        assert_eq!(
+            flattened,
+            vec![
+                "cap_excluded".to_string(),
+                "other_suppressed".to_string(),
+                "suppressed".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_engine_flatten_baskets_for_plan_skips_flattening_for_long_replacement() {
+        let plan = PortfolioPlan {
+            symbol_notionals: HashMap::new(),
+            selected_baskets: vec!["admitted".to_string()],
+            excluded_baskets: vec!["cap_excluded".to_string()],
+            active_baskets: 2,
+        };
+
+        let flattened =
+            engine_flatten_baskets_for_plan(&plan, &["suppressed".to_string()], true);
+
+        assert!(flattened.is_empty());
     }
 
     #[test]

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -41,8 +41,12 @@ use tracing::{debug, error, info, warn};
 use crate::alpaca::ExecutionMode;
 use crate::bar_source::BarSource;
 use crate::basket_journal::{
-    serialize_shares_map, serialize_string_vec, BasketJournal, BasketOrderEvent, BasketRunRecord,
-    BasketSessionCloseRecord,
+    serialize_shares_map, serialize_string_vec, BasketJournal, BasketOrderEvent,
+    BasketPickerDecisionRecord, BasketRunRecord, BasketSessionCloseRecord,
+};
+use crate::basket_overlay_picker::{
+    BasketOverlayMode, BasketOverlayPicker, BasketOverlayPickerFeatures, BasketOverlayPickerHandle,
+    BasketOverlayPickerKind,
 };
 use crate::broker::Broker;
 use crate::clock::Clock;
@@ -103,11 +107,23 @@ impl StartupPhase {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct BasketRunOptions {
     pub fit_artifact_path: Option<PathBuf>,
     pub journal_path: Option<PathBuf>,
     pub leadership_overlay: Option<LeadershipOverlayConfig>,
+    pub overlay_picker: BasketOverlayPickerKind,
+}
+
+impl Default for BasketRunOptions {
+    fn default() -> Self {
+        Self {
+            fit_artifact_path: None,
+            journal_path: None,
+            leadership_overlay: None,
+            overlay_picker: BasketOverlayPickerKind::Fixed,
+        }
+    }
 }
 
 // Grace period after session close before firing the engine. Lets
@@ -126,13 +142,6 @@ enum StartupStateSource {
     Fresh,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum LeadershipOverlayMode {
-    SuppressShorts,
-    ReplaceWithLongOnly,
-    AddCappedLongSleeve,
-}
-
 #[derive(Debug, Clone)]
 pub struct LeadershipOverlayConfig {
     pub sectors: Vec<String>,
@@ -142,7 +151,7 @@ pub struct LeadershipOverlayConfig {
     pub off_breadth5d_threshold: f64,
     pub persistence_days: usize,
     pub min_hold_days: usize,
-    pub mode: LeadershipOverlayMode,
+    pub mode: BasketOverlayMode,
     pub long_only_leverage: f64,
 }
 
@@ -231,9 +240,10 @@ impl SectorLeadershipTracker {
         let mut sectors = self.config.sectors.clone();
         sectors.sort();
         let mode = match self.config.mode {
-            LeadershipOverlayMode::SuppressShorts => "suppress_shorts",
-            LeadershipOverlayMode::ReplaceWithLongOnly => "replace_with_long_only",
-            LeadershipOverlayMode::AddCappedLongSleeve => "add_capped_long_sleeve",
+            BasketOverlayMode::Baseline => "baseline",
+            BasketOverlayMode::SuppressShorts => "suppress_shorts",
+            BasketOverlayMode::ReplaceWithLongOnly => "replace_with_long_only",
+            BasketOverlayMode::AddCappedLongSleeve => "add_capped_long_sleeve",
         };
         format!(
             "sectors={}|on_ret={:.8}|on_breadth={:.8}|off_ret={:.8}|off_breadth={:.8}|persistence={}|min_hold={}|mode={}|long_only_lev={:.8}",
@@ -456,6 +466,114 @@ fn warm_leadership_tracker(
     Ok(())
 }
 
+fn leadership_picker_features(
+    tracker: Option<&SectorLeadershipTracker>,
+    equity_features: StrategyEquityFeatures,
+) -> BasketOverlayPickerFeatures {
+    BasketOverlayPickerFeatures {
+        active_sectors: tracker
+            .map(|t| t.active_sectors_for_today().clone())
+            .unwrap_or_default(),
+        long_symbols: tracker
+            .map(|t| t.active_symbols_for_today())
+            .unwrap_or_default(),
+        leadership_short_conflict_ratio: 0.0,
+        strategy_return_20d: equity_features.return_20d,
+        strategy_drawdown_20d: equity_features.drawdown_20d,
+        baseline_scale_if_sleeve: 1.0,
+    }
+}
+
+fn add_baseline_plan_features(
+    mut features: BasketOverlayPickerFeatures,
+    baseline_notionals: &HashMap<String, f64>,
+    portfolio_config: &PortfolioConfig,
+    leadership_overlay: Option<&LeadershipOverlayConfig>,
+) -> BasketOverlayPickerFeatures {
+    let gross = baseline_notionals
+        .values()
+        .map(|notional| notional.abs())
+        .sum::<f64>();
+    if gross <= 0.0 || features.long_symbols.is_empty() {
+        features.leadership_short_conflict_ratio = 0.0;
+        return features;
+    }
+    let leadership_symbols: HashSet<&str> =
+        features.long_symbols.iter().map(String::as_str).collect();
+    let conflict = baseline_notionals
+        .iter()
+        .filter(|(symbol, notional)| {
+            **notional < 0.0 && leadership_symbols.contains(symbol.as_str())
+        })
+        .map(|(_symbol, notional)| notional.abs())
+        .sum::<f64>();
+    features.leadership_short_conflict_ratio = conflict / gross;
+    features.baseline_scale_if_sleeve =
+        baseline_scale_if_sleeve(baseline_notionals, portfolio_config, leadership_overlay);
+    features
+}
+
+fn baseline_scale_if_sleeve(
+    baseline_notionals: &HashMap<String, f64>,
+    portfolio_config: &PortfolioConfig,
+    leadership_overlay: Option<&LeadershipOverlayConfig>,
+) -> f64 {
+    let Some(cfg) = leadership_overlay else {
+        return 1.0;
+    };
+    let baseline_gross = baseline_notionals
+        .values()
+        .map(|notional| notional.abs())
+        .sum::<f64>();
+    if baseline_gross <= 0.0 {
+        return 1.0;
+    }
+    let gross_cap = portfolio_config.capital * portfolio_config.leverage;
+    let sleeve_budget = (cfg.long_only_leverage * portfolio_config.capital).min(gross_cap);
+    let baseline_budget = (gross_cap - sleeve_budget).max(0.0);
+    (baseline_budget / baseline_gross).clamp(0.0, 1.0)
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct StrategyEquityFeatures {
+    return_20d: f64,
+    drawdown_20d: f64,
+}
+
+fn strategy_equity_features(equity_history: &VecDeque<f64>) -> StrategyEquityFeatures {
+    let values: Vec<f64> = equity_history
+        .iter()
+        .copied()
+        .filter(|equity| equity.is_finite() && *equity > 0.0)
+        .collect();
+    if values.len() < 2 {
+        return StrategyEquityFeatures::default();
+    }
+    let last = *values.last().unwrap();
+    let window_start = values.len().saturating_sub(21);
+    let window = &values[window_start..];
+    let first = window[0];
+    let peak = window.iter().copied().fold(first, f64::max);
+    StrategyEquityFeatures {
+        return_20d: last / first - 1.0,
+        drawdown_20d: if peak > 0.0 {
+            (peak - last) / peak
+        } else {
+            0.0
+        },
+    }
+}
+
+fn push_equity_history(equity_history: &mut VecDeque<f64>, equity: f64) {
+    if !equity.is_finite() || equity <= 0.0 {
+        return;
+    }
+    equity_history.push_back(equity);
+    while equity_history.len() > 21 {
+        equity_history.pop_front();
+    }
+}
+
 pub fn leadership_classifier_state_path(engine_state_path: &Path) -> PathBuf {
     let mut name = engine_state_path
         .file_name()
@@ -465,12 +583,21 @@ pub fn leadership_classifier_state_path(engine_state_path: &Path) -> PathBuf {
     engine_state_path.with_file_name(name)
 }
 
+pub fn overlay_picker_state_path(engine_state_path: &Path) -> PathBuf {
+    let mut name = engine_state_path
+        .file_name()
+        .map(|s| s.to_os_string())
+        .unwrap_or_else(|| OsString::from("basket.state.json"));
+    name.push(".picker.json");
+    engine_state_path.with_file_name(name)
+}
+
 fn basket_sector(basket_id: &str) -> &str {
     basket_id.split(':').next().unwrap_or(basket_id)
 }
 
-fn apply_leadership_short_suppression(
-    engine: &mut basket_engine::BasketEngine,
+fn leadership_short_suppression_baskets(
+    engine: &basket_engine::BasketEngine,
     active_sectors: &HashSet<String>,
 ) -> Vec<String> {
     if active_sectors.is_empty() {
@@ -487,9 +614,6 @@ fn apply_leadership_short_suppression(
         if state.position < 0 {
             suppressed.push(basket_id.clone());
         }
-    }
-    if !suppressed.is_empty() {
-        engine.flatten_baskets(&suppressed);
     }
     suppressed
 }
@@ -928,6 +1052,8 @@ pub async fn run_basket_live(
         }
         Some(mode) => seed_current_shares_from_alpaca(broker, mode, &symbols).await?,
     };
+    let mut equity_history = VecDeque::new();
+    push_equity_history(&mut equity_history, portfolio_config.capital);
 
     let (mut engine, mut last_processed_trading_day, startup_state_source) =
         initialize_engine_state(
@@ -972,14 +1098,35 @@ pub async fn run_basket_live(
             persistence_days = cfg.persistence_days,
             min_hold_days = cfg.min_hold_days,
             mode = match cfg.mode {
-                LeadershipOverlayMode::SuppressShorts => "suppress_shorts",
-                LeadershipOverlayMode::ReplaceWithLongOnly => "replace_with_long_only",
-                LeadershipOverlayMode::AddCappedLongSleeve => "add_capped_long_sleeve",
+                BasketOverlayMode::Baseline => "baseline",
+                BasketOverlayMode::SuppressShorts => "suppress_shorts",
+                BasketOverlayMode::ReplaceWithLongOnly => "replace_with_long_only",
+                BasketOverlayMode::AddCappedLongSleeve => "add_capped_long_sleeve",
             },
             long_only_leverage = cfg.long_only_leverage,
             "leadership_overlay ENABLED — run may alter basket behavior in flagged sectors"
         );
     }
+    let mut overlay_picker = BasketOverlayPickerHandle::from_kind(
+        options.overlay_picker,
+        options.leadership_overlay.as_ref().map(|cfg| cfg.mode),
+    );
+    let picker_state_path = overlay_picker_state_path(state_path);
+    match overlay_picker.load_state(&picker_state_path) {
+        Ok(true) => info!(
+            state_path = %picker_state_path.display(),
+            picker_id = overlay_picker.id(),
+            "loaded persisted basket overlay picker state"
+        ),
+        Ok(false) => {
+            overlay_picker.save_state(&picker_state_path)?;
+        }
+        Err(e) => return Err(e),
+    }
+    info!(
+        picker_id = overlay_picker.id(),
+        "basket overlay picker initialized"
+    );
 
     let startup_phase = classify_startup_phase(now, last_processed_trading_day, CLOSE_GRACE_MIN);
     let journal = match options.journal_path.as_deref() {
@@ -1058,23 +1205,25 @@ pub async fn run_basket_live(
             execution,
             journal.as_ref(),
             run_id.as_str(),
-            leadership_tracker
-                .as_ref()
-                .map(|t| t.active_sectors_for_today().clone())
-                .unwrap_or_default(),
-            leadership_tracker
-                .as_ref()
-                .map(|t| t.active_symbols_for_today())
-                .unwrap_or_default(),
+            leadership_picker_features(
+                leadership_tracker.as_ref(),
+                strategy_equity_features(&equity_history),
+            ),
+            &mut overlay_picker,
             options.leadership_overlay.as_ref(),
         )
         .await?;
+        overlay_picker.save_state(&picker_state_path)?;
         if let Some(tracker) = leadership_tracker.as_mut() {
             tracker.observe_close_snapshot(&catchup_closes);
             tracker.save_state(&leadership_state_path)?;
         }
         // Hook for replay's daily-equity time series. Noop on AlpacaClient.
         broker.record_eod(today).await;
+        if let Some(mode) = execution.alpaca_mode() {
+            let equity = parse_equity(&broker.get_account(mode).await?)?;
+            push_equity_history(&mut equity_history, equity);
+        }
         last_processed_trading_day = Some(today);
         engine.save_state_with_day(state_path, last_processed_trading_day)?;
         processed_sessions.insert(today);
@@ -1314,17 +1463,15 @@ pub async fn run_basket_live(
                         execution,
                         journal.as_ref(),
                         run_id.as_str(),
-                        leadership_tracker
-                            .as_ref()
-                            .map(|t| t.active_sectors_for_today().clone())
-                            .unwrap_or_default(),
-                        leadership_tracker
-                            .as_ref()
-                            .map(|t| t.active_symbols_for_today())
-                            .unwrap_or_default(),
+                        leadership_picker_features(
+                            leadership_tracker.as_ref(),
+                            strategy_equity_features(&equity_history),
+                        ),
+                        &mut overlay_picker,
                         options.leadership_overlay.as_ref(),
                     )
                     .await?;
+                    overlay_picker.save_state(&picker_state_path)?;
                     if let Some(tracker) = leadership_tracker.as_mut() {
                         tracker.observe_close_snapshot(&closes_for_day);
                         tracker.save_state(&leadership_state_path)?;
@@ -1332,6 +1479,10 @@ pub async fn run_basket_live(
                     // Hook for replay's daily-equity time series.
                     // Noop on AlpacaClient.
                     broker.record_eod(today).await;
+                    if let Some(mode) = execution.alpaca_mode() {
+                        let equity = parse_equity(&broker.get_account(mode).await?)?;
+                        push_equity_history(&mut equity_history, equity);
+                    }
                     last_processed_trading_day = Some(today);
                     engine.save_state_with_day(state_path, last_processed_trading_day)?;
                     info!(
@@ -1618,8 +1769,8 @@ async fn process_session_close(
     execution: BasketExecution,
     journal: Option<&BasketJournal>,
     run_id: &str,
-    leadership_active_sectors: HashSet<String>,
-    leadership_long_symbols: Vec<String>,
+    picker_features: BasketOverlayPickerFeatures,
+    overlay_picker: &mut impl BasketOverlayPicker,
     leadership_overlay: Option<&LeadershipOverlayConfig>,
 ) -> Result<(), String> {
     debug_assert!(
@@ -1653,22 +1804,6 @@ async fn process_session_close(
         log_intent(intent);
     }
 
-    if matches!(
-        leadership_overlay.map(|cfg| cfg.mode),
-        Some(LeadershipOverlayMode::SuppressShorts)
-    ) {
-        let suppressed_baskets =
-            apply_leadership_short_suppression(engine, &leadership_active_sectors);
-        if !suppressed_baskets.is_empty() {
-            info!(
-                date = %date,
-                leadership_active_sectors = ?leadership_active_sectors,
-                suppressed_baskets = ?suppressed_baskets,
-                "leadership short suppression flattened active shorts in flagged sectors"
-            );
-        }
-    }
-
     let allowed_symbols: Vec<String> = closes.keys().cloned().collect();
     if let Some(mode) = execution.alpaca_mode() {
         *current_shares = seed_current_shares_from_alpaca(broker, mode, &allowed_symbols).await?;
@@ -1688,33 +1823,96 @@ async fn process_session_close(
         effective_execution_capital(portfolio_config.capital, execution_account_equity);
 
     // Portfolio layer: apply active-basket admission first, then convert
-    // admitted target notionals to target shares.
-    let plan = plan_portfolio(engine, &effective_portfolio_config);
-    let using_long_replacement = matches!(
-        leadership_overlay.map(|cfg| cfg.mode),
-        Some(LeadershipOverlayMode::ReplaceWithLongOnly)
-    ) && !leadership_long_symbols.is_empty();
-    let using_capped_long_sleeve = matches!(
-        leadership_overlay.map(|cfg| cfg.mode),
-        Some(LeadershipOverlayMode::AddCappedLongSleeve)
-    ) && !leadership_long_symbols.is_empty();
+    // admitted target notionals to target shares. Suppression is planned on
+    // a clone so the core basket engine state remains intact.
+    let baseline_plan = plan_portfolio(engine, &effective_portfolio_config);
+    let baseline_features = add_baseline_plan_features(
+        picker_features,
+        &baseline_plan.symbol_notionals,
+        &effective_portfolio_config,
+        leadership_overlay,
+    );
+    let baseline_excluded_baskets = baseline_plan.excluded_baskets.clone();
+    let picker_decision = overlay_picker.decide(&baseline_features);
+    let leadership_active_sectors = &picker_decision.active_sectors;
+    let leadership_long_symbols = &picker_decision.long_symbols;
+    info!(
+        date = %date,
+        picker_id = overlay_picker.id(),
+        picker_mode = picker_decision.mode.as_str(),
+        picker_reason = picker_decision.reason,
+        leadership_active_sectors = ?leadership_active_sectors,
+        leadership_symbols_active = leadership_long_symbols.len(),
+        leadership_short_conflict_ratio = %format!("{:.4}", baseline_features.leadership_short_conflict_ratio),
+        strategy_return_20d = %format!("{:.4}", baseline_features.strategy_return_20d),
+        strategy_drawdown_20d = %format!("{:.4}", baseline_features.strategy_drawdown_20d),
+        baseline_scale_if_sleeve = %format!("{:.4}", baseline_features.baseline_scale_if_sleeve),
+        sleeve_leverage_scale = %format!("{:.4}", picker_decision.sleeve_leverage_scale),
+        "basket overlay picker decision"
+    );
+    if let Some(journal) = journal {
+        let mut active_sectors: Vec<String> = leadership_active_sectors.iter().cloned().collect();
+        active_sectors.sort();
+        journal.record_picker_decision(&BasketPickerDecisionRecord {
+            run_id,
+            trading_day: date,
+            picker_id: overlay_picker.id(),
+            mode: picker_decision.mode.as_str(),
+            reason: picker_decision.reason,
+            active_sectors_json: serialize_string_vec(&active_sectors),
+            active_symbols_json: serialize_string_vec(leadership_long_symbols),
+            leadership_short_conflict_ratio: baseline_features.leadership_short_conflict_ratio,
+            strategy_return_20d: baseline_features.strategy_return_20d,
+            strategy_drawdown_20d: baseline_features.strategy_drawdown_20d,
+            baseline_scale_if_sleeve: baseline_features.baseline_scale_if_sleeve,
+            sleeve_leverage_scale: picker_decision.sleeve_leverage_scale,
+        })?;
+    }
+
+    let suppressed_baskets = if matches!(picker_decision.mode, BasketOverlayMode::SuppressShorts) {
+        leadership_short_suppression_baskets(engine, leadership_active_sectors)
+    } else {
+        Vec::new()
+    };
+    let plan = if suppressed_baskets.is_empty() {
+        baseline_plan
+    } else {
+        let mut planning_engine = engine.clone();
+        planning_engine.flatten_baskets(&suppressed_baskets);
+        info!(
+            date = %date,
+            leadership_active_sectors = ?leadership_active_sectors,
+            suppressed_baskets = ?suppressed_baskets,
+            "leadership short suppression removed flagged shorts from target plan"
+        );
+        plan_portfolio(&planning_engine, &effective_portfolio_config)
+    };
+    let using_long_replacement =
+        matches!(picker_decision.mode, BasketOverlayMode::ReplaceWithLongOnly)
+            && !leadership_long_symbols.is_empty();
+    let using_capped_long_sleeve =
+        matches!(picker_decision.mode, BasketOverlayMode::AddCappedLongSleeve)
+            && !leadership_long_symbols.is_empty();
     let baseline_target_notionals = plan.symbol_notionals.clone();
     let target_notionals = if using_long_replacement {
         leadership_long_only_notionals(
             closes,
-            &leadership_long_symbols,
+            leadership_long_symbols,
             effective_portfolio_config.capital,
             leadership_overlay
                 .map(|cfg| cfg.long_only_leverage)
                 .unwrap_or(1.0),
         )
     } else if using_capped_long_sleeve {
+        let sleeve_leverage = leadership_overlay
+            .map(|cfg| cfg.long_only_leverage * picker_decision.sleeve_leverage_scale)
+            .unwrap_or(0.0);
         let baseline_gross = baseline_target_notionals
             .values()
             .map(|notional| notional.abs())
             .sum::<f64>();
         let sleeve_budget = leadership_overlay
-            .map(|cfg| cfg.long_only_leverage * effective_portfolio_config.capital)
+            .map(|_| sleeve_leverage * effective_portfolio_config.capital)
             .unwrap_or(0.0)
             .min(effective_portfolio_config.capital * effective_portfolio_config.leverage);
         let baseline_budget = (effective_portfolio_config.capital
@@ -1729,11 +1927,9 @@ async fn process_session_close(
         let scaled_baseline = scale_notionals(&baseline_target_notionals, baseline_scale);
         let sleeve_notionals = leadership_long_only_notionals(
             closes,
-            &leadership_long_symbols,
+            leadership_long_symbols,
             effective_portfolio_config.capital,
-            leadership_overlay
-                .map(|cfg| cfg.long_only_leverage)
-                .unwrap_or(1.0),
+            sleeve_leverage,
         );
         merge_notionals(&scaled_baseline, &sleeve_notionals)
     } else {
@@ -1767,8 +1963,13 @@ async fn process_session_close(
             "leadership overlay transformed baseline basket portfolio"
         );
     }
-    if !using_long_replacement && !plan.excluded_baskets.is_empty() {
-        engine.flatten_baskets(&plan.excluded_baskets);
+    let engine_excluded_baskets = if suppressed_baskets.is_empty() {
+        &plan.excluded_baskets
+    } else {
+        &baseline_excluded_baskets
+    };
+    if !using_long_replacement && !engine_excluded_baskets.is_empty() {
+        engine.flatten_baskets(engine_excluded_baskets);
     }
     let target_shares = target_shares_from_notionals(&target_notionals, closes)?;
 
@@ -1792,14 +1993,15 @@ async fn process_session_close(
     let target_positions_len = target_shares.len();
     info!(
         date = %date,
-        leadership_mode = match leadership_overlay.map(|cfg| cfg.mode) {
-            Some(LeadershipOverlayMode::SuppressShorts) if !leadership_active_sectors.is_empty() => "suppress_shorts",
-            Some(LeadershipOverlayMode::SuppressShorts) => "suppress_shorts_inactive",
-            Some(LeadershipOverlayMode::ReplaceWithLongOnly) if using_long_replacement => "replace_with_long_only",
-            Some(LeadershipOverlayMode::ReplaceWithLongOnly) => "replace_with_long_only_inactive",
-            Some(LeadershipOverlayMode::AddCappedLongSleeve) if using_capped_long_sleeve => "add_capped_long_sleeve",
-            Some(LeadershipOverlayMode::AddCappedLongSleeve) => "add_capped_long_sleeve_inactive",
-            None => "disabled",
+        leadership_mode = match picker_decision.mode {
+            BasketOverlayMode::Baseline if leadership_overlay.is_none() => "disabled",
+            BasketOverlayMode::Baseline => "baseline",
+            BasketOverlayMode::SuppressShorts if !leadership_active_sectors.is_empty() => "suppress_shorts",
+            BasketOverlayMode::SuppressShorts => "suppress_shorts_inactive",
+            BasketOverlayMode::ReplaceWithLongOnly if using_long_replacement => "replace_with_long_only",
+            BasketOverlayMode::ReplaceWithLongOnly => "replace_with_long_only_inactive",
+            BasketOverlayMode::AddCappedLongSleeve if using_capped_long_sleeve => "add_capped_long_sleeve",
+            BasketOverlayMode::AddCappedLongSleeve => "add_capped_long_sleeve_inactive",
         },
         leadership_sectors_active = ?leadership_active_sectors,
         leadership_symbols_active = leadership_long_symbols.len(),
@@ -2678,7 +2880,7 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_leadership_short_suppression_flattens_only_flagged_shorts() {
+    fn test_leadership_short_suppression_selects_only_flagged_shorts_without_mutation() {
         let fits = make_test_fits();
         let mut engine = BasketEngine::new(&fits);
         let states = HashMap::from([
@@ -2699,17 +2901,91 @@ mod tests {
         ]);
         engine.apply_states(states).unwrap();
         let suppressed =
-            apply_leadership_short_suppression(&mut engine, &HashSet::from(["chips".to_string()]));
+            leadership_short_suppression_baskets(&engine, &HashSet::from(["chips".to_string()]));
         assert_eq!(suppressed.len(), 1);
         assert_eq!(basket_sector(&suppressed[0]), "chips");
         assert_eq!(
             engine.get_state(&fits[0].candidate.id()).unwrap().position,
-            0
+            -1
         );
         assert_eq!(
             engine.get_state(&fits[1].candidate.id()).unwrap().position,
             1
         );
+    }
+
+    #[test]
+    fn test_baseline_scale_if_sleeve_respects_gross_budget() {
+        let portfolio_config = PortfolioConfig {
+            capital: 10_000.0,
+            leverage: 4.0,
+            n_active_baskets: 5,
+        };
+        let overlay = LeadershipOverlayConfig {
+            sectors: vec!["chips".to_string()],
+            on_ret5d_threshold: 0.02,
+            on_breadth5d_threshold: 0.56,
+            off_ret5d_threshold: 0.0,
+            off_breadth5d_threshold: 0.5,
+            persistence_days: 2,
+            min_hold_days: 3,
+            mode: BasketOverlayMode::Baseline,
+            long_only_leverage: 1.0,
+        };
+        let baseline_notionals = HashMap::from([
+            ("NVDA".to_string(), -10_000.0),
+            ("AAPL".to_string(), 10_000.0),
+            ("UNH".to_string(), 10_000.0),
+            ("CNC".to_string(), -10_000.0),
+        ]);
+
+        let scale =
+            baseline_scale_if_sleeve(&baseline_notionals, &portfolio_config, Some(&overlay));
+
+        assert!((scale - 0.75).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_add_baseline_plan_features_measures_leadership_short_conflict() {
+        let portfolio_config = PortfolioConfig {
+            capital: 10_000.0,
+            leverage: 4.0,
+            n_active_baskets: 5,
+        };
+        let overlay = LeadershipOverlayConfig {
+            sectors: vec!["chips".to_string()],
+            on_ret5d_threshold: 0.02,
+            on_breadth5d_threshold: 0.56,
+            off_ret5d_threshold: 0.0,
+            off_breadth5d_threshold: 0.5,
+            persistence_days: 2,
+            min_hold_days: 3,
+            mode: BasketOverlayMode::Baseline,
+            long_only_leverage: 1.0,
+        };
+        let features = BasketOverlayPickerFeatures {
+            active_sectors: HashSet::from(["chips".to_string()]),
+            long_symbols: vec!["NVDA".to_string(), "AAPL".to_string()],
+            strategy_return_20d: 0.04,
+            strategy_drawdown_20d: 0.01,
+            ..Default::default()
+        };
+        let baseline_notionals = HashMap::from([
+            ("NVDA".to_string(), -10_000.0),
+            ("AAPL".to_string(), 10_000.0),
+            ("UNH".to_string(), 10_000.0),
+            ("CNC".to_string(), -10_000.0),
+        ]);
+
+        let features = add_baseline_plan_features(
+            features,
+            &baseline_notionals,
+            &portfolio_config,
+            Some(&overlay),
+        );
+
+        assert!((features.leadership_short_conflict_ratio - 0.25).abs() < 1e-9);
+        assert!((features.baseline_scale_if_sleeve - 0.75).abs() < 1e-9);
     }
 
     #[test]
@@ -2722,7 +2998,7 @@ mod tests {
             off_breadth5d_threshold: 0.5,
             persistence_days: 1,
             min_hold_days: 2,
-            mode: LeadershipOverlayMode::SuppressShorts,
+            mode: BasketOverlayMode::SuppressShorts,
             long_only_leverage: 1.0,
         };
         let mut tracker = SectorLeadershipTracker::new(
@@ -2760,7 +3036,7 @@ mod tests {
             off_breadth5d_threshold: 0.5,
             persistence_days: 1,
             min_hold_days: 2,
-            mode: LeadershipOverlayMode::SuppressShorts,
+            mode: BasketOverlayMode::SuppressShorts,
             long_only_leverage: 1.0,
         };
         let mut tracker = SectorLeadershipTracker::new(
@@ -2807,7 +3083,7 @@ mod tests {
             off_breadth5d_threshold: 0.5,
             persistence_days: 1,
             min_hold_days: 3,
-            mode: LeadershipOverlayMode::SuppressShorts,
+            mode: BasketOverlayMode::SuppressShorts,
             long_only_leverage: 1.0,
         };
         let sector_members = HashMap::from([(
@@ -2845,7 +3121,7 @@ mod tests {
             off_breadth5d_threshold: 0.5,
             persistence_days: 1,
             min_hold_days: 3,
-            mode: LeadershipOverlayMode::SuppressShorts,
+            mode: BasketOverlayMode::SuppressShorts,
             long_only_leverage: 1.0,
         };
         let sector_members = HashMap::from([(

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -1993,12 +1993,8 @@ async fn process_session_close(
         );
         engine.flatten_baskets(&engine_flatten_baskets);
     }
-    let mut target_shares = target_shares_from_notionals(&target_notionals, closes)?;
-    trim_target_shares_to_gross_cap(
-        &mut target_shares,
-        closes,
-        effective_portfolio_config.capital * effective_portfolio_config.leverage,
-    );
+    let target_shares = target_shares_from_notionals(&target_notionals, closes)?;
+    let executable_target_notionals = notionals_from_target_shares(&target_shares, closes);
 
     // Summary of the notional plan before we diff — this is where yesterday's
     // $340K-on-$100K problem was invisible. Emit gross long, gross short,
@@ -2006,7 +2002,8 @@ async fn process_session_close(
     // without shelling into sqlite. `gross_long + gross_short` = gross
     // notional = leverage × equity (should be ≤ equity × leverage_assumed
     // from the universe TOML).
-    let (gross_long, gross_short, max_abs, sorted_abs) = summarize_notionals(&target_notionals);
+    let (gross_long, gross_short, max_abs, sorted_abs) =
+        summarize_notionals(&executable_target_notionals);
     let median_abs = if sorted_abs.is_empty() {
         0.0
     } else {
@@ -2032,7 +2029,7 @@ async fn process_session_close(
         },
         leadership_sectors_active = ?leadership_active_sectors,
         leadership_symbols_active = leadership_long_symbols.len(),
-        targets = target_notionals.len(),
+        targets = executable_target_notionals.len(),
         target_positions = target_shares.len(),
         current_positions = current_shares.len(),
         gross_long = %format!("{:.0}", gross_long),
@@ -2042,7 +2039,7 @@ async fn process_session_close(
         net_notional = %format!("{:.0}", gross_long + gross_short),
         max_abs_leg = %format!("{:.0}", max_abs),
         median_abs_leg = %format!("{:.0}", median_abs),
-        top_abs_legs = ?top_abs_notional_legs(&target_notionals, 6),
+        top_abs_legs = ?top_abs_notional_legs(&executable_target_notionals, 6),
         "target notionals summary"
     );
     if gross_notional > gross_cap + 1.0 {
@@ -2475,7 +2472,12 @@ fn target_shares_from_notionals(
                 continue;
             }
         };
-        let shares = (notional / price).round();
+        let raw_shares = notional / price;
+        let shares = if raw_shares > 0.0 {
+            raw_shares.floor()
+        } else {
+            raw_shares.ceil()
+        };
         if shares.abs() >= 1.0 {
             target_shares.insert(symbol.clone(), shares);
         }
@@ -2491,52 +2493,23 @@ fn target_shares_from_notionals(
     }
 }
 
-fn trim_target_shares_to_gross_cap(
-    target_shares: &mut HashMap<String, f64>,
+fn notionals_from_target_shares(
+    target_shares: &HashMap<String, f64>,
     closes: &HashMap<String, f64>,
-    gross_cap: f64,
-) {
-    if !gross_cap.is_finite() || gross_cap <= 0.0 {
-        target_shares.clear();
-        return;
-    }
-
-    loop {
-        let current_gross: f64 = target_shares
-            .iter()
-            .filter_map(|(symbol, shares)| closes.get(symbol).map(|price| shares.abs() * price))
-            .sum();
-        if current_gross <= gross_cap + 1.0 {
-            break;
-        }
-
-        let Some((symbol_to_trim, _)) = target_shares
-            .iter()
-            .filter_map(|(symbol, shares)| {
-                closes
-                    .get(symbol)
-                    .filter(|price| price.is_finite() && **price > 0.0 && shares.abs() >= 1.0)
-                    .map(|price| (symbol.clone(), shares.abs() * price))
+) -> HashMap<String, f64> {
+    target_shares
+        .iter()
+        .filter_map(|(symbol, shares)| {
+            closes.get(symbol).and_then(|price| {
+                let notional = shares * price;
+                if notional.is_finite() && notional.abs() > f64::EPSILON {
+                    Some((symbol.clone(), notional))
+                } else {
+                    None
+                }
             })
-            .max_by(|(lhs_symbol, lhs_notional), (rhs_symbol, rhs_notional)| {
-                lhs_notional
-                    .partial_cmp(rhs_notional)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-                    .then_with(|| lhs_symbol.cmp(rhs_symbol))
-            })
-        else {
-            break;
-        };
-
-        let remove_symbol = {
-            let shares = target_shares.get_mut(&symbol_to_trim).unwrap();
-            *shares -= shares.signum();
-            shares.abs() < 1.0
-        };
-        if remove_symbol {
-            target_shares.remove(&symbol_to_trim);
-        }
-    }
+        })
+        .collect()
 }
 
 /// Summarize a `target_notionals` map into (gross_long, gross_short, max_abs,
@@ -2940,10 +2913,10 @@ mod tests {
     }
 
     #[test]
-    fn test_target_shares_from_notionals_rounds_to_whole_shares() {
+    fn test_target_shares_from_notionals_truncates_toward_zero() {
         let mut notionals = HashMap::new();
         notionals.insert("AMD".to_string(), 5050.0);
-        notionals.insert("NVDA".to_string(), -2400.0);
+        notionals.insert("NVDA".to_string(), -2501.0);
 
         let mut closes = HashMap::new();
         closes.insert("AMD".to_string(), 101.0);
@@ -2955,25 +2928,20 @@ mod tests {
     }
 
     #[test]
-    fn test_trim_target_shares_to_gross_cap_reduces_rounded_overshoot() {
-        let mut shares = HashMap::from([
+    fn test_notionals_from_target_shares_uses_executable_share_book() {
+        let shares = HashMap::from([
             ("AAA".to_string(), 2.0),
-            ("BBB".to_string(), 2.0),
-            ("CCC".to_string(), -2.0),
+            ("BBB".to_string(), -3.0),
         ]);
         let closes = HashMap::from([
             ("AAA".to_string(), 100.0),
-            ("BBB".to_string(), 100.0),
-            ("CCC".to_string(), 100.0),
+            ("BBB".to_string(), 50.0),
         ]);
 
-        trim_target_shares_to_gross_cap(&mut shares, &closes, 500.0);
+        let notionals = notionals_from_target_shares(&shares, &closes);
 
-        let gross: f64 = shares
-            .iter()
-            .map(|(symbol, qty)| qty.abs() * closes.get(symbol).unwrap())
-            .sum();
-        assert!(gross <= 501.0, "gross remained too large: {gross}");
+        assert_eq!(notionals.get("AAA").copied(), Some(200.0));
+        assert_eq!(notionals.get("BBB").copied(), Some(-150.0));
     }
 
     #[test]

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -2929,14 +2929,8 @@ mod tests {
 
     #[test]
     fn test_notionals_from_target_shares_uses_executable_share_book() {
-        let shares = HashMap::from([
-            ("AAA".to_string(), 2.0),
-            ("BBB".to_string(), -3.0),
-        ]);
-        let closes = HashMap::from([
-            ("AAA".to_string(), 100.0),
-            ("BBB".to_string(), 50.0),
-        ]);
+        let shares = HashMap::from([("AAA".to_string(), 2.0), ("BBB".to_string(), -3.0)]);
+        let closes = HashMap::from([("AAA".to_string(), 100.0), ("BBB".to_string(), 50.0)]);
 
         let notionals = notionals_from_target_shares(&shares, &closes);
 
@@ -3044,8 +3038,7 @@ mod tests {
             active_baskets: 2,
         };
 
-        let flattened =
-            engine_flatten_baskets_for_plan(&plan, &["suppressed".to_string()], true);
+        let flattened = engine_flatten_baskets_for_plan(&plan, &["suppressed".to_string()], true);
 
         assert!(flattened.is_empty());
     }

--- a/engine/crates/runner/src/basket_overlay_picker.rs
+++ b/engine/crates/runner/src/basket_overlay_picker.rs
@@ -1,0 +1,741 @@
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BasketOverlayMode {
+    Baseline,
+    SuppressShorts,
+    ReplaceWithLongOnly,
+    AddCappedLongSleeve,
+}
+
+impl BasketOverlayMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Baseline => "baseline",
+            Self::SuppressShorts => "suppress_shorts",
+            Self::ReplaceWithLongOnly => "replace_with_long_only",
+            Self::AddCappedLongSleeve => "add_capped_long_sleeve",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BasketOverlayPickerKind {
+    Fixed,
+    RuleV1,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct BasketOverlayPickerFeatures {
+    pub active_sectors: HashSet<String>,
+    pub long_symbols: Vec<String>,
+    pub leadership_short_conflict_ratio: f64,
+    pub strategy_return_20d: f64,
+    pub strategy_drawdown_20d: f64,
+    pub baseline_scale_if_sleeve: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BasketOverlayPickerDecision {
+    pub mode: BasketOverlayMode,
+    pub reason: &'static str,
+    pub active_sectors: HashSet<String>,
+    pub long_symbols: Vec<String>,
+    pub sleeve_leverage_scale: f64,
+}
+
+impl BasketOverlayPickerDecision {
+    pub fn baseline(reason: &'static str) -> Self {
+        Self {
+            mode: BasketOverlayMode::Baseline,
+            reason,
+            active_sectors: HashSet::new(),
+            long_symbols: Vec::new(),
+            sleeve_leverage_scale: 1.0,
+        }
+    }
+
+    fn from_mode(
+        mode: BasketOverlayMode,
+        reason: &'static str,
+        features: &BasketOverlayPickerFeatures,
+    ) -> Self {
+        if mode == BasketOverlayMode::Baseline {
+            return Self::baseline(reason);
+        }
+        Self {
+            mode,
+            reason,
+            active_sectors: features.active_sectors.clone(),
+            long_symbols: features.long_symbols.clone(),
+            sleeve_leverage_scale: 1.0,
+        }
+    }
+
+    fn with_sleeve_scale(mut self, scale: f64) -> Self {
+        self.sleeve_leverage_scale = if scale.is_finite() {
+            scale.clamp(0.0, 1.0)
+        } else {
+            1.0
+        };
+        self
+    }
+}
+
+pub trait BasketOverlayPicker {
+    fn id(&self) -> &'static str;
+
+    fn decide(&mut self, features: &BasketOverlayPickerFeatures) -> BasketOverlayPickerDecision;
+}
+
+#[derive(Debug, Default)]
+pub struct BaselineOverlayPicker;
+
+impl BasketOverlayPicker for BaselineOverlayPicker {
+    fn id(&self) -> &'static str {
+        "baseline"
+    }
+
+    fn decide(&mut self, _features: &BasketOverlayPickerFeatures) -> BasketOverlayPickerDecision {
+        BasketOverlayPickerDecision::baseline("no_picker_configured")
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct FixedOverlayPicker {
+    mode: BasketOverlayMode,
+}
+
+impl FixedOverlayPicker {
+    pub fn new(mode: BasketOverlayMode) -> Self {
+        Self { mode }
+    }
+}
+
+impl BasketOverlayPicker for FixedOverlayPicker {
+    fn id(&self) -> &'static str {
+        "fixed_overlay"
+    }
+
+    fn decide(&mut self, features: &BasketOverlayPickerFeatures) -> BasketOverlayPickerDecision {
+        BasketOverlayPickerDecision::from_mode(self.mode, "configured_overlay_mode", features)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RuleV1OverlayPickerConfig {
+    pub min_dwell_days: usize,
+    pub off_confirmation_days: usize,
+    pub suppress_conflict_on_threshold: f64,
+    pub suppress_conflict_off_threshold: f64,
+    pub weak_return_threshold: f64,
+    pub drawdown_on_threshold: f64,
+    pub recovered_return_threshold: f64,
+    pub recovered_drawdown_threshold: f64,
+    pub sleeve_return_ceiling: f64,
+    pub min_baseline_scale_for_sleeve: f64,
+    pub opportunistic_sleeve_min_baseline_scale: f64,
+    pub opportunistic_sleeve_return_ceiling: f64,
+    pub halve_sleeve_drawdown_threshold: f64,
+    pub quarter_sleeve_drawdown_threshold: f64,
+}
+
+impl Default for RuleV1OverlayPickerConfig {
+    fn default() -> Self {
+        Self {
+            min_dwell_days: 5,
+            off_confirmation_days: 2,
+            suppress_conflict_on_threshold: 0.15,
+            suppress_conflict_off_threshold: 0.05,
+            weak_return_threshold: 0.0,
+            drawdown_on_threshold: 0.05,
+            recovered_return_threshold: 0.03,
+            recovered_drawdown_threshold: 0.03,
+            sleeve_return_ceiling: 0.03,
+            min_baseline_scale_for_sleeve: 0.70,
+            opportunistic_sleeve_min_baseline_scale: 0.85,
+            opportunistic_sleeve_return_ceiling: 0.10,
+            halve_sleeve_drawdown_threshold: 0.05,
+            quarter_sleeve_drawdown_threshold: 0.10,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuleV1OverlayPicker {
+    config: RuleV1OverlayPickerConfig,
+    current_mode: BasketOverlayMode,
+    dwell_remaining_days: usize,
+    off_signal_days: usize,
+}
+
+impl RuleV1OverlayPicker {
+    pub fn new(config: RuleV1OverlayPickerConfig) -> Self {
+        Self {
+            config,
+            current_mode: BasketOverlayMode::Baseline,
+            dwell_remaining_days: 0,
+            off_signal_days: 0,
+        }
+    }
+
+    fn leadership_on(features: &BasketOverlayPickerFeatures) -> bool {
+        !features.active_sectors.is_empty() && !features.long_symbols.is_empty()
+    }
+
+    fn strategy_weak(&self, features: &BasketOverlayPickerFeatures) -> bool {
+        features.strategy_return_20d <= self.config.weak_return_threshold
+            || features.strategy_drawdown_20d >= self.config.drawdown_on_threshold
+    }
+
+    fn strategy_recovered(&self, features: &BasketOverlayPickerFeatures) -> bool {
+        features.strategy_return_20d >= self.config.recovered_return_threshold
+            && features.strategy_drawdown_20d <= self.config.recovered_drawdown_threshold
+    }
+
+    fn sleeve_allowed(&self, features: &BasketOverlayPickerFeatures) -> bool {
+        features.baseline_scale_if_sleeve >= self.config.min_baseline_scale_for_sleeve
+            && (self.strategy_weak(features)
+                || features.strategy_return_20d <= self.config.sleeve_return_ceiling)
+    }
+
+    fn opportunistic_sleeve_allowed(&self, features: &BasketOverlayPickerFeatures) -> bool {
+        features.baseline_scale_if_sleeve >= self.config.opportunistic_sleeve_min_baseline_scale
+            && features.strategy_return_20d <= self.config.opportunistic_sleeve_return_ceiling
+            && features.leadership_short_conflict_ratio < self.config.suppress_conflict_on_threshold
+    }
+
+    fn sleeve_scale(&self, features: &BasketOverlayPickerFeatures) -> f64 {
+        if features.strategy_drawdown_20d >= self.config.quarter_sleeve_drawdown_threshold {
+            0.25
+        } else if features.strategy_drawdown_20d >= self.config.halve_sleeve_drawdown_threshold
+            && features.strategy_return_20d >= self.config.weak_return_threshold
+        {
+            0.5
+        } else {
+            1.0
+        }
+    }
+
+    fn enter(
+        &mut self,
+        mode: BasketOverlayMode,
+        reason: &'static str,
+        features: &BasketOverlayPickerFeatures,
+    ) -> BasketOverlayPickerDecision {
+        self.current_mode = mode;
+        self.dwell_remaining_days = self.config.min_dwell_days;
+        self.off_signal_days = 0;
+        BasketOverlayPickerDecision::from_mode(mode, reason, features)
+    }
+
+    fn hold(
+        &self,
+        reason: &'static str,
+        features: &BasketOverlayPickerFeatures,
+    ) -> BasketOverlayPickerDecision {
+        BasketOverlayPickerDecision::from_mode(self.current_mode, reason, features)
+    }
+}
+
+impl Default for RuleV1OverlayPicker {
+    fn default() -> Self {
+        Self::new(RuleV1OverlayPickerConfig::default())
+    }
+}
+
+impl BasketOverlayPicker for RuleV1OverlayPicker {
+    fn id(&self) -> &'static str {
+        "rule_v1"
+    }
+
+    fn decide(&mut self, features: &BasketOverlayPickerFeatures) -> BasketOverlayPickerDecision {
+        if self.dwell_remaining_days > 0 {
+            self.dwell_remaining_days -= 1;
+            let decision = self.hold("min_dwell", features);
+            return if self.current_mode == BasketOverlayMode::AddCappedLongSleeve {
+                decision.with_sleeve_scale(self.sleeve_scale(features))
+            } else {
+                decision
+            };
+        }
+
+        let leadership_on = Self::leadership_on(features);
+        match self.current_mode {
+            BasketOverlayMode::Baseline => {
+                self.off_signal_days = 0;
+                if !leadership_on {
+                    return BasketOverlayPickerDecision::baseline("no_leadership");
+                }
+                let material_short_conflict = features.leadership_short_conflict_ratio
+                    >= self.config.suppress_conflict_on_threshold;
+                if material_short_conflict && self.strategy_recovered(features) {
+                    return self.enter(
+                        BasketOverlayMode::SuppressShorts,
+                        "leadership_short_conflict",
+                        features,
+                    );
+                }
+                if !self.sleeve_allowed(features) {
+                    if self.opportunistic_sleeve_allowed(features) {
+                        return self
+                            .enter(
+                                BasketOverlayMode::AddCappedLongSleeve,
+                                "leadership_spare_budget",
+                                features,
+                            )
+                            .with_sleeve_scale(self.sleeve_scale(features));
+                    }
+                    if !self.strategy_weak(features) {
+                        return BasketOverlayPickerDecision::baseline("leadership_basket_healthy");
+                    }
+                    return BasketOverlayPickerDecision::baseline("sleeve_crowds_baseline");
+                }
+                self.enter(
+                    BasketOverlayMode::AddCappedLongSleeve,
+                    "leadership_weak_basket",
+                    features,
+                )
+                .with_sleeve_scale(self.sleeve_scale(features))
+            }
+            BasketOverlayMode::SuppressShorts => {
+                let off_signal = !leadership_on
+                    || features.leadership_short_conflict_ratio
+                        <= self.config.suppress_conflict_off_threshold;
+                if off_signal {
+                    self.off_signal_days += 1;
+                } else {
+                    self.off_signal_days = 0;
+                }
+                if self.off_signal_days >= self.config.off_confirmation_days {
+                    self.current_mode = BasketOverlayMode::Baseline;
+                    self.off_signal_days = 0;
+                    return BasketOverlayPickerDecision::baseline("suppress_signal_cleared");
+                }
+                self.hold("suppress_signal_still_active", features)
+            }
+            BasketOverlayMode::AddCappedLongSleeve => {
+                if !leadership_on {
+                    self.off_signal_days += 1;
+                } else {
+                    self.off_signal_days = 0;
+                }
+                if self.off_signal_days >= self.config.off_confirmation_days {
+                    self.current_mode = BasketOverlayMode::Baseline;
+                    self.off_signal_days = 0;
+                    return BasketOverlayPickerDecision::baseline("sleeve_signal_cleared");
+                }
+                self.hold("sleeve_signal_still_active", features)
+                    .with_sleeve_scale(self.sleeve_scale(features))
+            }
+            BasketOverlayMode::ReplaceWithLongOnly => {
+                self.current_mode = BasketOverlayMode::Baseline;
+                BasketOverlayPickerDecision::baseline("replace_not_allowed")
+            }
+        }
+    }
+}
+
+pub enum BasketOverlayPickerHandle {
+    Baseline(BaselineOverlayPicker),
+    Fixed(FixedOverlayPicker),
+    RuleV1(RuleV1OverlayPicker),
+}
+
+impl BasketOverlayPickerHandle {
+    pub fn from_kind(
+        kind: BasketOverlayPickerKind,
+        configured_mode: Option<BasketOverlayMode>,
+    ) -> Self {
+        match kind {
+            BasketOverlayPickerKind::Fixed => configured_mode
+                .map(FixedOverlayPicker::new)
+                .map(Self::Fixed)
+                .unwrap_or_else(|| Self::Baseline(BaselineOverlayPicker)),
+            BasketOverlayPickerKind::RuleV1 => Self::RuleV1(RuleV1OverlayPicker::default()),
+        }
+    }
+
+    pub fn load_state(&mut self, path: &std::path::Path) -> Result<bool, String> {
+        if !path.exists() {
+            return Ok(false);
+        }
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| format!("read overlay picker state {}: {e}", path.display()))?;
+        let state: BasketOverlayPickerState = serde_json::from_str(&content)
+            .map_err(|e| format!("parse overlay picker state {}: {e}", path.display()))?;
+        if state.picker_id != self.id() {
+            return Ok(false);
+        }
+        match (self, state.rule_v1) {
+            (Self::RuleV1(picker), Some(rule_state)) => {
+                if picker.config != rule_state.config {
+                    return Ok(false);
+                }
+                *picker = rule_state;
+                Ok(true)
+            }
+            (Self::Baseline(_), None) | (Self::Fixed(_), None) => Ok(true),
+            _ => Ok(false),
+        }
+    }
+
+    pub fn save_state(&self, path: &std::path::Path) -> Result<(), String> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("create picker state dir {}: {e}", parent.display()))?;
+        }
+        let state = BasketOverlayPickerState {
+            picker_id: self.id().to_string(),
+            rule_v1: match self {
+                Self::RuleV1(picker) => Some(picker.clone()),
+                Self::Baseline(_) | Self::Fixed(_) => None,
+            },
+        };
+        let content = serde_json::to_string_pretty(&state)
+            .map_err(|e| format!("serialize overlay picker state: {e}"))?;
+        let tmp = path.with_extension("picker.tmp");
+        std::fs::write(&tmp, content)
+            .map_err(|e| format!("write overlay picker tmp {}: {e}", tmp.display()))?;
+        std::fs::rename(&tmp, path)
+            .map_err(|e| format!("rename overlay picker state {}: {e}", path.display()))
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct BasketOverlayPickerState {
+    picker_id: String,
+    rule_v1: Option<RuleV1OverlayPicker>,
+}
+
+impl BasketOverlayPicker for BasketOverlayPickerHandle {
+    fn id(&self) -> &'static str {
+        match self {
+            Self::Baseline(picker) => picker.id(),
+            Self::Fixed(picker) => picker.id(),
+            Self::RuleV1(picker) => picker.id(),
+        }
+    }
+
+    fn decide(&mut self, features: &BasketOverlayPickerFeatures) -> BasketOverlayPickerDecision {
+        match self {
+            Self::Baseline(picker) => picker.decide(features),
+            Self::Fixed(picker) => picker.decide(features),
+            Self::RuleV1(picker) => picker.decide(features),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn baseline_picker_ignores_feature_payload() {
+        let features = BasketOverlayPickerFeatures {
+            active_sectors: HashSet::from(["chips".to_string()]),
+            long_symbols: vec!["NVDA".to_string()],
+            leadership_short_conflict_ratio: 0.0,
+            strategy_return_20d: 0.0,
+            strategy_drawdown_20d: 0.0,
+            baseline_scale_if_sleeve: 1.0,
+        };
+
+        let mut picker = BaselineOverlayPicker;
+        let decision = picker.decide(&features);
+
+        assert_eq!(decision.mode, BasketOverlayMode::Baseline);
+        assert!(decision.active_sectors.is_empty());
+        assert!(decision.long_symbols.is_empty());
+    }
+
+    #[test]
+    fn fixed_picker_freezes_feature_payload() {
+        let features = BasketOverlayPickerFeatures {
+            active_sectors: HashSet::from(["chips".to_string()]),
+            long_symbols: vec!["NVDA".to_string(), "AMD".to_string()],
+            leadership_short_conflict_ratio: 0.0,
+            strategy_return_20d: 0.0,
+            strategy_drawdown_20d: 0.0,
+            baseline_scale_if_sleeve: 1.0,
+        };
+
+        let mut picker = FixedOverlayPicker::new(BasketOverlayMode::AddCappedLongSleeve);
+        let decision = picker.decide(&features);
+
+        assert_eq!(decision.mode, BasketOverlayMode::AddCappedLongSleeve);
+        assert_eq!(decision.active_sectors, features.active_sectors);
+        assert_eq!(decision.long_symbols, features.long_symbols);
+    }
+
+    #[test]
+    fn rule_v1_uses_suppress_for_material_short_conflict() {
+        let mut picker = RuleV1OverlayPicker::new(RuleV1OverlayPickerConfig {
+            min_dwell_days: 0,
+            off_confirmation_days: 2,
+            suppress_conflict_on_threshold: 0.15,
+            suppress_conflict_off_threshold: 0.05,
+            ..RuleV1OverlayPickerConfig::default()
+        });
+        let features = BasketOverlayPickerFeatures {
+            active_sectors: HashSet::from(["chips".to_string()]),
+            long_symbols: vec!["NVDA".to_string()],
+            leadership_short_conflict_ratio: 0.25,
+            strategy_return_20d: 0.10,
+            strategy_drawdown_20d: 0.0,
+            baseline_scale_if_sleeve: 1.0,
+        };
+
+        let decision = picker.decide(&features);
+
+        assert_eq!(decision.mode, BasketOverlayMode::SuppressShorts);
+        assert_eq!(decision.reason, "leadership_short_conflict");
+    }
+
+    #[test]
+    fn rule_v1_uses_sleeve_when_leadership_has_no_short_conflict_and_strategy_is_weak() {
+        let mut picker = RuleV1OverlayPicker::new(RuleV1OverlayPickerConfig {
+            min_dwell_days: 0,
+            off_confirmation_days: 2,
+            suppress_conflict_on_threshold: 0.15,
+            suppress_conflict_off_threshold: 0.05,
+            ..RuleV1OverlayPickerConfig::default()
+        });
+        let features = BasketOverlayPickerFeatures {
+            active_sectors: HashSet::from(["faang".to_string()]),
+            long_symbols: vec!["META".to_string()],
+            leadership_short_conflict_ratio: 0.0,
+            strategy_return_20d: -0.02,
+            strategy_drawdown_20d: 0.06,
+            baseline_scale_if_sleeve: 0.75,
+        };
+
+        let decision = picker.decide(&features);
+
+        assert_eq!(decision.mode, BasketOverlayMode::AddCappedLongSleeve);
+        assert_eq!(decision.reason, "leadership_weak_basket");
+    }
+
+    #[test]
+    fn rule_v1_stays_baseline_when_basket_is_healthy() {
+        let mut picker = RuleV1OverlayPicker::new(RuleV1OverlayPickerConfig {
+            min_dwell_days: 0,
+            off_confirmation_days: 2,
+            suppress_conflict_on_threshold: 0.15,
+            suppress_conflict_off_threshold: 0.05,
+            ..RuleV1OverlayPickerConfig::default()
+        });
+        let features = BasketOverlayPickerFeatures {
+            active_sectors: HashSet::from(["faang".to_string()]),
+            long_symbols: vec!["META".to_string()],
+            leadership_short_conflict_ratio: 0.0,
+            strategy_return_20d: 0.07,
+            strategy_drawdown_20d: 0.01,
+            baseline_scale_if_sleeve: 0.75,
+        };
+
+        let decision = picker.decide(&features);
+
+        assert_eq!(decision.mode, BasketOverlayMode::Baseline);
+        assert_eq!(decision.reason, "leadership_basket_healthy");
+    }
+
+    #[test]
+    fn rule_v1_uses_opportunistic_sleeve_when_it_does_not_crowd_the_basket() {
+        let mut picker = RuleV1OverlayPicker::new(RuleV1OverlayPickerConfig {
+            min_dwell_days: 0,
+            off_confirmation_days: 2,
+            ..RuleV1OverlayPickerConfig::default()
+        });
+        let features = BasketOverlayPickerFeatures {
+            active_sectors: HashSet::from(["chips".to_string()]),
+            long_symbols: vec!["NVDA".to_string()],
+            leadership_short_conflict_ratio: 0.10,
+            strategy_return_20d: 0.08,
+            strategy_drawdown_20d: 0.01,
+            baseline_scale_if_sleeve: 0.90,
+        };
+
+        let decision = picker.decide(&features);
+
+        assert_eq!(decision.mode, BasketOverlayMode::AddCappedLongSleeve);
+        assert_eq!(decision.reason, "leadership_spare_budget");
+    }
+
+    #[test]
+    fn rule_v1_avoids_opportunistic_sleeve_when_basket_is_too_strong() {
+        let mut picker = RuleV1OverlayPicker::new(RuleV1OverlayPickerConfig {
+            min_dwell_days: 0,
+            off_confirmation_days: 2,
+            ..RuleV1OverlayPickerConfig::default()
+        });
+        let features = BasketOverlayPickerFeatures {
+            active_sectors: HashSet::from(["chips".to_string()]),
+            long_symbols: vec!["NVDA".to_string()],
+            leadership_short_conflict_ratio: 0.10,
+            strategy_return_20d: 0.12,
+            strategy_drawdown_20d: 0.01,
+            baseline_scale_if_sleeve: 0.90,
+        };
+
+        let decision = picker.decide(&features);
+
+        assert_eq!(decision.mode, BasketOverlayMode::Baseline);
+        assert_eq!(decision.reason, "leadership_basket_healthy");
+    }
+
+    #[test]
+    fn rule_v1_uses_suppress_not_opportunistic_sleeve_when_short_conflict_is_material() {
+        let mut picker = RuleV1OverlayPicker::new(RuleV1OverlayPickerConfig {
+            min_dwell_days: 0,
+            off_confirmation_days: 2,
+            ..RuleV1OverlayPickerConfig::default()
+        });
+        let features = BasketOverlayPickerFeatures {
+            active_sectors: HashSet::from(["chips".to_string()]),
+            long_symbols: vec!["NVDA".to_string()],
+            leadership_short_conflict_ratio: 0.18,
+            strategy_return_20d: 0.08,
+            strategy_drawdown_20d: 0.01,
+            baseline_scale_if_sleeve: 0.90,
+        };
+
+        let decision = picker.decide(&features);
+
+        assert_eq!(decision.mode, BasketOverlayMode::SuppressShorts);
+        assert_eq!(decision.reason, "leadership_short_conflict");
+    }
+
+    #[test]
+    fn rule_v1_holds_sleeve_while_leadership_stays_active_after_recovery() {
+        let mut picker = RuleV1OverlayPicker::new(RuleV1OverlayPickerConfig {
+            min_dwell_days: 0,
+            off_confirmation_days: 2,
+            ..RuleV1OverlayPickerConfig::default()
+        });
+        let weak_features = BasketOverlayPickerFeatures {
+            active_sectors: HashSet::from(["faang".to_string()]),
+            long_symbols: vec!["META".to_string()],
+            leadership_short_conflict_ratio: 0.0,
+            strategy_return_20d: -0.02,
+            strategy_drawdown_20d: 0.04,
+            baseline_scale_if_sleeve: 0.90,
+        };
+        let recovered_features = BasketOverlayPickerFeatures {
+            active_sectors: HashSet::from(["faang".to_string()]),
+            long_symbols: vec!["META".to_string()],
+            leadership_short_conflict_ratio: 0.0,
+            strategy_return_20d: 0.12,
+            strategy_drawdown_20d: 0.0,
+            baseline_scale_if_sleeve: 0.90,
+        };
+
+        assert_eq!(
+            picker.decide(&weak_features).mode,
+            BasketOverlayMode::AddCappedLongSleeve
+        );
+        let decision = picker.decide(&recovered_features);
+
+        assert_eq!(decision.mode, BasketOverlayMode::AddCappedLongSleeve);
+        assert_eq!(decision.reason, "sleeve_signal_still_active");
+    }
+
+    #[test]
+    fn rule_v1_uses_sleeve_not_suppress_when_conflict_exists_but_basket_is_not_healthy() {
+        let mut picker = RuleV1OverlayPicker::new(RuleV1OverlayPickerConfig {
+            min_dwell_days: 0,
+            off_confirmation_days: 2,
+            suppress_conflict_on_threshold: 0.15,
+            suppress_conflict_off_threshold: 0.05,
+            ..RuleV1OverlayPickerConfig::default()
+        });
+        let features = BasketOverlayPickerFeatures {
+            active_sectors: HashSet::from(["chips".to_string()]),
+            long_symbols: vec!["NVDA".to_string()],
+            leadership_short_conflict_ratio: 0.25,
+            strategy_return_20d: -0.01,
+            strategy_drawdown_20d: 0.04,
+            baseline_scale_if_sleeve: 0.90,
+        };
+
+        let decision = picker.decide(&features);
+
+        assert_eq!(decision.mode, BasketOverlayMode::AddCappedLongSleeve);
+        assert_eq!(decision.reason, "leadership_weak_basket");
+    }
+
+    #[test]
+    fn rule_v1_scales_sleeve_down_in_drawdown() {
+        let mut picker = RuleV1OverlayPicker::new(RuleV1OverlayPickerConfig {
+            min_dwell_days: 0,
+            off_confirmation_days: 2,
+            ..RuleV1OverlayPickerConfig::default()
+        });
+        let features = BasketOverlayPickerFeatures {
+            active_sectors: HashSet::from(["faang".to_string()]),
+            long_symbols: vec!["META".to_string()],
+            leadership_short_conflict_ratio: 0.0,
+            strategy_return_20d: 0.02,
+            strategy_drawdown_20d: 0.08,
+            baseline_scale_if_sleeve: 0.90,
+        };
+
+        let decision = picker.decide(&features);
+
+        assert_eq!(decision.mode, BasketOverlayMode::AddCappedLongSleeve);
+        assert_eq!(decision.sleeve_leverage_scale, 0.5);
+    }
+
+    #[test]
+    fn rule_v1_keeps_rescue_sleeve_full_until_deeper_drawdown() {
+        let mut picker = RuleV1OverlayPicker::new(RuleV1OverlayPickerConfig {
+            min_dwell_days: 0,
+            off_confirmation_days: 2,
+            ..RuleV1OverlayPickerConfig::default()
+        });
+        let features = BasketOverlayPickerFeatures {
+            active_sectors: HashSet::from(["faang".to_string()]),
+            long_symbols: vec!["META".to_string()],
+            leadership_short_conflict_ratio: 0.0,
+            strategy_return_20d: -0.02,
+            strategy_drawdown_20d: 0.08,
+            baseline_scale_if_sleeve: 0.90,
+        };
+
+        let decision = picker.decide(&features);
+
+        assert_eq!(decision.mode, BasketOverlayMode::AddCappedLongSleeve);
+        assert_eq!(decision.sleeve_leverage_scale, 1.0);
+    }
+
+    #[test]
+    fn rule_v1_state_roundtrips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("picker.json");
+        let features = BasketOverlayPickerFeatures {
+            active_sectors: HashSet::from(["chips".to_string()]),
+            long_symbols: vec!["NVDA".to_string()],
+            leadership_short_conflict_ratio: 0.25,
+            strategy_return_20d: 0.08,
+            strategy_drawdown_20d: 0.01,
+            baseline_scale_if_sleeve: 0.75,
+        };
+        let mut picker =
+            BasketOverlayPickerHandle::from_kind(BasketOverlayPickerKind::RuleV1, None);
+        assert_eq!(
+            picker.decide(&features).mode,
+            BasketOverlayMode::SuppressShorts
+        );
+        picker.save_state(&path).unwrap();
+
+        let mut loaded =
+            BasketOverlayPickerHandle::from_kind(BasketOverlayPickerKind::RuleV1, None);
+        assert!(loaded.load_state(&path).unwrap());
+        assert_eq!(
+            loaded.decide(&features).mode,
+            BasketOverlayMode::SuppressShorts
+        );
+    }
+}

--- a/engine/crates/runner/src/main.rs
+++ b/engine/crates/runner/src/main.rs
@@ -20,6 +20,7 @@ mod bar_source;
 mod basket_fits;
 mod basket_journal;
 mod basket_live;
+mod basket_overlay_picker;
 mod broker;
 mod clock;
 mod earnings;
@@ -204,6 +205,10 @@ struct StreamArgs {
     #[arg(long, value_enum)]
     leadership_mode: Option<LeadershipModeArg>,
 
+    /// Basket-only: picker used to choose the overlay mechanism.
+    #[arg(long, value_enum, default_value_t = LeadershipPickerArg::Fixed)]
+    leadership_picker: LeadershipPickerArg,
+
     /// Basket-only: leverage/budget for directional leadership overlay modes.
     /// For `replace_with_long_only`, this is the long-only book leverage.
     /// For `add_capped_long_sleeve`, this is the sleeve gross budget in units of capital.
@@ -345,6 +350,10 @@ struct ReplayArgs {
     #[arg(long, value_enum)]
     leadership_mode: Option<LeadershipModeArg>,
 
+    /// Replay-only: picker used to choose the overlay mechanism.
+    #[arg(long, value_enum, default_value_t = LeadershipPickerArg::Fixed)]
+    leadership_picker: LeadershipPickerArg,
+
     /// Replay-only: leverage/budget for directional leadership overlay modes.
     #[arg(long, default_value_t = 1.0)]
     leadership_long_only_leverage: f64,
@@ -383,6 +392,21 @@ enum LeadershipModeArg {
     AddCappedLongSleeve,
 }
 
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+enum LeadershipPickerArg {
+    Fixed,
+    RuleV1,
+}
+
+impl From<LeadershipPickerArg> for basket_overlay_picker::BasketOverlayPickerKind {
+    fn from(value: LeadershipPickerArg) -> Self {
+        match value {
+            LeadershipPickerArg::Fixed => basket_overlay_picker::BasketOverlayPickerKind::Fixed,
+            LeadershipPickerArg::RuleV1 => basket_overlay_picker::BasketOverlayPickerKind::RuleV1,
+        }
+    }
+}
+
 fn build_leadership_overlay_config(
     universe: &Universe,
     sectors: &[String],
@@ -393,6 +417,7 @@ fn build_leadership_overlay_config(
     persistence_days: Option<usize>,
     min_hold_days: Option<usize>,
     mode: Option<LeadershipModeArg>,
+    picker: LeadershipPickerArg,
     long_only_leverage: f64,
 ) -> Option<basket_live::LeadershipOverlayConfig> {
     if sectors.is_empty()
@@ -403,17 +428,16 @@ fn build_leadership_overlay_config(
         && persistence_days.is_none()
         && min_hold_days.is_none()
         && mode.is_none()
+        && picker == LeadershipPickerArg::Fixed
     {
         return None;
     }
-    if sectors.is_empty()
-        || on_ret5d_threshold.is_none()
-        || on_breadth5d_threshold.is_none()
-        || mode.is_none()
-    {
-        error!(
-            "leadership overlay requires --leadership-overlay-sectors, --leadership-mode, and both threshold flags"
-        );
+    if sectors.is_empty() || on_ret5d_threshold.is_none() || on_breadth5d_threshold.is_none() {
+        error!("leadership overlay requires --leadership-overlay-sectors and both threshold flags");
+        std::process::exit(2);
+    }
+    if picker == LeadershipPickerArg::Fixed && mode.is_none() {
+        error!("fixed leadership picker requires --leadership-mode");
         std::process::exit(2);
     }
     let unknown: Vec<String> = sectors
@@ -474,24 +498,29 @@ fn build_leadership_overlay_config(
         off_breadth5d_threshold,
         persistence_days,
         min_hold_days,
-        mode: match mode.unwrap() {
-            LeadershipModeArg::SuppressShorts => basket_live::LeadershipOverlayMode::SuppressShorts,
-            LeadershipModeArg::ReplaceWithLongOnly => {
-                basket_live::LeadershipOverlayMode::ReplaceWithLongOnly
-            }
-            LeadershipModeArg::AddCappedLongSleeve => {
-                basket_live::LeadershipOverlayMode::AddCappedLongSleeve
-            }
-        },
+        mode: mode
+            .map(|mode| match mode {
+                LeadershipModeArg::SuppressShorts => {
+                    basket_overlay_picker::BasketOverlayMode::SuppressShorts
+                }
+                LeadershipModeArg::ReplaceWithLongOnly => {
+                    basket_overlay_picker::BasketOverlayMode::ReplaceWithLongOnly
+                }
+                LeadershipModeArg::AddCappedLongSleeve => {
+                    basket_overlay_picker::BasketOverlayMode::AddCappedLongSleeve
+                }
+            })
+            .unwrap_or(basket_overlay_picker::BasketOverlayMode::Baseline),
         long_only_leverage,
     })
 }
 
 fn leadership_overlay_fingerprint(cfg: &basket_live::LeadershipOverlayConfig) -> String {
     let mode = match cfg.mode {
-        basket_live::LeadershipOverlayMode::SuppressShorts => "suppress",
-        basket_live::LeadershipOverlayMode::ReplaceWithLongOnly => "replace",
-        basket_live::LeadershipOverlayMode::AddCappedLongSleeve => "sleeve",
+        basket_overlay_picker::BasketOverlayMode::Baseline => "baseline",
+        basket_overlay_picker::BasketOverlayMode::SuppressShorts => "suppress",
+        basket_overlay_picker::BasketOverlayMode::ReplaceWithLongOnly => "replace",
+        basket_overlay_picker::BasketOverlayMode::AddCappedLongSleeve => "sleeve",
     };
     let sectors = cfg.sectors.join("-");
     let ret = format!("{:.4}", cfg.on_ret5d_threshold).replace('.', "p");
@@ -764,6 +793,7 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
         args.leadership_persistence_days,
         args.leadership_min_hold_days,
         args.leadership_mode,
+        args.leadership_picker,
         args.leadership_long_only_leverage,
     );
     if leadership_overlay.is_some() && matches!(execution, basket_live::BasketExecution::Live) {
@@ -893,6 +923,7 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
             fit_artifact_path: Some(fit_artifact_path.clone()),
             journal_path: Some(basket_journal_path),
             leadership_overlay,
+            overlay_picker: args.leadership_picker.into(),
         },
     )
     .await
@@ -1604,6 +1635,7 @@ async fn run_basket_replay_live_path(args: ReplayArgs) {
         for path in [
             state_path.clone(),
             basket_live::leadership_classifier_state_path(&state_path),
+            basket_live::overlay_picker_state_path(&state_path),
         ] {
             if !path.exists() {
                 continue;
@@ -1669,6 +1701,7 @@ async fn run_basket_replay_live_path(args: ReplayArgs) {
         args.leadership_persistence_days,
         args.leadership_min_hold_days,
         args.leadership_mode,
+        args.leadership_picker,
         args.leadership_long_only_leverage,
     );
 
@@ -1759,6 +1792,7 @@ async fn run_basket_replay_live_path(args: ReplayArgs) {
             fit_artifact_path: None,
             journal_path: None,
             leadership_overlay,
+            overlay_picker: args.leadership_picker.into(),
         },
     )
     .await;

--- a/engine/crates/runner/src/main.rs
+++ b/engine/crates/runner/src/main.rs
@@ -407,9 +407,8 @@ impl From<LeadershipPickerArg> for basket_overlay_picker::BasketOverlayPickerKin
     }
 }
 
-fn build_leadership_overlay_config(
-    universe: &Universe,
-    sectors: &[String],
+struct LeadershipOverlayBuildArgs<'a> {
+    sectors: &'a [String],
     on_ret5d_threshold: Option<f64>,
     on_breadth5d_threshold: Option<f64>,
     off_ret5d_threshold: Option<f64>,
@@ -419,28 +418,37 @@ fn build_leadership_overlay_config(
     mode: Option<LeadershipModeArg>,
     picker: LeadershipPickerArg,
     long_only_leverage: f64,
+}
+
+fn build_leadership_overlay_config(
+    universe: &Universe,
+    args: LeadershipOverlayBuildArgs<'_>,
 ) -> Option<basket_live::LeadershipOverlayConfig> {
-    if sectors.is_empty()
-        && on_ret5d_threshold.is_none()
-        && on_breadth5d_threshold.is_none()
-        && off_ret5d_threshold.is_none()
-        && off_breadth5d_threshold.is_none()
-        && persistence_days.is_none()
-        && min_hold_days.is_none()
-        && mode.is_none()
-        && picker == LeadershipPickerArg::Fixed
+    if args.sectors.is_empty()
+        && args.on_ret5d_threshold.is_none()
+        && args.on_breadth5d_threshold.is_none()
+        && args.off_ret5d_threshold.is_none()
+        && args.off_breadth5d_threshold.is_none()
+        && args.persistence_days.is_none()
+        && args.min_hold_days.is_none()
+        && args.mode.is_none()
+        && args.picker == LeadershipPickerArg::Fixed
     {
         return None;
     }
-    if sectors.is_empty() || on_ret5d_threshold.is_none() || on_breadth5d_threshold.is_none() {
+    if args.sectors.is_empty()
+        || args.on_ret5d_threshold.is_none()
+        || args.on_breadth5d_threshold.is_none()
+    {
         error!("leadership overlay requires --leadership-overlay-sectors and both threshold flags");
         std::process::exit(2);
     }
-    if picker == LeadershipPickerArg::Fixed && mode.is_none() {
+    if args.picker == LeadershipPickerArg::Fixed && args.mode.is_none() {
         error!("fixed leadership picker requires --leadership-mode");
         std::process::exit(2);
     }
-    let unknown: Vec<String> = sectors
+    let unknown: Vec<String> = args
+        .sectors
         .iter()
         .filter(|sector| !universe.sectors.contains_key(sector.as_str()))
         .cloned()
@@ -449,20 +457,20 @@ fn build_leadership_overlay_config(
         error!(unknown = ?unknown, "leadership overlay sectors are not in the basket universe");
         std::process::exit(2);
     }
-    let on_ret5d_threshold = on_ret5d_threshold.unwrap();
+    let on_ret5d_threshold = args.on_ret5d_threshold.unwrap();
     if !on_ret5d_threshold.is_finite() {
         error!("leadership overlay ret5d threshold must be finite");
         std::process::exit(2);
     }
-    let on_breadth5d_threshold = on_breadth5d_threshold.unwrap();
+    let on_breadth5d_threshold = args.on_breadth5d_threshold.unwrap();
     if !on_breadth5d_threshold.is_finite() || !(0.0..=1.0).contains(&on_breadth5d_threshold) {
         error!("leadership overlay breadth5d threshold must be finite and in [0, 1]");
         std::process::exit(2);
     }
-    let off_ret5d_threshold = off_ret5d_threshold.unwrap_or(0.0);
-    let off_breadth5d_threshold = off_breadth5d_threshold.unwrap_or(0.5);
-    let persistence_days = persistence_days.unwrap_or(2);
-    let min_hold_days = min_hold_days.unwrap_or(3);
+    let off_ret5d_threshold = args.off_ret5d_threshold.unwrap_or(0.0);
+    let off_breadth5d_threshold = args.off_breadth5d_threshold.unwrap_or(0.5);
+    let persistence_days = args.persistence_days.unwrap_or(2);
+    let min_hold_days = args.min_hold_days.unwrap_or(3);
     if !off_ret5d_threshold.is_finite() || off_ret5d_threshold > on_ret5d_threshold {
         error!("leadership overlay off ret5d threshold must be finite and <= on threshold");
         std::process::exit(2);
@@ -478,27 +486,28 @@ fn build_leadership_overlay_config(
         error!("leadership overlay persistence/min-hold days must both be > 0");
         std::process::exit(2);
     }
-    if !long_only_leverage.is_finite() || long_only_leverage <= 0.0 {
+    if !args.long_only_leverage.is_finite() || args.long_only_leverage <= 0.0 {
         error!("leadership overlay long-only leverage must be finite and > 0");
         std::process::exit(2);
     }
-    if long_only_leverage > universe.strategy.leverage_assumed + f64::EPSILON {
+    if args.long_only_leverage > universe.strategy.leverage_assumed + f64::EPSILON {
         error!(
-            requested = long_only_leverage,
+            requested = args.long_only_leverage,
             max_allowed = universe.strategy.leverage_assumed,
             "leadership overlay leverage exceeds configured basket leverage"
         );
         std::process::exit(2);
     }
     Some(basket_live::LeadershipOverlayConfig {
-        sectors: sectors.to_vec(),
+        sectors: args.sectors.to_vec(),
         on_ret5d_threshold,
         on_breadth5d_threshold,
         off_ret5d_threshold,
         off_breadth5d_threshold,
         persistence_days,
         min_hold_days,
-        mode: mode
+        mode: args
+            .mode
             .map(|mode| match mode {
                 LeadershipModeArg::SuppressShorts => {
                     basket_overlay_picker::BasketOverlayMode::SuppressShorts
@@ -511,7 +520,7 @@ fn build_leadership_overlay_config(
                 }
             })
             .unwrap_or(basket_overlay_picker::BasketOverlayMode::Baseline),
-        long_only_leverage,
+        long_only_leverage: args.long_only_leverage,
     })
 }
 
@@ -785,16 +794,18 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
     }
     let leadership_overlay = build_leadership_overlay_config(
         &universe,
-        &args.leadership_overlay_sectors,
-        args.leadership_ret5d_threshold,
-        args.leadership_breadth5d_threshold,
-        args.leadership_off_ret5d_threshold,
-        args.leadership_off_breadth5d_threshold,
-        args.leadership_persistence_days,
-        args.leadership_min_hold_days,
-        args.leadership_mode,
-        args.leadership_picker,
-        args.leadership_long_only_leverage,
+        LeadershipOverlayBuildArgs {
+            sectors: &args.leadership_overlay_sectors,
+            on_ret5d_threshold: args.leadership_ret5d_threshold,
+            on_breadth5d_threshold: args.leadership_breadth5d_threshold,
+            off_ret5d_threshold: args.leadership_off_ret5d_threshold,
+            off_breadth5d_threshold: args.leadership_off_breadth5d_threshold,
+            persistence_days: args.leadership_persistence_days,
+            min_hold_days: args.leadership_min_hold_days,
+            mode: args.leadership_mode,
+            picker: args.leadership_picker,
+            long_only_leverage: args.leadership_long_only_leverage,
+        },
     );
     if leadership_overlay.is_some() && matches!(execution, basket_live::BasketExecution::Live) {
         error!(
@@ -1693,16 +1704,18 @@ async fn run_basket_replay_live_path(args: ReplayArgs) {
 
     let leadership_overlay = build_leadership_overlay_config(
         &universe,
-        &args.leadership_overlay_sectors,
-        args.leadership_ret5d_threshold,
-        args.leadership_breadth5d_threshold,
-        args.leadership_off_ret5d_threshold,
-        args.leadership_off_breadth5d_threshold,
-        args.leadership_persistence_days,
-        args.leadership_min_hold_days,
-        args.leadership_mode,
-        args.leadership_picker,
-        args.leadership_long_only_leverage,
+        LeadershipOverlayBuildArgs {
+            sectors: &args.leadership_overlay_sectors,
+            on_ret5d_threshold: args.leadership_ret5d_threshold,
+            on_breadth5d_threshold: args.leadership_breadth5d_threshold,
+            off_ret5d_threshold: args.leadership_off_ret5d_threshold,
+            off_breadth5d_threshold: args.leadership_off_breadth5d_threshold,
+            persistence_days: args.leadership_persistence_days,
+            min_hold_days: args.leadership_min_hold_days,
+            mode: args.leadership_mode,
+            picker: args.leadership_picker,
+            long_only_leverage: args.leadership_long_only_leverage,
+        },
     );
 
     // Walk-forward fit: build the basket fit using data STRICTLY BEFORE

--- a/engine/crates/runner/src/simulated_broker.rs
+++ b/engine/crates/runner/src/simulated_broker.rs
@@ -252,9 +252,15 @@ impl Broker for SimulatedBroker {
         let buying_power = current_equity * self.state.leverage;
         let prev_qty_signed = positions.get(symbol).map(|(q, _)| *q).unwrap_or(0.0);
         let new_qty_signed_full = prev_qty_signed + signed_qty_full;
+        let mut current_gross: f64 = 0.0;
         let mut projected_gross: f64 = 0.0;
         let mut traded_symbol_seen = false;
         for (sym, (q, _)) in positions.iter() {
+            let current_price = closes_snapshot
+                .get(sym)
+                .copied()
+                .unwrap_or_else(|| positions.get(sym).map(|(_, a)| *a).unwrap_or(0.0));
+            current_gross += q.abs() * current_price;
             if sym == symbol {
                 projected_gross += new_qty_signed_full.abs() * price;
                 traded_symbol_seen = true;
@@ -269,7 +275,8 @@ impl Broker for SimulatedBroker {
             projected_gross += new_qty_signed_full.abs() * price;
         }
         drop(closes_snapshot);
-        if projected_gross > buying_power * 1.01 {
+        let reduces_gross = projected_gross <= current_gross + 1e-9;
+        if projected_gross > buying_power * 1.01 && !reduces_gross {
             return Err(format!(
                 "buying power exceeded: gross {projected_gross:.2} > buying_power {buying_power:.2}"
             ));
@@ -489,6 +496,52 @@ mod tests {
             .unwrap();
         let positions = broker.get_positions(ExecutionMode::Paper).await.unwrap();
         assert_eq!(positions.get("AMD").map(|(q, _)| *q), Some(50.0));
+    }
+
+    #[tokio::test]
+    async fn allows_risk_reducing_order_even_if_book_remains_over_buying_power() {
+        let closes = shared_closes(&[("A", 100.0), ("B", 100.0)]);
+        let broker = SimulatedBroker::new(&portfolio_config(), closes, 0.0);
+        broker
+            .place_order("A", 200.0, "buy", ExecutionMode::Paper)
+            .await
+            .unwrap();
+        broker
+            .place_order("B", 200.0, "buy", ExecutionMode::Paper)
+            .await
+            .unwrap();
+
+        let positions_before = broker.get_positions(ExecutionMode::Paper).await.unwrap();
+        assert_eq!(positions_before.get("A").map(|(q, _)| *q), Some(200.0));
+        assert_eq!(positions_before.get("B").map(|(q, _)| *q), Some(200.0));
+
+        broker
+            .place_order("A", 10.0, "sell", ExecutionMode::Paper)
+            .await
+            .unwrap();
+
+        let positions_after = broker.get_positions(ExecutionMode::Paper).await.unwrap();
+        assert_eq!(positions_after.get("A").map(|(q, _)| *q), Some(190.0));
+    }
+
+    #[tokio::test]
+    async fn still_rejects_risk_increasing_order_when_over_buying_power() {
+        let closes = shared_closes(&[("A", 100.0), ("B", 100.0)]);
+        let broker = SimulatedBroker::new(&portfolio_config(), closes, 0.0);
+        broker
+            .place_order("A", 200.0, "buy", ExecutionMode::Paper)
+            .await
+            .unwrap();
+        broker
+            .place_order("B", 200.0, "buy", ExecutionMode::Paper)
+            .await
+            .unwrap();
+
+        let err = broker
+            .place_order("A", 10.0, "buy", ExecutionMode::Paper)
+            .await
+            .unwrap_err();
+        assert!(err.contains("buying power exceeded"), "got: {err}");
     }
 
     #[tokio::test]

--- a/engine/crates/runner/src/simulated_broker.rs
+++ b/engine/crates/runner/src/simulated_broker.rs
@@ -347,7 +347,15 @@ impl Broker for SimulatedBroker {
         let positions = self.state.positions.read().unwrap();
         let cash = *self.state.cash.read().unwrap();
         let equity = self.equity_unlocked(&positions, cash);
-        let buying_power = equity * self.state.leverage;
+        let closes = self.state.closes.read().unwrap();
+        let current_gross: f64 = positions
+            .iter()
+            .map(|(symbol, (qty, avg))| {
+                let price = closes.get(symbol).copied().unwrap_or(*avg);
+                qty.abs() * price
+            })
+            .sum();
+        let buying_power = (equity * self.state.leverage - current_gross).max(0.0);
         Ok(AlpacaAccount {
             status: "ACTIVE".to_string(),
             buying_power: format!("{buying_power:.2}"),
@@ -480,6 +488,19 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.contains("buying power exceeded"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn account_buying_power_reports_remaining_headroom() {
+        let closes = shared_closes(&[("AMD", 100.0)]);
+        let broker = SimulatedBroker::new(&portfolio_config(), closes, 0.0);
+        broker
+            .place_order("AMD", 100.0, "buy", ExecutionMode::Paper)
+            .await
+            .unwrap();
+        let account = broker.get_account(ExecutionMode::Paper).await.unwrap();
+        let buying_power: f64 = account.buying_power.parse().unwrap();
+        assert!((buying_power - 30_000.0).abs() < 1e-6, "got {buying_power}");
     }
 
     #[tokio::test]

--- a/scripts/run_basket_overlay_benchmark.py
+++ b/scripts/run_basket_overlay_benchmark.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUN_REPLAY = REPO_ROOT / "scripts" / "run_basket_replay_quiet.sh"
+REPLAY_ROOT = REPO_ROOT / "data" / "replay"
+DEFAULT_LEADERSHIP_ARGS = [
+    "--leadership-overlay-sectors",
+    "faang,chips",
+    "--leadership-ret5d-threshold",
+    "0.02",
+    "--leadership-breadth5d-threshold",
+    "0.56",
+    "--leadership-long-only-leverage",
+    "1.0",
+]
+
+
+@dataclass(frozen=True)
+class Window:
+    name: str
+    start: str
+    end: str
+
+
+@dataclass(frozen=True)
+class Variant:
+    name: str
+    args: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Metrics:
+    cum_return: float
+    sharpe: float
+    max_dd: float
+    n_days: int
+
+
+WINDOWS = [
+    Window("wide_q3", "2025-07-01", "2025-09-30"),
+    Window("wide_q4", "2025-10-01", "2025-12-31"),
+    Window("wide_2026ytd", "2026-01-01", "2026-05-15"),
+    Window("strong_2025_q1", "2025-01-01", "2025-03-31"),
+]
+
+VARIANTS = [
+    Variant("baseline", ()),
+    Variant(
+        "fixed_suppress",
+        (
+            *DEFAULT_LEADERSHIP_ARGS,
+            "--leadership-picker",
+            "fixed",
+            "--leadership-mode",
+            "suppress-shorts",
+        ),
+    ),
+    Variant(
+        "fixed_sleeve",
+        (
+            *DEFAULT_LEADERSHIP_ARGS,
+            "--leadership-picker",
+            "fixed",
+            "--leadership-mode",
+            "add-capped-long-sleeve",
+        ),
+    ),
+    Variant(
+        "rule_v1",
+        (*DEFAULT_LEADERSHIP_ARGS, "--leadership-picker", "rule-v1"),
+    ),
+]
+
+
+def parse_metrics(report_path: Path) -> Metrics:
+    first = report_path.read_text().splitlines()[0]
+    fields: dict[str, str] = {}
+    for token in first.removeprefix("# ").split("\t"):
+        key, value = token.split("=", 1)
+        fields[key] = value
+    return Metrics(
+        cum_return=float(fields["cum_return"]),
+        sharpe=float(fields["sharpe"]),
+        max_dd=float(fields["max_dd"]),
+        n_days=int(fields["n_days"]),
+    )
+
+
+def run_replay(name: str, window: Window, args: tuple[str, ...], reuse_existing: bool) -> Metrics:
+    report_path = REPLAY_ROOT / name / "report.tsv"
+    if reuse_existing and report_path.exists():
+        return parse_metrics(report_path)
+    cmd = [str(RUN_REPLAY), name, window.start, window.end, *args]
+    print(f"running {name} ...", flush=True)
+    subprocess.run(cmd, cwd=REPO_ROOT, check=True)
+    return parse_metrics(report_path)
+
+
+def fmt_pct(value: float) -> str:
+    return f"{value:+.2%}"
+
+
+def fmt_dd(value: float) -> str:
+    return f"{value:.2%}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run the basket overlay picker replay matrix against fixed mechanism benchmarks."
+    )
+    parser.add_argument(
+        "--prefix",
+        default="overlay_bench",
+        help="Replay directory prefix under data/replay.",
+    )
+    parser.add_argument(
+        "--reuse-existing",
+        action="store_true",
+        help="Read existing report.tsv files instead of rerunning completed cases.",
+    )
+    args = parser.parse_args()
+
+    results: dict[tuple[str, str], Metrics] = {}
+    for window in WINDOWS:
+        for variant in VARIANTS:
+            run_name = f"{args.prefix}_{window.name}_{variant.name}"
+            results[(window.name, variant.name)] = run_replay(
+                run_name, window, variant.args, args.reuse_existing
+            )
+
+    print(
+        "\nwindow\tbaseline\tfixed_suppress\tfixed_sleeve\t"
+        "rule_v1\tbest_fixed\trule_vs_best_fixed"
+    )
+    for window in WINDOWS:
+        baseline = results[(window.name, "baseline")]
+        suppress = results[(window.name, "fixed_suppress")]
+        sleeve = results[(window.name, "fixed_sleeve")]
+        rule = results[(window.name, "rule_v1")]
+        fixed = {
+            "baseline": baseline,
+            "fixed_suppress": suppress,
+            "fixed_sleeve": sleeve,
+        }
+        best_fixed_name, best_fixed = max(fixed.items(), key=lambda item: item[1].cum_return)
+        print(
+            "\t".join(
+                [
+                    window.name,
+                    f"{fmt_pct(baseline.cum_return)} / DD {fmt_dd(baseline.max_dd)}",
+                    f"{fmt_pct(suppress.cum_return)} / DD {fmt_dd(suppress.max_dd)}",
+                    f"{fmt_pct(sleeve.cum_return)} / DD {fmt_dd(sleeve.max_dd)}",
+                    f"{fmt_pct(rule.cum_return)} / DD {fmt_dd(rule.max_dd)}",
+                    best_fixed_name,
+                    f"{fmt_pct(rule.cum_return - best_fixed.cum_return)} / "
+                    f"DD diff {fmt_dd(rule.max_dd - best_fixed.max_dd)}",
+                ]
+            )
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except subprocess.CalledProcessError as exc:
+        print(
+            f"benchmark command failed with exit code {exc.returncode}: "
+            f"{' '.join(exc.cmd)}",
+            file=sys.stderr,
+        )
+        raise

--- a/scripts/run_basket_overlay_benchmark.py
+++ b/scripts/run_basket_overlay_benchmark.py
@@ -166,6 +166,12 @@ def main() -> int:
             )
         )
 
+    print(
+        "\nDesign guardrail: treat rule_v1 as a conservative governor with dwell/hysteresis, "
+        "not a daily overlay optimizer; prefer stable mode holds unless switching clearly "
+        "earns its complexity."
+    )
+
     return 0
 
 

--- a/scripts/run_basket_replay_quiet.sh
+++ b/scripts/run_basket_replay_quiet.sh
@@ -33,11 +33,13 @@ state_path="$out_dir/state.json"
 
 mkdir -p "$out_dir"
 
-if [[ ! -x "$runner" ]]; then
-  echo "runner binary not found at $runner" >&2
-  echo "build it first: cargo build -p openquant-runner" >&2
-  exit 1
-fi
+# Force a clean rebuild each run so replay results cannot accidentally reuse
+# a stale runner binary from an older checkout or partial local build.
+(
+  cd "$repo_root/engine"
+  cargo clean
+  cargo build -p openquant-runner
+)
 
 RUST_LOG=info "$runner" replay --engine basket \
   --start "$start" \


### PR DESCRIPTION
## Summary
- add the trait-based `rule-v1` basket overlay picker and replay/journal wiring
- align suppress-overlay engine state with the actually executed post-replan basket book
- harden execution against buying-power drift in replay/paper mode

## What changed
- introduced `BasketOverlayPicker` with `fixed` and `rule-v1` implementations
- wired picker decisions into basket live/replay execution and persisted picker state for restart-stable behavior
- journaled picker decisions for replay forensics
- fixed suppress-shorts engine flattening so state matches the executed target plan
- updated the simulated broker to allow risk-reducing orders even when the book is still above buying power after that single step
- trimmed rounded target share books back under the configured gross cap to stop whole-share rounding from creating buying-power rejects
- added tests around suppress-path alignment, broker risk-reduction semantics, and rounded-share cap trimming
- added a benchmark-harness guardrail reminder that `rule-v1` should be treated as a conservative dwell/hysteresis governor, not a daily optimizer

## Validation
- `cargo test -p openquant-runner`
- replay benchmark matrix for rule-v1 vs fixed mechanisms
- focused replay validation of switch-path logs
- `2026-04-01` to `2026-05-10` baseline window before/after execution hardening:
  - before: `16` failed orders
  - after: `0` failed orders

## Notes
- `rule-v1` remains an enter-and-hold governor with dwell/hysteresis, not a free daily overlay argmax chooser
- the basket engine remains the core; overlays behave like cautious capital/risk governors layered on top
