### PR TITLE
[codex] Harden basket paper startup observability

### DIFF
--- a/CODEX_CODING_HARNESS.md
+++ b/CODEX_CODING_HARNESS.md
@@ -181,6 +181,21 @@ Important trading paths must log enough to reconstruct:
 - whether reconciliation matched target
 - what state was persisted
 
+Every new or materially changed implementation path must include a complete
+operator log surface:
+
+- `info`: normal lifecycle, selected config, state source, decision summaries,
+  sizing summaries, orders, reconciliation, and persistence.
+- `warn`: recoverable degraded behavior, fallback paths, ignored stale inputs,
+  skipped optional work, or conditions requiring operator attention.
+- `error`: fatal startup/runtime failures, broker/API failures, rejected orders,
+  missing required data, or anything that stops safe execution.
+- `bug!`: should-not-happen internal states, invariant breaks, mismatched state,
+  suspicious fallback behavior, target/account divergence, or unexpected
+  sidecar/config interactions. A `bug!` must be visible in logs with
+  `bug=true bug_marker="BUG"` and counted by the metrics recorder when the
+  runner is active.
+
 Use `RUST_LOG` to switch detail levels. Paper runs should write durable logs to `data/journal/engine.log` or the configured journal path. High log volume is acceptable for now; missing decision evidence is not.
 
 For replay evidence, high log volume belongs in files, not in the chat transcript.

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1774,6 +1774,7 @@ dependencies = [
  "chrono-tz",
  "clap",
  "futures-util",
+ "metrics",
  "nyse-holiday-cal",
  "openquant-core",
  "pair-picker",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1777,6 +1777,7 @@ dependencies = [
  "metrics",
  "nyse-holiday-cal",
  "openquant-core",
+ "openquant-metrics",
  "pair-picker",
  "parquet",
  "rand 0.8.5",

--- a/engine/crates/runner/Cargo.toml
+++ b/engine/crates/runner/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 openquant-core = { path = "../core" }
+openquant-metrics = { path = "../metrics" }
 pair-picker = { path = "../pair-picker" }
 basket-picker = { path = "../basket-picker" }
 basket-engine = { path = "../basket-engine" }

--- a/engine/crates/runner/Cargo.toml
+++ b/engine/crates/runner/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
 tracing-appender = "0.2"
+metrics = "0.24"
 clap = { version = "4", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -1113,11 +1113,11 @@ pub async fn run_basket_live(
             ),
             Ok(false) => {
                 if can_load_sidecar_state && leadership_state_path.exists() {
-                    bug!(
-                        "leadership_sidecar_state_rebuilt",
-                        state_path = %leadership_state_path.display(),
-                        "persisted leadership sidecar state could not be reused and will be rebuilt"
-                    );
+                    move_sidecar_state_aside_if_present(
+                        &leadership_state_path,
+                        startup_state_source,
+                        "leadership_sidecar_state_mismatch",
+                    )?;
                 }
                 let warm_anchor = if last_processed_trading_day == Some(today) {
                     Some(today)
@@ -1180,12 +1180,11 @@ pub async fn run_basket_live(
         ),
         Ok(false) => {
             if can_load_sidecar_state && picker_state_path.exists() {
-                bug!(
-                    "overlay_picker_sidecar_state_rebuilt",
-                    state_path = %picker_state_path.display(),
-                    picker_id = overlay_picker.id(),
-                    "persisted overlay picker sidecar state could not be reused and will be rebuilt"
-                );
+                move_sidecar_state_aside_if_present(
+                    &picker_state_path,
+                    startup_state_source,
+                    "overlay_picker_sidecar_state_mismatch",
+                )?;
             }
             overlay_picker.save_state(&picker_state_path)?;
         }

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -55,6 +55,13 @@ use crate::market_session;
 use crate::session_trigger::SessionTrigger;
 use crate::stream;
 
+macro_rules! bug {
+    ($kind:literal, $($field:tt)*) => {{
+        metrics::counter!("bug", "component" => "basket_live", "kind" => $kind).increment(1);
+        error!(bug = true, bug_marker = "BUG", kind = $kind, $($field)*);
+    }};
+}
+
 /// Execution mode for basket live/paper.
 ///
 /// Distinct from [`ExecutionMode`] because basket adds a `Noop` shadow mode.
@@ -1081,18 +1088,37 @@ pub async fn run_basket_live(
             execution.alpaca_mode().is_some(),
         )?;
     let leadership_state_path = leadership_classifier_state_path(state_path);
+    let can_load_sidecar_state = matches!(startup_state_source, StartupStateSource::Snapshot);
+    if !can_load_sidecar_state {
+        move_sidecar_state_aside_if_present(
+            &leadership_state_path,
+            startup_state_source,
+            "engine_state_not_loaded_from_snapshot",
+        )?;
+    }
     let mut leadership_tracker = options
         .leadership_overlay
         .clone()
         .map(|cfg| SectorLeadershipTracker::new(cfg, sector_members));
     if let Some(tracker) = leadership_tracker.as_mut() {
-        match tracker.load_state(&leadership_state_path) {
+        match if can_load_sidecar_state {
+            tracker.load_state(&leadership_state_path)
+        } else {
+            Ok(false)
+        } {
             Ok(true) => info!(
                 state_path = %leadership_state_path.display(),
                 active_sectors = ?tracker.active_sectors_for_today(),
                 "loaded persisted leadership overlay classifier state"
             ),
             Ok(false) => {
+                if can_load_sidecar_state && leadership_state_path.exists() {
+                    bug!(
+                        "leadership_sidecar_state_rebuilt",
+                        state_path = %leadership_state_path.display(),
+                        "persisted leadership sidecar state could not be reused and will be rebuilt"
+                    );
+                }
                 let warm_anchor = if last_processed_trading_day == Some(today) {
                     Some(today)
                 } else {
@@ -1135,13 +1161,32 @@ pub async fn run_basket_live(
         options.rule_v1_config.clone(),
     );
     let picker_state_path = overlay_picker_state_path(state_path);
-    match overlay_picker.load_state(&picker_state_path) {
+    if !can_load_sidecar_state {
+        move_sidecar_state_aside_if_present(
+            &picker_state_path,
+            startup_state_source,
+            "engine_state_not_loaded_from_snapshot",
+        )?;
+    }
+    match if can_load_sidecar_state {
+        overlay_picker.load_state(&picker_state_path)
+    } else {
+        Ok(false)
+    } {
         Ok(true) => info!(
             state_path = %picker_state_path.display(),
             picker_id = overlay_picker.id(),
             "loaded persisted basket overlay picker state"
         ),
         Ok(false) => {
+            if can_load_sidecar_state && picker_state_path.exists() {
+                bug!(
+                    "overlay_picker_sidecar_state_rebuilt",
+                    state_path = %picker_state_path.display(),
+                    picker_id = overlay_picker.id(),
+                    "persisted overlay picker sidecar state could not be reused and will be rebuilt"
+                );
+            }
             overlay_picker.save_state(&picker_state_path)?;
         }
         Err(e) => return Err(e),
@@ -1174,6 +1219,29 @@ pub async fn run_basket_live(
         broker_positions = current_shares.len(),
         "basket startup phase evaluated"
     );
+    if let Some(mode) = execution.alpaca_mode() {
+        let account = broker.get_account(mode).await?;
+        let account_equity = parse_equity(&account)?;
+        let effective_capital =
+            effective_execution_capital(portfolio_config.capital, Some(account_equity));
+        info!(
+            configured_capital = %format!("{:.0}", portfolio_config.capital),
+            account_equity = %format!("{:.0}", account_equity),
+            effective_execution_capital = %format!("{:.0}", effective_capital),
+            leverage = portfolio_config.leverage,
+            gross_cap = %format!("{:.0}", effective_capital * portfolio_config.leverage),
+            n_active_baskets = portfolio_config.n_active_baskets,
+            "basket execution capital resolved"
+        );
+        if effective_capital < portfolio_config.capital {
+            warn!(
+                configured_capital = %format!("{:.0}", portfolio_config.capital),
+                account_equity = %format!("{:.0}", account_equity),
+                effective_execution_capital = %format!("{:.0}", effective_capital),
+                "account equity is below configured basket capital; sizing will be capped to account equity"
+            );
+        }
+    }
     if let Some(journal) = &journal {
         let universe_path_str = universe_path.display().to_string();
         let state_path_str = state_path.display().to_string();
@@ -1433,7 +1501,8 @@ pub async fn run_basket_live(
                             processed_sessions.insert(today);
                             break 'session;
                         }
-                        error!(
+                        bug!(
+                            "zero_buffered_closes_on_trading_day",
                             date = %today,
                             symbols_expected,
                             buffered_days = day_closes.len(),
@@ -1462,7 +1531,8 @@ pub async fn run_basket_live(
                         "session close firing"
                     );
                     if !missing.is_empty() {
-                        error!(
+                        bug!(
+                            "incomplete_close_snapshot",
                             date = %today,
                             closes_in_buffer = closes_for_day.len(),
                             symbols_expected,
@@ -1651,7 +1721,8 @@ fn recover_from_unloadable_state(
     reason: String,
 ) -> Result<(BasketEngine, Option<NaiveDate>, StartupStateSource), String> {
     let backup_path = move_state_file_aside(state_path)?;
-    warn!(
+    bug!(
+        "engine_state_snapshot_unusable",
         state_path = %state_path.display(),
         backup_path = %backup_path.display(),
         reason = %reason,
@@ -1691,6 +1762,39 @@ fn move_state_file_aside(path: &Path) -> Result<PathBuf, String> {
         )
     })?;
     Ok(backup_path)
+}
+
+fn move_sidecar_state_aside_if_present(
+    path: &Path,
+    startup_source: StartupStateSource,
+    reason: &str,
+) -> Result<(), String> {
+    if !path.exists() {
+        return Ok(());
+    }
+    let ts = chrono::Utc::now().format("%Y%m%dT%H%M%SZ");
+    let mut backup_name: OsString = path
+        .file_name()
+        .map(|s| s.to_os_string())
+        .unwrap_or_else(|| OsString::from("basket.sidecar.json"));
+    backup_name.push(format!(".ignored.{ts}"));
+    let backup_path = path.with_file_name(backup_name);
+    std::fs::rename(path, &backup_path).map_err(|e| {
+        format!(
+            "failed to move stale sidecar state {} aside to {}: {e}",
+            path.display(),
+            backup_path.display()
+        )
+    })?;
+    bug!(
+        "stale_sidecar_state_ignored",
+        state_path = %path.display(),
+        backup_path = %backup_path.display(),
+        startup_state_source = ?startup_source,
+        reason,
+        "sidecar state ignored because engine state did not load from a matching snapshot"
+    );
+    Ok(())
 }
 
 /// paper/live execution (trading from an empty share map would double-size
@@ -1858,6 +1962,20 @@ async fn process_session_close(
     let picker_decision = overlay_picker.decide(&baseline_features);
     let leadership_active_sectors = &picker_decision.active_sectors;
     let leadership_long_symbols = &picker_decision.long_symbols;
+    if leadership_overlay.is_none() && picker_decision.mode != BasketOverlayMode::Baseline {
+        bug!(
+            "overlay_mode_without_config",
+            date = %date,
+            picker_id = overlay_picker.id(),
+            picker_mode = picker_decision.mode.as_str(),
+            picker_reason = picker_decision.reason,
+            "overlay picker selected a non-baseline mode without leadership overlay config"
+        );
+        return Err(format!(
+            "overlay picker selected {} without leadership overlay config",
+            picker_decision.mode.as_str()
+        ));
+    }
     info!(
         date = %date,
         picker_id = overlay_picker.id(),
@@ -2046,6 +2164,13 @@ async fn process_session_close(
         "target notionals summary"
     );
     if gross_notional > gross_cap + 1.0 {
+        bug!(
+            "target_gross_exceeds_cap",
+            date = %date,
+            gross_notional = %format!("{:.2}", gross_notional),
+            gross_cap = %format!("{:.2}", gross_cap),
+            "target gross notional exceeds configured cap"
+        );
         return Err(format!(
             "target gross notional {:.2} exceeds configured cap {:.2}",
             gross_notional, gross_cap
@@ -2314,7 +2439,8 @@ async fn process_session_close(
                     }
                     Err(e) => {
                         failed_orders += 1;
-                        error!(
+                        bug!(
+                            "broker_order_failed",
                             symbol = order.symbol.as_str(),
                             qty = order.qty,
                             side = side_str,
@@ -2383,7 +2509,8 @@ async fn process_session_close(
                         current_positions_after = actual_shares.len();
                         current_shares_after_json = Some(serialize_shares_map(&actual_shares));
                         if divergence_pct_value > 10.0 {
-                            error!(
+                            bug!(
+                                "post_submit_gross_divergence",
                                 date = %date,
                                 target_gross = %format!("{:.0}", target_gross),
                                 actual_gross = %format!("{:.0}", actual_gross_value),
@@ -2405,7 +2532,8 @@ async fn process_session_close(
                         }
                     }
                     Err(e) => {
-                        error!(
+                        bug!(
+                            "post_submit_reconciliation_failed",
                             date = %date,
                             error = e.as_str(),
                             "post-submission reconciliation failed — could not refetch broker positions"
@@ -2823,6 +2951,23 @@ mod tests {
             BasketExecution::Live.alpaca_mode(),
             Some(ExecutionMode::Live)
         );
+    }
+
+    #[test]
+    fn test_sidecar_state_is_moved_aside_when_engine_state_is_not_snapshot() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("basket.state.json.picker.json");
+        std::fs::write(&path, "{}").unwrap();
+
+        move_sidecar_state_aside_if_present(&path, StartupStateSource::Fresh, "test").unwrap();
+
+        assert!(!path.exists());
+        let backups: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(backups.len(), 1);
+        assert!(backups[0].starts_with("basket.state.json.picker.json.ignored."));
     }
 
     /// Verifies the bar-timestamp unshift needed in the live bar loop.

--- a/engine/crates/runner/src/main.rs
+++ b/engine/crates/runner/src/main.rs
@@ -48,6 +48,14 @@ use std::io::Write;
 use std::path::PathBuf;
 use tracing::{error, info, warn};
 
+macro_rules! bug {
+    ($kind:literal, $($field:tt)*) => {{
+        metrics::counter!("bug", "component" => "basket_runtime_config", "kind" => $kind)
+            .increment(1);
+        error!(bug = true, bug_marker = "BUG", kind = $kind, $($field)*);
+    }};
+}
+
 // ── CLI ──────────────────────────────────────────────────────────────
 
 #[derive(Parser, Debug)]
@@ -533,13 +541,7 @@ fn resolve_basket_runtime(
             .unwrap_or(universe.runner.portfolio.n_active_baskets),
     };
 
-    let overlay_defaults = if overrides.disable_leadership_overlay {
-        None
-    } else {
-        universe.runner.leadership_overlay.as_ref()
-    };
-    let overlay_enabled = overlay_defaults.is_some()
-        || !overrides.leadership_overlay_sectors.is_empty()
+    let has_overlay_override = !overrides.leadership_overlay_sectors.is_empty()
         || overrides.leadership_ret5d_threshold.is_some()
         || overrides.leadership_breadth5d_threshold.is_some()
         || overrides.leadership_off_ret5d_threshold.is_some()
@@ -549,6 +551,21 @@ fn resolve_basket_runtime(
         || overrides.leadership_mode.is_some()
         || overrides.leadership_picker.is_some()
         || overrides.leadership_long_only_leverage.is_some();
+
+    if overrides.disable_leadership_overlay && has_overlay_override {
+        bug!(
+            "leadership_overlay_disabled_with_overrides",
+            "leadership overlay override flags were supplied while --disable-leadership-overlay is set; ignoring overlay overrides"
+        );
+    }
+
+    let overlay_defaults = if overrides.disable_leadership_overlay {
+        None
+    } else {
+        universe.runner.leadership_overlay.as_ref()
+    };
+    let overlay_enabled = !overrides.disable_leadership_overlay
+        && (overlay_defaults.is_some() || has_overlay_override);
 
     let overlay_picker_arg = overrides.leadership_picker.unwrap_or_else(|| {
         overlay_defaults
@@ -624,10 +641,16 @@ fn resolve_basket_runtime(
         None
     };
 
+    let (overlay_picker, rule_v1_config) = if leadership_overlay.is_some() {
+        (overlay_picker_arg.into(), rule_v1_config)
+    } else {
+        (basket_overlay_picker::BasketOverlayPickerKind::Fixed, None)
+    };
+
     ResolvedBasketRuntime {
         portfolio_config,
         leadership_overlay,
-        overlay_picker: overlay_picker_arg.into(),
+        overlay_picker,
         rule_v1_config,
     }
 }

--- a/engine/crates/runner/src/main.rs
+++ b/engine/crates/runner/src/main.rs
@@ -888,18 +888,29 @@ async fn main() {
         .with_writer(tee)
         .init();
 
+    let metrics_dir = data_dir.join("metrics");
+    match openquant_metrics::install(
+        metrics_dir.to_string_lossy().as_ref(),
+        std::time::Duration::from_secs(10),
+    ) {
+        Ok(()) => info!(metrics_dir = %metrics_dir.display(), "metrics recorder installed"),
+        Err(e) => warn!(error = e.as_str(), "metrics recorder not installed"),
+    }
+
     // Basket engine in Live/Paper mode takes a dedicated path — it uses
     // BasketEngine (continuous state machine) driven by 1-min bars, not the
     // PairsEngine pipeline below. Early-return after the basket runner finishes.
     if let Command::Live(a) | Command::Paper(a) = &cli.command {
         if a.engine.is_basket() {
             run_basket_stream(a.clone(), matches!(&cli.command, Command::Live(_))).await;
+            openquant_metrics::shutdown().await;
             return;
         }
     }
 
     if let Command::FreezeBasketFits(a) = &cli.command {
         run_freeze_basket_fits(a.clone());
+        openquant_metrics::shutdown().await;
         return;
     }
 
@@ -932,6 +943,7 @@ async fn main() {
         Command::Replay(a) => {
             if a.engine.is_basket() {
                 run_basket_replay_live_path(a).await;
+                openquant_metrics::shutdown().await;
                 return;
             }
 
@@ -962,6 +974,7 @@ async fn main() {
         run_mode,
     )
     .await;
+    openquant_metrics::shutdown().await;
 }
 
 // ── Basket live/paper dispatch ──────────────────────────────────────


### PR DESCRIPTION
## Summary

- harden basket paper/live startup by quarantining overlay sidecar state when engine state is fresh or broker-recovered
- make `--disable-leadership-overlay` resolve to a true baseline picker with no rule-v1 sidecar state
- add high-signal `bug!` anomaly counters that also show up in logs as `bug=true bug_marker="BUG" kind=...`
- log configured capital, account equity, effective execution capital, leverage, and gross cap at startup

## Why

Before paper trading, restart safety and operator observability matter more than strategy changes. The risky path was a recovered or fresh basket engine accidentally reusing stale leadership classifier / picker sidecar state, plus disabled overlay runs still taking a stateful picker path.

## Validation

- `cargo check -p openquant-runner`
- `cargo test -p openquant-runner basket_live -- --nocapture`
- `cargo test -p openquant-runner basket_overlay_picker -- --nocapture`
- isolated replay smoke: `replay --start 2026-04-01 --end 2026-04-03 --state-path data/replay/codex_hardening_smoke/state.json --report-tsv data/replay/codex_hardening_smoke/report.tsv`
- isolated baseline replay smoke with `--disable-leadership-overlay`, confirming picker initialized as `baseline`
