### PR TITLE
Promote basket paper trading to v2 universe

### DIFF
--- a/BASELINES.md
+++ b/BASELINES.md
@@ -1,4 +1,4 @@
-# Baselines
+# Benchmarks
 
 This file tracks current, reproducible benchmark references. Older branch
 experiments and stale pre-picker basket numbers were removed because they are
@@ -7,10 +7,10 @@ not reliable yardsticks for the current basket engine.
 ## Basket Overlay Picker
 
 Current basket leadership work should be judged against fixed mechanism
-benchmarks, not baseline alone. The basket core remains the foundation; the
-rule picker is evaluated as a conservative allocator among:
+benchmarks, not `basket_only` alone. The basket core remains the foundation;
+the rule picker is evaluated as a conservative allocator among:
 
-- basket core only
+- `basket_only`
 - basket core + `suppress_shorts`
 - basket core + `add_capped_long_sleeve`
 
@@ -29,7 +29,7 @@ Shared replay settings:
 - capital: `10000`
 - active basket cap: `5`
 
-| Window | Baseline | Fixed suppress | Fixed sleeve | Rule v1 | Best fixed | Rule v1 vs best fixed |
+| Window | Basket only | Fixed suppress | Fixed sleeve | Rule v1 | Best fixed | Rule v1 vs best fixed |
 |--------|----------|----------------|--------------|---------|------------|-----------------------|
 | wide Q3 2025 | -4.19%, DD 17.09% | -2.22%, DD 19.57% | +10.51%, DD 12.08% | +13.02%, DD 12.08% | Fixed sleeve | +2.52%, DD +0.00% |
 | wide Q4 2025 | -5.00%, DD 13.09% | -5.00%, DD 13.09% | -2.17%, DD 10.95% | +4.42%, DD 7.25% | Fixed sleeve | +6.60%, DD -3.70% |
@@ -41,7 +41,7 @@ Shared replay settings:
 The rule picker should continue to clear these bars before promotion:
 
 - do not degrade the best fixed mechanism materially in strong leadership windows
-- do not beat baseline by merely taking more drawdown
+- do not beat `basket_only` by merely taking more drawdown
 - preserve basket-core behavior when leadership is absent
 - keep replay outputs deterministic and restart-stable
 - record picker decisions so regressions can be attributed to mode selection,

--- a/CODEX_PAPER_TRADING_HARNESS.md
+++ b/CODEX_PAPER_TRADING_HARNESS.md
@@ -32,6 +32,9 @@ Before starting:
    - basket with leadership overlay
 5. Start the runner through `openquant-runner`, not ad hoc scripts.
 
+Default paper run now uses `config/basket_universe_v2.toml` unless `--universe`
+is provided explicitly.
+
 Example `basket_only` paper run:
 
 ```bash

--- a/CODEX_PAPER_TRADING_HARNESS.md
+++ b/CODEX_PAPER_TRADING_HARNESS.md
@@ -28,11 +28,11 @@ Before starting:
 2. Confirm working tree is clean or identify unrelated local output.
 3. Confirm no stale runner is active.
 4. Confirm the intended mode:
-   - baseline basket
+   - basket_only
    - basket with leadership overlay
 5. Start the runner through `openquant-runner`, not ad hoc scripts.
 
-Example baseline paper run:
+Example `basket_only` paper run:
 
 ```bash
 RUST_LOG=info openquant-runner paper --engine basket --execution paper
@@ -158,7 +158,7 @@ If reconciliation fails:
 If the strategy loses money:
 
 - do not hand-wave it as noise
-- compare against baseline and overlay expectations
+- compare against `basket_only` and overlay expectations
 - inspect whether the day was a mean-reversion regime or leadership/trend regime
 - open or update a research issue when the loss exposes a new failure mode
 
@@ -173,7 +173,6 @@ A mode is paper-worthy only if:
 - restart behavior is tested
 - logs explain decisions
 - operator command is simple
-- baseline behavior remains available
+- `basket_only` behavior remains available
 
 Live-money promotion requires a separate decision. Do not infer live approval from paper success.
-

--- a/REGIME_OVERLAY_PLAYBOOK.md
+++ b/REGIME_OVERLAY_PLAYBOOK.md
@@ -1,0 +1,127 @@
+# Regime Overlay Playbook
+
+This note captures the reusable lesson from the `v2` research cycle:
+
+- the trading universe and the overlay do different jobs
+- the best overlay is not always the same thing as the best new regime basket
+- regime work should be replayed in layers instead of promoted all at once
+
+## Core idea
+
+Treat a new regime in three separate pieces:
+
+1. `trading universe`
+   The sectors and symbols we actually want the basket engine to trade.
+2. `overlay detector`
+   The fast leadership sectors that tell us when the tape is favorable.
+3. `overlay action`
+   What we do when leadership is present:
+   - stay `basket_only`
+   - `suppress_shorts`
+   - add `add_capped_long_sleeve`
+
+Do not force these three pieces to be the same.
+
+## What we learned from `v2`
+
+`v2` improved the basket universe in `2026-01-02` to `2026-04-30`, but the
+best overlay signal still came from `faang,chips`, not from the newer
+`ai_power,gas_infra` sectors.
+
+That means:
+
+- the new regime thesis was useful for basket construction
+- the old leadership complex was still better for timing the overlay
+- the overlay worked because it measured market leadership well, not because it
+  matched the narrative perfectly
+
+This is the main pattern to reuse.
+
+## Why overlays matter
+
+The basket engine is good at spread selection and relative-value behavior.
+The overlay adds a second layer that can lean into broad leadership when the
+tape is trending hard.
+
+That combination can outperform either piece on its own:
+
+- `basket_only` keeps us grounded in the basket engine
+- the overlay lets us participate when leadership is obvious
+- `rule_v1` is useful because it behaves like a governor, not a daily toggle
+
+The overlay should be chosen for signal quality, not story purity.
+
+## How to choose overlay sectors
+
+Good overlay sectors usually have these properties:
+
+- highly liquid names
+- clean institutional leadership
+- fast breadth expansion when the regime is working
+- strong trend persistence over 5d to 20d windows
+- broad market signaling value, not just isolated stock moves
+
+Good examples:
+
+- `faang`
+- `chips`
+
+Possible but weaker candidates:
+
+- downstream beneficiaries with slower price discovery
+- utilities and materials that move later than the real leadership complex
+
+In practice, the sectors that explain the regime best are not always the ones
+that monetize first.
+
+## How to build the next regime
+
+When we research a new regime, follow this order:
+
+1. Build the thesis basket.
+   Keep sectors narrow, liquid, and easy to replay.
+2. Run `basket_only`.
+   Verify the universe itself adds value before introducing overlay help.
+3. Test overlay candidates separately.
+   Include both:
+   - thesis-native candidates
+   - existing market leadership sectors that may still time better
+4. Compare against fixed mechanisms.
+   Every overlay idea should be judged against:
+   - `basket_only`
+   - fixed `suppress_shorts`
+   - fixed `add_capped_long_sleeve`
+   - `rule_v1`
+5. Promote in layers.
+   A new universe can be good even if its own overlay idea is not ready.
+
+## Promotion rules
+
+Promote a new regime only when we can say which layer improved:
+
+- universe only
+- overlay detector only
+- both
+
+Do not promote a new regime because the narrative is strong.
+Promote it because replay shows:
+
+- better return
+- acceptable drawdown
+- understandable behavior
+- repeatable results
+
+## Monday research loop
+
+The weekly automation should do the first half of regime work:
+
+- scan fresh news and trend leadership
+- identify sectors with shifting fundamentals
+- turn them into candidate baskets
+- classify each idea as:
+  - `universe_candidate`
+  - `overlay_candidate`
+  - `watch_only`
+
+The automation should not silently promote anything. Its job is to narrow the
+research queue so manual replay work starts from stronger hypotheses.

--- a/config/basket_universe_v1.toml
+++ b/config/basket_universe_v1.toml
@@ -6,7 +6,7 @@
 # Frozen: 2026-05-04
 # Research basis: issue #321 frozen-rule walk-forward across 4 OOS blocks
 #   (2024-07 -> 2026-03), 5 variants compared. dom060 (this file) was
-#   chosen — dual-OOS lift +0.58 / +2.59 vs no-gate baseline, mean +1.03,
+#   chosen — dual-OOS lift +0.58 / +2.59 vs no-gate basket-only reference, mean +1.03,
 #   12 baskets always rejected for single-name dominance.
 #
 # Differences vs the prior frozen basket universe:
@@ -28,17 +28,13 @@
 #   1. Re-running the walk-forward across the 4 OOS blocks.
 #   2. Opening a GitHub issue describing the change and the experimental
 #      evidence that justified it.
-#   3. Updating the baseline metrics below.
+#   3. Updating the reference metrics below.
 # ----------------------------------------------------------------------
 
 [version]
 schema = "basket_universe"
 version = "v1"
 frozen_at = "2026-05-04"
-baseline_sharpe_point = 2.31
-baseline_ci_95_lo = 1.64
-baseline_ci_95_hi = 3.08
-baseline_ci_method = "walk-forward across 4 OOS blocks; min/max as CI bounds"
 
 [strategy]
 method = "basket_spread_ou_bertram"
@@ -134,7 +130,6 @@ off_breadth5d_threshold = 0.5
 persistence_days = 2
 min_hold_days = 3
 picker = "rule_v1"
-mode = "baseline"
 long_only_leverage = 1.0
 
 [runner.leadership_overlay.rule_v1]
@@ -147,8 +142,8 @@ drawdown_on_threshold = 0.05
 recovered_return_threshold = 0.03
 recovered_drawdown_threshold = 0.03
 sleeve_return_ceiling = 0.03
-min_baseline_scale_for_sleeve = 0.70
-opportunistic_sleeve_min_baseline_scale = 0.85
+min_basket_only_scale_for_sleeve = 0.70
+opportunistic_sleeve_min_basket_only_scale = 0.85
 opportunistic_sleeve_return_ceiling = 0.10
 halve_sleeve_drawdown_threshold = 0.05
 quarter_sleeve_drawdown_threshold = 0.10

--- a/config/basket_universe_v2.toml
+++ b/config/basket_universe_v2.toml
@@ -1,0 +1,123 @@
+# basket_universe_v2.toml — EXPERIMENTAL UNIVERSE CONFIG
+# ------------------------------------------------------
+# Research experiment only. This file extends the frozen v1 basket universe
+# with additional sectors tied to the AI power / electrification buildout so
+# we can replay them against the same runner path and compare results.
+#
+# This does NOT replace production defaults. Keep v1 frozen until a wider
+# replay gauntlet shows durable improvement.
+
+[version]
+schema = "basket_universe"
+version = "v1"
+frozen_at = "2026-05-21"
+
+[strategy]
+method = "basket_spread_ou_bertram"
+spread_formula = "log(target) - mean(log(peers))"
+threshold_method = "bertram_symmetric"
+threshold_clip_min = 0.15
+threshold_clip_max = 2.5
+residual_window_days = 60
+forward_window_days = 60
+refit_cadence = "quarterly"
+cost_bps_assumed = 5.0
+leverage_assumed = 4.0
+sizing = "equal_weight_across_baskets"
+dominance_gate_enabled = true
+dominance_max = 0.60
+
+[sectors.chips]
+members = ["NVDA", "AVGO", "AMD", "INTC", "MU", "ADI"]
+traded_targets = ["AMD", "INTC", "ADI", "MU", "NVDA"]
+
+[sectors.hc_providers]
+members = ["UNH", "CI", "HUM", "CNC", "ELV", "MOH"]
+traded_targets = ["UNH", "CI", "HUM", "CNC", "ELV", "MOH"]
+
+[sectors.energy]
+members = ["XOM", "CVX", "COP", "OXY", "MPC", "PSX"]
+traded_targets = ["XOM", "CVX", "COP", "OXY", "MPC", "PSX"]
+
+[sectors.entsw]
+members = ["MSFT", "ORCL", "CRM", "ADBE", "INTU", "IBM"]
+traded_targets = ["ORCL", "CRM", "ADBE", "INTU"]
+
+[sectors.utilities]
+members = ["NEE", "DUK", "SO", "D", "AEP", "EXC"]
+traded_targets = ["NEE", "DUK", "SO", "D", "AEP", "EXC"]
+
+[sectors.banks_regional]
+members = ["USB", "PNC", "TFC", "KEY", "HBAN", "RF"]
+traded_targets = ["USB", "PNC", "TFC", "KEY", "HBAN", "RF"]
+
+[sectors.faang]
+members = ["AAPL", "AMZN", "MSFT", "GOOGL", "META", "NVDA"]
+traded_targets = ["AAPL", "GOOGL", "META", "AMZN"]
+
+[sectors.insurance]
+members = ["ALL", "TRV", "PGR", "AIG", "MET", "PRU"]
+traded_targets = ["ALL", "TRV", "PGR", "AIG", "MET", "PRU"]
+
+# Experimental sectors for the AI power / industrial buildout thesis.
+# Keep these narrow and replayable with the current parquet dataset.
+
+[sectors.electrification]
+members = ["ETN", "GEV", "HUBB", "PWR", "EMR", "PH"]
+traded_targets = ["ETN", "GEV", "HUBB", "PWR"]
+
+[sectors.ai_power]
+members = ["CEG", "VST", "NEE", "NRG", "EXC", "ETR"]
+traded_targets = ["CEG", "VST", "NEE", "NRG"]
+
+[sectors.gas_infra]
+members = ["EQT", "WMB", "KMI", "OKE", "TRGP", "EXE"]
+traded_targets = ["EQT", "WMB", "KMI", "OKE"]
+
+[sectors.cyc_materials]
+members = ["FCX", "NUE", "STLD", "MLM", "VMC", "CRH"]
+traded_targets = ["FCX", "NUE", "STLD"]
+
+[dont_do]
+hl_trade_gate = false
+time_based_exit = false
+stop_loss = false
+regime_derisk = false
+continuous_sizing = false
+score_based_ranking = false
+hl_derived_max_hold = false
+pair_engine_reuse = false
+
+[runner]
+decision_offset_minutes_before_close = 0
+
+[runner.portfolio]
+capital = 10000
+n_active_baskets = 5
+
+[runner.leadership_overlay]
+sectors = ["faang", "chips"]
+on_ret5d_threshold = 0.02
+on_breadth5d_threshold = 0.56
+off_ret5d_threshold = 0.0
+off_breadth5d_threshold = 0.5
+persistence_days = 2
+min_hold_days = 3
+picker = "rule_v1"
+long_only_leverage = 1.0
+
+[runner.leadership_overlay.rule_v1]
+min_dwell_days = 5
+off_confirmation_days = 2
+suppress_conflict_on_threshold = 0.15
+suppress_conflict_off_threshold = 0.05
+weak_return_threshold = 0.0
+drawdown_on_threshold = 0.05
+recovered_return_threshold = 0.03
+recovered_drawdown_threshold = 0.03
+sleeve_return_ceiling = 0.03
+min_basket_only_scale_for_sleeve = 0.70
+opportunistic_sleeve_min_basket_only_scale = 0.85
+opportunistic_sleeve_return_ceiling = 0.10
+halve_sleeve_drawdown_threshold = 0.05
+quarter_sleeve_drawdown_threshold = 0.10

--- a/engine/crates/basket-picker/src/universe.rs
+++ b/engine/crates/basket-picker/src/universe.rs
@@ -15,14 +15,6 @@ pub struct VersionInfo {
     pub schema: String,
     pub version: String,
     pub frozen_at: String,
-    #[serde(default)]
-    pub baseline_sharpe_point: Option<f64>,
-    #[serde(default)]
-    pub baseline_ci_95_lo: Option<f64>,
-    #[serde(default)]
-    pub baseline_ci_95_hi: Option<f64>,
-    #[serde(default)]
-    pub baseline_ci_method: Option<String>,
 }
 
 /// Strategy configuration from the universe file.
@@ -70,7 +62,7 @@ fn default_runner_picker() -> RunnerLeadershipPickerConfig {
 }
 
 fn default_runner_overlay_mode() -> RunnerLeadershipOverlayModeConfig {
-    RunnerLeadershipOverlayModeConfig::Baseline
+    RunnerLeadershipOverlayModeConfig::BasketOnly
 }
 
 fn default_runner_long_only_leverage() -> f64 {
@@ -129,11 +121,11 @@ fn default_rule_v1_sleeve_return_ceiling() -> f64 {
     0.03
 }
 
-fn default_rule_v1_min_baseline_scale_for_sleeve() -> f64 {
+fn default_rule_v1_min_basket_only_scale_for_sleeve() -> f64 {
     0.70
 }
 
-fn default_rule_v1_opportunistic_sleeve_min_baseline_scale() -> f64 {
+fn default_rule_v1_opportunistic_sleeve_min_basket_only_scale() -> f64 {
     0.85
 }
 
@@ -206,8 +198,8 @@ pub enum RunnerLeadershipPickerConfig {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub enum RunnerLeadershipOverlayModeConfig {
     #[default]
-    #[serde(rename = "baseline")]
-    Baseline,
+    #[serde(rename = "basket_only")]
+    BasketOnly,
     #[serde(rename = "suppress_shorts", alias = "suppress-shorts")]
     SuppressShorts,
     #[serde(rename = "replace_with_long_only", alias = "replace-with-long-only")]
@@ -236,10 +228,10 @@ pub struct RunnerRuleV1OverlayConfig {
     pub recovered_drawdown_threshold: f64,
     #[serde(default = "default_rule_v1_sleeve_return_ceiling")]
     pub sleeve_return_ceiling: f64,
-    #[serde(default = "default_rule_v1_min_baseline_scale_for_sleeve")]
-    pub min_baseline_scale_for_sleeve: f64,
-    #[serde(default = "default_rule_v1_opportunistic_sleeve_min_baseline_scale")]
-    pub opportunistic_sleeve_min_baseline_scale: f64,
+    #[serde(default = "default_rule_v1_min_basket_only_scale_for_sleeve")]
+    pub min_basket_only_scale_for_sleeve: f64,
+    #[serde(default = "default_rule_v1_opportunistic_sleeve_min_basket_only_scale")]
+    pub opportunistic_sleeve_min_basket_only_scale: f64,
     #[serde(default = "default_rule_v1_opportunistic_sleeve_return_ceiling")]
     pub opportunistic_sleeve_return_ceiling: f64,
     #[serde(default = "default_rule_v1_halve_sleeve_drawdown_threshold")]
@@ -260,9 +252,9 @@ impl Default for RunnerRuleV1OverlayConfig {
             recovered_return_threshold: default_rule_v1_recovered_return_threshold(),
             recovered_drawdown_threshold: default_rule_v1_recovered_drawdown_threshold(),
             sleeve_return_ceiling: default_rule_v1_sleeve_return_ceiling(),
-            min_baseline_scale_for_sleeve: default_rule_v1_min_baseline_scale_for_sleeve(),
-            opportunistic_sleeve_min_baseline_scale:
-                default_rule_v1_opportunistic_sleeve_min_baseline_scale(),
+            min_basket_only_scale_for_sleeve: default_rule_v1_min_basket_only_scale_for_sleeve(),
+            opportunistic_sleeve_min_basket_only_scale:
+                default_rule_v1_opportunistic_sleeve_min_basket_only_scale(),
             opportunistic_sleeve_return_ceiling:
                 default_rule_v1_opportunistic_sleeve_return_ceiling(),
             halve_sleeve_drawdown_threshold: default_rule_v1_halve_sleeve_drawdown_threshold(),
@@ -490,7 +482,6 @@ sectors = ["chips"]
 on_ret5d_threshold = 0.02
 on_breadth5d_threshold = 0.56
 picker = "rule_v1"
-mode = "baseline"
 long_only_leverage = 1.0
 "#;
 

--- a/engine/crates/basket-picker/src/universe.rs
+++ b/engine/crates/basket-picker/src/universe.rs
@@ -198,7 +198,7 @@ pub enum RunnerLeadershipPickerConfig {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub enum RunnerLeadershipOverlayModeConfig {
     #[default]
-    #[serde(rename = "basket_only")]
+    #[serde(rename = "basket_only", alias = "baseline")]
     BasketOnly,
     #[serde(rename = "suppress_shorts", alias = "suppress-shorts")]
     SuppressShorts,
@@ -228,9 +228,15 @@ pub struct RunnerRuleV1OverlayConfig {
     pub recovered_drawdown_threshold: f64,
     #[serde(default = "default_rule_v1_sleeve_return_ceiling")]
     pub sleeve_return_ceiling: f64,
-    #[serde(default = "default_rule_v1_min_basket_only_scale_for_sleeve")]
+    #[serde(
+        default = "default_rule_v1_min_basket_only_scale_for_sleeve",
+        alias = "min_baseline_scale_for_sleeve"
+    )]
     pub min_basket_only_scale_for_sleeve: f64,
-    #[serde(default = "default_rule_v1_opportunistic_sleeve_min_basket_only_scale")]
+    #[serde(
+        default = "default_rule_v1_opportunistic_sleeve_min_basket_only_scale",
+        alias = "opportunistic_sleeve_min_baseline_scale"
+    )]
     pub opportunistic_sleeve_min_basket_only_scale: f64,
     #[serde(default = "default_rule_v1_opportunistic_sleeve_return_ceiling")]
     pub opportunistic_sleeve_return_ceiling: f64,
@@ -611,5 +617,61 @@ traded_targets = ["AMD"]
 "#;
         let err = load_universe_from_str(toml).unwrap_err();
         assert!(err.contains("has only 1 peer(s), need >= 2"));
+    }
+
+    #[test]
+    fn test_legacy_overlay_keys_still_load() {
+        let toml = r#"
+[version]
+schema = "basket_universe"
+version = "v1"
+frozen_at = "2026-04-20"
+
+[strategy]
+method = "basket_spread_ou_bertram"
+spread_formula = "log(target) - mean(log(peers))"
+threshold_method = "bertram_symmetric"
+threshold_clip_min = 0.15
+threshold_clip_max = 2.5
+residual_window_days = 60
+forward_window_days = 60
+refit_cadence = "quarterly"
+cost_bps_assumed = 5.0
+leverage_assumed = 4.0
+sizing = "equal_weight_across_baskets"
+
+[sectors.chips]
+members = ["NVDA", "AMD", "AVGO"]
+traded_targets = ["AMD"]
+
+[runner]
+decision_offset_minutes_before_close = 0
+
+[runner.portfolio]
+capital = 10000
+n_active_baskets = 5
+
+[runner.leadership_overlay]
+mode = "baseline"
+sectors = ["chips"]
+on_ret5d_threshold = 0.02
+on_breadth5d_threshold = 0.56
+off_ret5d_threshold = 0.0
+off_breadth5d_threshold = 0.5
+persistence_days = 2
+min_hold_days = 3
+picker = "rule_v1"
+
+[runner.leadership_overlay.rule_v1]
+min_baseline_scale_for_sleeve = 0.65
+opportunistic_sleeve_min_baseline_scale = 0.80
+"#;
+        let universe = load_universe_from_str(toml).unwrap();
+        let overlay = universe.runner.leadership_overlay.unwrap();
+        assert_eq!(overlay.mode, RunnerLeadershipOverlayModeConfig::BasketOnly);
+        assert!((overlay.rule_v1.min_basket_only_scale_for_sleeve - 0.65).abs() < 1e-9);
+        assert!(
+            (overlay.rule_v1.opportunistic_sleeve_min_basket_only_scale - 0.80).abs() < 1e-9
+        );
     }
 }

--- a/engine/crates/runner/src/basket_journal.rs
+++ b/engine/crates/runner/src/basket_journal.rs
@@ -118,6 +118,7 @@ CREATE INDEX IF NOT EXISTS idx_basket_picker_decisions_run_day
 #[derive(Clone)]
 pub struct BasketJournal {
     conn: Arc<Mutex<Connection>>,
+    legacy_picker_scale_column: bool,
 }
 
 pub struct BasketRunRecord<'a> {
@@ -218,8 +219,14 @@ impl BasketJournal {
             .map_err(|e| format!("set journal pragmas: {e}"))?;
         conn.execute_batch(SCHEMA)
             .map_err(|e| format!("init basket journal schema: {e}"))?;
+        migrate_picker_decisions_schema(&conn)
+            .map_err(|e| format!("migrate basket journal schema: {e}"))?;
+        let legacy_picker_scale_column =
+            table_has_column(&conn, "basket_picker_decisions", "baseline_scale_if_sleeve")
+                .map_err(|e| format!("inspect basket journal schema: {e}"))?;
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),
+            legacy_picker_scale_column,
         })
     }
 
@@ -368,30 +375,58 @@ impl BasketJournal {
             .conn
             .lock()
             .map_err(|_| "basket journal mutex poisoned".to_string())?;
-        conn.execute(
-            "INSERT INTO basket_picker_decisions (
-                run_id, trading_day, picker_id, mode, reason,
-                active_sectors_json, active_symbols_json,
-                leadership_short_conflict_ratio, strategy_return_20d,
-                strategy_drawdown_20d, basket_only_scale_if_sleeve,
-                sleeve_leverage_scale, created_at_utc
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
-            params![
-                rec.run_id,
-                rec.trading_day.to_string(),
-                rec.picker_id,
-                rec.mode,
-                rec.reason,
-                rec.active_sectors_json,
-                rec.active_symbols_json,
-                rec.leadership_short_conflict_ratio,
-                rec.strategy_return_20d,
-                rec.strategy_drawdown_20d,
-                rec.basket_only_scale_if_sleeve,
-                rec.sleeve_leverage_scale,
-                Utc::now().to_rfc3339(),
-            ],
-        )
+        if self.legacy_picker_scale_column {
+            conn.execute(
+                "INSERT INTO basket_picker_decisions (
+                    run_id, trading_day, picker_id, mode, reason,
+                    active_sectors_json, active_symbols_json,
+                    leadership_short_conflict_ratio, strategy_return_20d,
+                    strategy_drawdown_20d, baseline_scale_if_sleeve,
+                    basket_only_scale_if_sleeve, sleeve_leverage_scale, created_at_utc
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+                params![
+                    rec.run_id,
+                    rec.trading_day.to_string(),
+                    rec.picker_id,
+                    rec.mode,
+                    rec.reason,
+                    rec.active_sectors_json,
+                    rec.active_symbols_json,
+                    rec.leadership_short_conflict_ratio,
+                    rec.strategy_return_20d,
+                    rec.strategy_drawdown_20d,
+                    rec.basket_only_scale_if_sleeve,
+                    rec.basket_only_scale_if_sleeve,
+                    rec.sleeve_leverage_scale,
+                    Utc::now().to_rfc3339(),
+                ],
+            )
+        } else {
+            conn.execute(
+                "INSERT INTO basket_picker_decisions (
+                    run_id, trading_day, picker_id, mode, reason,
+                    active_sectors_json, active_symbols_json,
+                    leadership_short_conflict_ratio, strategy_return_20d,
+                    strategy_drawdown_20d, basket_only_scale_if_sleeve,
+                    sleeve_leverage_scale, created_at_utc
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+                params![
+                    rec.run_id,
+                    rec.trading_day.to_string(),
+                    rec.picker_id,
+                    rec.mode,
+                    rec.reason,
+                    rec.active_sectors_json,
+                    rec.active_symbols_json,
+                    rec.leadership_short_conflict_ratio,
+                    rec.strategy_return_20d,
+                    rec.strategy_drawdown_20d,
+                    rec.basket_only_scale_if_sleeve,
+                    rec.sleeve_leverage_scale,
+                    Utc::now().to_rfc3339(),
+                ],
+            )
+        }
         .map_err(|e| format!("insert basket picker decision: {e}"))?;
         Ok(())
     }
@@ -405,9 +440,47 @@ pub fn serialize_shares_map(values: &HashMap<String, f64>) -> String {
     serde_json::to_string(values).unwrap_or_else(|_| "{}".to_string())
 }
 
+fn table_has_column(conn: &Connection, table: &str, column: &str) -> Result<bool, rusqlite::Error> {
+    let pragma = format!("PRAGMA table_info({table})");
+    let mut stmt = conn.prepare(&pragma)?;
+    let mut rows = stmt.query([])?;
+    while let Some(row) = rows.next()? {
+        let name: String = row.get(1)?;
+        if name == column {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn migrate_picker_decisions_schema(conn: &Connection) -> Result<(), rusqlite::Error> {
+    let has_new = table_has_column(conn, "basket_picker_decisions", "basket_only_scale_if_sleeve")?;
+    if has_new {
+        return Ok(());
+    }
+
+    let has_old = table_has_column(conn, "basket_picker_decisions", "baseline_scale_if_sleeve")?;
+    if !has_old {
+        return Ok(());
+    }
+
+    conn.execute(
+        "ALTER TABLE basket_picker_decisions
+         ADD COLUMN basket_only_scale_if_sleeve REAL NOT NULL DEFAULT 1.0",
+        [],
+    )?;
+    conn.execute(
+        "UPDATE basket_picker_decisions
+            SET basket_only_scale_if_sleeve = baseline_scale_if_sleeve",
+        [],
+    )?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
 
     #[test]
     fn basket_journal_roundtrip() {
@@ -526,5 +599,87 @@ mod tests {
         assert_eq!(sessions, 1);
         assert_eq!(orders, 1);
         assert_eq!(decisions, 1);
+    }
+
+    #[test]
+    fn basket_journal_migrates_legacy_picker_column() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("legacy.sqlite3");
+        let conn = Connection::open(&db).unwrap();
+        conn.execute_batch(
+            "
+CREATE TABLE basket_picker_decisions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT NOT NULL,
+    trading_day TEXT NOT NULL,
+    picker_id TEXT NOT NULL,
+    mode TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    active_sectors_json TEXT NOT NULL,
+    active_symbols_json TEXT NOT NULL,
+    leadership_short_conflict_ratio REAL NOT NULL,
+    strategy_return_20d REAL NOT NULL,
+    strategy_drawdown_20d REAL NOT NULL,
+    baseline_scale_if_sleeve REAL NOT NULL,
+    sleeve_leverage_scale REAL NOT NULL DEFAULT 1.0,
+    created_at_utc TEXT NOT NULL
+);",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO basket_picker_decisions (
+                run_id, trading_day, picker_id, mode, reason, active_sectors_json,
+                active_symbols_json, leadership_short_conflict_ratio,
+                strategy_return_20d, strategy_drawdown_20d, baseline_scale_if_sleeve,
+                sleeve_leverage_scale, created_at_utc
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+            params![
+                "legacy-run",
+                "2026-04-28",
+                "rule_v1",
+                "baseline",
+                "legacy",
+                "[]",
+                "[]",
+                0.0_f64,
+                0.01_f64,
+                0.02_f64,
+                0.75_f64,
+                1.0_f64,
+                Utc::now().to_rfc3339(),
+            ],
+        )
+        .unwrap();
+        drop(conn);
+
+        let journal = BasketJournal::open(&db).unwrap();
+        journal
+            .record_picker_decision(&BasketPickerDecisionRecord {
+                run_id: "new-run",
+                trading_day: NaiveDate::from_ymd_opt(2026, 4, 29).unwrap(),
+                picker_id: "rule_v1",
+                mode: "basket_only",
+                reason: "post_migration",
+                active_sectors_json: "[]".to_string(),
+                active_symbols_json: "[]".to_string(),
+                leadership_short_conflict_ratio: 0.0,
+                strategy_return_20d: 0.0,
+                strategy_drawdown_20d: 0.0,
+                basket_only_scale_if_sleeve: 0.9,
+                sleeve_leverage_scale: 1.0,
+            })
+            .unwrap();
+
+        let conn = journal.conn.lock().unwrap();
+        let migrated: f64 = conn
+            .query_row(
+                "SELECT basket_only_scale_if_sleeve
+                   FROM basket_picker_decisions
+                  WHERE run_id = 'legacy-run'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!((migrated - 0.75).abs() < 1e-9);
     }
 }

--- a/engine/crates/runner/src/basket_journal.rs
+++ b/engine/crates/runner/src/basket_journal.rs
@@ -100,7 +100,7 @@ CREATE TABLE IF NOT EXISTS basket_picker_decisions (
     leadership_short_conflict_ratio REAL NOT NULL,
     strategy_return_20d REAL NOT NULL,
     strategy_drawdown_20d REAL NOT NULL,
-    baseline_scale_if_sleeve REAL NOT NULL,
+    basket_only_scale_if_sleeve REAL NOT NULL,
     sleeve_leverage_scale REAL NOT NULL DEFAULT 1.0,
     created_at_utc TEXT NOT NULL
 );
@@ -202,7 +202,7 @@ pub struct BasketPickerDecisionRecord<'a> {
     pub leadership_short_conflict_ratio: f64,
     pub strategy_return_20d: f64,
     pub strategy_drawdown_20d: f64,
-    pub baseline_scale_if_sleeve: f64,
+    pub basket_only_scale_if_sleeve: f64,
     pub sleeve_leverage_scale: f64,
 }
 
@@ -373,7 +373,7 @@ impl BasketJournal {
                 run_id, trading_day, picker_id, mode, reason,
                 active_sectors_json, active_symbols_json,
                 leadership_short_conflict_ratio, strategy_return_20d,
-                strategy_drawdown_20d, baseline_scale_if_sleeve,
+                strategy_drawdown_20d, basket_only_scale_if_sleeve,
                 sleeve_leverage_scale, created_at_utc
             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
             params![
@@ -387,7 +387,7 @@ impl BasketJournal {
                 rec.leadership_short_conflict_ratio,
                 rec.strategy_return_20d,
                 rec.strategy_drawdown_20d,
-                rec.baseline_scale_if_sleeve,
+                rec.basket_only_scale_if_sleeve,
                 rec.sleeve_leverage_scale,
                 Utc::now().to_rfc3339(),
             ],
@@ -454,14 +454,14 @@ mod tests {
                 run_id: "run-1",
                 trading_day: NaiveDate::from_ymd_opt(2026, 4, 28).unwrap(),
                 picker_id: "rule_v1",
-                mode: "baseline",
+                mode: "basket_only",
                 reason: "no_leadership",
                 active_sectors_json: "[]".to_string(),
                 active_symbols_json: "[]".to_string(),
                 leadership_short_conflict_ratio: 0.0,
                 strategy_return_20d: 0.0,
                 strategy_drawdown_20d: 0.0,
-                baseline_scale_if_sleeve: 1.0,
+                basket_only_scale_if_sleeve: 1.0,
                 sleeve_leverage_scale: 1.0,
             })
             .unwrap();

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -250,7 +250,7 @@ impl SectorLeadershipTracker {
         let mut sectors = self.config.sectors.clone();
         sectors.sort();
         let mode = match self.config.mode {
-            BasketOverlayMode::Baseline => "baseline",
+            BasketOverlayMode::BasketOnly => "basket_only",
             BasketOverlayMode::SuppressShorts => "suppress_shorts",
             BasketOverlayMode::ReplaceWithLongOnly => "replace_with_long_only",
             BasketOverlayMode::AddCappedLongSleeve => "add_capped_long_sleeve",
@@ -490,17 +490,17 @@ fn leadership_picker_features(
         leadership_short_conflict_ratio: 0.0,
         strategy_return_20d: equity_features.return_20d,
         strategy_drawdown_20d: equity_features.drawdown_20d,
-        baseline_scale_if_sleeve: 1.0,
+        basket_only_scale_if_sleeve: 1.0,
     }
 }
 
-fn add_baseline_plan_features(
+fn add_basket_only_plan_features(
     mut features: BasketOverlayPickerFeatures,
-    baseline_notionals: &HashMap<String, f64>,
+    basket_only_notionals: &HashMap<String, f64>,
     portfolio_config: &PortfolioConfig,
     leadership_overlay: Option<&LeadershipOverlayConfig>,
 ) -> BasketOverlayPickerFeatures {
-    let gross = baseline_notionals
+    let gross = basket_only_notionals
         .values()
         .map(|notional| notional.abs())
         .sum::<f64>();
@@ -510,7 +510,7 @@ fn add_baseline_plan_features(
     }
     let leadership_symbols: HashSet<&str> =
         features.long_symbols.iter().map(String::as_str).collect();
-    let conflict = baseline_notionals
+    let conflict = basket_only_notionals
         .iter()
         .filter(|(symbol, notional)| {
             **notional < 0.0 && leadership_symbols.contains(symbol.as_str())
@@ -518,30 +518,30 @@ fn add_baseline_plan_features(
         .map(|(_symbol, notional)| notional.abs())
         .sum::<f64>();
     features.leadership_short_conflict_ratio = conflict / gross;
-    features.baseline_scale_if_sleeve =
-        baseline_scale_if_sleeve(baseline_notionals, portfolio_config, leadership_overlay);
+    features.basket_only_scale_if_sleeve =
+        basket_only_scale_if_sleeve(basket_only_notionals, portfolio_config, leadership_overlay);
     features
 }
 
-fn baseline_scale_if_sleeve(
-    baseline_notionals: &HashMap<String, f64>,
+fn basket_only_scale_if_sleeve(
+    basket_only_notionals: &HashMap<String, f64>,
     portfolio_config: &PortfolioConfig,
     leadership_overlay: Option<&LeadershipOverlayConfig>,
 ) -> f64 {
     let Some(cfg) = leadership_overlay else {
         return 1.0;
     };
-    let baseline_gross = baseline_notionals
+    let basket_only_gross = basket_only_notionals
         .values()
         .map(|notional| notional.abs())
         .sum::<f64>();
-    if baseline_gross <= 0.0 {
+    if basket_only_gross <= 0.0 {
         return 1.0;
     }
     let gross_cap = portfolio_config.capital * portfolio_config.leverage;
     let sleeve_budget = (cfg.long_only_leverage * portfolio_config.capital).min(gross_cap);
-    let baseline_budget = (gross_cap - sleeve_budget).max(0.0);
-    (baseline_budget / baseline_gross).clamp(0.0, 1.0)
+    let basket_only_budget = (gross_cap - sleeve_budget).max(0.0);
+    (basket_only_budget / basket_only_gross).clamp(0.0, 1.0)
 }
 
 fn engine_flatten_baskets_for_plan(
@@ -1294,7 +1294,7 @@ pub async fn run_basket_live(
             persistence_days = cfg.persistence_days,
             min_hold_days = cfg.min_hold_days,
             configured_overlay_mode = match cfg.mode {
-                BasketOverlayMode::Baseline => "baseline",
+                BasketOverlayMode::BasketOnly => "basket_only",
                 BasketOverlayMode::SuppressShorts => "suppress_shorts",
                 BasketOverlayMode::ReplaceWithLongOnly => "replace_with_long_only",
                 BasketOverlayMode::AddCappedLongSleeve => "add_capped_long_sleeve",
@@ -2103,24 +2103,24 @@ async fn process_session_close(
     // Portfolio layer: apply active-basket admission first, then convert
     // admitted target notionals to target shares. Suppression is planned on
     // a clone so the core basket engine state remains intact.
-    let baseline_plan = plan_portfolio(engine, &effective_portfolio_config);
-    let baseline_features = add_baseline_plan_features(
+    let basket_only_plan = plan_portfolio(engine, &effective_portfolio_config);
+    let basket_only_features = add_basket_only_plan_features(
         picker_features,
-        &baseline_plan.symbol_notionals,
+        &basket_only_plan.symbol_notionals,
         &effective_portfolio_config,
         leadership_overlay,
     );
-    let picker_decision = overlay_picker.decide(&baseline_features);
+    let picker_decision = overlay_picker.decide(&basket_only_features);
     let leadership_active_sectors = &picker_decision.active_sectors;
     let leadership_long_symbols = &picker_decision.long_symbols;
-    if leadership_overlay.is_none() && picker_decision.mode != BasketOverlayMode::Baseline {
+    if leadership_overlay.is_none() && picker_decision.mode != BasketOverlayMode::BasketOnly {
         bug!(
             "overlay_mode_without_config",
             date = %date,
             picker_id = overlay_picker.id(),
             picker_mode = picker_decision.mode.as_str(),
             picker_reason = picker_decision.reason,
-            "overlay picker selected a non-baseline mode without leadership overlay config"
+            "overlay picker selected a non-basket-only mode without leadership overlay config"
         );
         return Err(format!(
             "overlay picker selected {} without leadership overlay config",
@@ -2134,10 +2134,10 @@ async fn process_session_close(
         picker_reason = picker_decision.reason,
         leadership_active_sectors = ?leadership_active_sectors,
         leadership_symbols_active = leadership_long_symbols.len(),
-        leadership_short_conflict_ratio = %format!("{:.4}", baseline_features.leadership_short_conflict_ratio),
-        strategy_return_20d = %format!("{:.4}", baseline_features.strategy_return_20d),
-        strategy_drawdown_20d = %format!("{:.4}", baseline_features.strategy_drawdown_20d),
-        baseline_scale_if_sleeve = %format!("{:.4}", baseline_features.baseline_scale_if_sleeve),
+        leadership_short_conflict_ratio = %format!("{:.4}", basket_only_features.leadership_short_conflict_ratio),
+        strategy_return_20d = %format!("{:.4}", basket_only_features.strategy_return_20d),
+        strategy_drawdown_20d = %format!("{:.4}", basket_only_features.strategy_drawdown_20d),
+        basket_only_scale_if_sleeve = %format!("{:.4}", basket_only_features.basket_only_scale_if_sleeve),
         sleeve_leverage_scale = %format!("{:.4}", picker_decision.sleeve_leverage_scale),
         "basket overlay picker decision"
     );
@@ -2152,10 +2152,10 @@ async fn process_session_close(
             reason: picker_decision.reason,
             active_sectors_json: serialize_string_vec(&active_sectors),
             active_symbols_json: serialize_string_vec(leadership_long_symbols),
-            leadership_short_conflict_ratio: baseline_features.leadership_short_conflict_ratio,
-            strategy_return_20d: baseline_features.strategy_return_20d,
-            strategy_drawdown_20d: baseline_features.strategy_drawdown_20d,
-            baseline_scale_if_sleeve: baseline_features.baseline_scale_if_sleeve,
+            leadership_short_conflict_ratio: basket_only_features.leadership_short_conflict_ratio,
+            strategy_return_20d: basket_only_features.strategy_return_20d,
+            strategy_drawdown_20d: basket_only_features.strategy_drawdown_20d,
+            basket_only_scale_if_sleeve: basket_only_features.basket_only_scale_if_sleeve,
             sleeve_leverage_scale: picker_decision.sleeve_leverage_scale,
         })?;
     }
@@ -2166,7 +2166,7 @@ async fn process_session_close(
         Vec::new()
     };
     let plan = if suppressed_baskets.is_empty() {
-        baseline_plan
+        basket_only_plan
     } else {
         let mut planning_engine = engine.clone();
         planning_engine.flatten_baskets(&suppressed_baskets);
@@ -2184,7 +2184,7 @@ async fn process_session_close(
     let using_capped_long_sleeve =
         matches!(picker_decision.mode, BasketOverlayMode::AddCappedLongSleeve)
             && !leadership_long_symbols.is_empty();
-    let baseline_target_notionals = plan.symbol_notionals.clone();
+    let basket_only_target_notionals = plan.symbol_notionals.clone();
     let target_notionals = if using_long_replacement {
         leadership_long_only_notionals(
             closes,
@@ -2198,7 +2198,7 @@ async fn process_session_close(
         let sleeve_leverage = leadership_overlay
             .map(|cfg| cfg.long_only_leverage * picker_decision.sleeve_leverage_scale)
             .unwrap_or(0.0);
-        let baseline_gross = baseline_target_notionals
+        let basket_only_gross = basket_only_target_notionals
             .values()
             .map(|notional| notional.abs())
             .sum::<f64>();
@@ -2206,30 +2206,30 @@ async fn process_session_close(
             .map(|_| sleeve_leverage * effective_portfolio_config.capital)
             .unwrap_or(0.0)
             .min(effective_portfolio_config.capital * effective_portfolio_config.leverage);
-        let baseline_budget = (effective_portfolio_config.capital
+        let basket_only_budget = (effective_portfolio_config.capital
             * effective_portfolio_config.leverage
             - sleeve_budget)
             .max(0.0);
-        let baseline_scale = if baseline_gross > 0.0 {
-            (baseline_budget / baseline_gross).clamp(0.0, 1.0)
+        let basket_only_scale = if basket_only_gross > 0.0 {
+            (basket_only_budget / basket_only_gross).clamp(0.0, 1.0)
         } else {
             0.0
         };
-        let scaled_baseline = scale_notionals(&baseline_target_notionals, baseline_scale);
+        let scaled_basket_only = scale_notionals(&basket_only_target_notionals, basket_only_scale);
         let sleeve_notionals = leadership_long_only_notionals(
             closes,
             leadership_long_symbols,
             effective_portfolio_config.capital,
             sleeve_leverage,
         );
-        merge_notionals(&scaled_baseline, &sleeve_notionals)
+        merge_notionals(&scaled_basket_only, &sleeve_notionals)
     } else {
         plan.symbol_notionals.clone()
     };
     if using_long_replacement || using_capped_long_sleeve {
-        let (baseline_gross_long, baseline_gross_short, baseline_max_abs, _) =
-            summarize_notionals(&baseline_target_notionals);
-        let baseline_gross_notional = baseline_gross_long + baseline_gross_short.abs();
+        let (basket_only_gross_long, basket_only_gross_short, basket_only_max_abs, _) =
+            summarize_notionals(&basket_only_target_notionals);
+        let basket_only_gross_notional = basket_only_gross_long + basket_only_gross_short.abs();
         info!(
             date = %date,
             leadership_active_sectors = ?leadership_active_sectors,
@@ -2242,16 +2242,16 @@ async fn process_session_close(
             } else {
                 "add_capped_long_sleeve"
             },
-            baseline_selected_baskets = plan.selected_baskets.len(),
-            baseline_selected_baskets_sample = ?plan.selected_baskets.iter().take(8).collect::<Vec<_>>(),
-            baseline_targets = baseline_target_notionals.len(),
-            baseline_gross_long = %format!("{:.0}", baseline_gross_long),
-            baseline_gross_short = %format!("{:.0}", baseline_gross_short),
-            baseline_gross_notional = %format!("{:.0}", baseline_gross_notional),
-            baseline_max_abs_leg = %format!("{:.0}", baseline_max_abs),
-            baseline_top_abs_legs = ?top_abs_notional_legs(&baseline_target_notionals, 6),
+            basket_only_selected_baskets = plan.selected_baskets.len(),
+            basket_only_selected_baskets_sample = ?plan.selected_baskets.iter().take(8).collect::<Vec<_>>(),
+            basket_only_targets = basket_only_target_notionals.len(),
+            basket_only_gross_long = %format!("{:.0}", basket_only_gross_long),
+            basket_only_gross_short = %format!("{:.0}", basket_only_gross_short),
+            basket_only_gross_notional = %format!("{:.0}", basket_only_gross_notional),
+            basket_only_max_abs_leg = %format!("{:.0}", basket_only_max_abs),
+            basket_only_top_abs_legs = ?top_abs_notional_legs(&basket_only_target_notionals, 6),
             overlay_top_abs_legs = ?top_abs_notional_legs(&target_notionals, 6),
-            "leadership overlay transformed baseline basket portfolio"
+            "leadership overlay transformed basket-only basket portfolio"
         );
     }
     let engine_flatten_baskets =
@@ -2290,8 +2290,8 @@ async fn process_session_close(
     info!(
         date = %date,
         leadership_mode = match picker_decision.mode {
-            BasketOverlayMode::Baseline if leadership_overlay.is_none() => "disabled",
-            BasketOverlayMode::Baseline => "baseline",
+            BasketOverlayMode::BasketOnly if leadership_overlay.is_none() => "disabled",
+            BasketOverlayMode::BasketOnly => "basket_only",
             BasketOverlayMode::SuppressShorts if !leadership_active_sectors.is_empty() => "suppress_shorts",
             BasketOverlayMode::SuppressShorts => "suppress_shorts_inactive",
             BasketOverlayMode::ReplaceWithLongOnly if using_long_replacement => "replace_with_long_only",
@@ -2335,7 +2335,7 @@ async fn process_session_close(
             admitted = plan.selected_baskets.len(),
             excluded = plan.excluded_baskets.len(),
             excluded_sample = ?plan.excluded_baskets.iter().take(10).collect::<Vec<_>>(),
-            "active-basket cap excluded baskets from the baseline target portfolio"
+            "active-basket cap excluded baskets from the basket-only target portfolio"
         );
     } else {
         info!(
@@ -3292,7 +3292,7 @@ mod tests {
     }
 
     #[test]
-    fn test_baseline_scale_if_sleeve_respects_gross_budget() {
+    fn test_basket_only_scale_if_sleeve_respects_gross_budget() {
         let portfolio_config = PortfolioConfig {
             capital: 10_000.0,
             leverage: 4.0,
@@ -3306,7 +3306,7 @@ mod tests {
             off_breadth5d_threshold: 0.5,
             persistence_days: 2,
             min_hold_days: 3,
-            mode: BasketOverlayMode::Baseline,
+            mode: BasketOverlayMode::BasketOnly,
             long_only_leverage: 1.0,
         };
         let baseline_notionals = HashMap::from([
@@ -3317,7 +3317,7 @@ mod tests {
         ]);
 
         let scale =
-            baseline_scale_if_sleeve(&baseline_notionals, &portfolio_config, Some(&overlay));
+            basket_only_scale_if_sleeve(&baseline_notionals, &portfolio_config, Some(&overlay));
 
         assert!((scale - 0.75).abs() < 1e-9);
     }
@@ -3362,7 +3362,7 @@ mod tests {
     }
 
     #[test]
-    fn test_add_baseline_plan_features_measures_leadership_short_conflict() {
+    fn test_add_basket_only_plan_features_measures_leadership_short_conflict() {
         let portfolio_config = PortfolioConfig {
             capital: 10_000.0,
             leverage: 4.0,
@@ -3376,7 +3376,7 @@ mod tests {
             off_breadth5d_threshold: 0.5,
             persistence_days: 2,
             min_hold_days: 3,
-            mode: BasketOverlayMode::Baseline,
+            mode: BasketOverlayMode::BasketOnly,
             long_only_leverage: 1.0,
         };
         let features = BasketOverlayPickerFeatures {
@@ -3393,7 +3393,7 @@ mod tests {
             ("CNC".to_string(), -10_000.0),
         ]);
 
-        let features = add_baseline_plan_features(
+        let features = add_basket_only_plan_features(
             features,
             &baseline_notionals,
             &portfolio_config,
@@ -3401,7 +3401,7 @@ mod tests {
         );
 
         assert!((features.leadership_short_conflict_ratio - 0.25).abs() < 1e-9);
-        assert!((features.baseline_scale_if_sleeve - 0.75).abs() < 1e-9);
+        assert!((features.basket_only_scale_if_sleeve - 0.75).abs() < 1e-9);
     }
 
     #[test]

--- a/engine/crates/runner/src/basket_overlay_picker.rs
+++ b/engine/crates/runner/src/basket_overlay_picker.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BasketOverlayMode {
-    Baseline,
+    BasketOnly,
     SuppressShorts,
     ReplaceWithLongOnly,
     AddCappedLongSleeve,
@@ -13,7 +13,7 @@ pub enum BasketOverlayMode {
 impl BasketOverlayMode {
     pub fn as_str(self) -> &'static str {
         match self {
-            Self::Baseline => "baseline",
+            Self::BasketOnly => "basket_only",
             Self::SuppressShorts => "suppress_shorts",
             Self::ReplaceWithLongOnly => "replace_with_long_only",
             Self::AddCappedLongSleeve => "add_capped_long_sleeve",
@@ -34,7 +34,7 @@ pub struct BasketOverlayPickerFeatures {
     pub leadership_short_conflict_ratio: f64,
     pub strategy_return_20d: f64,
     pub strategy_drawdown_20d: f64,
-    pub baseline_scale_if_sleeve: f64,
+    pub basket_only_scale_if_sleeve: f64,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -47,9 +47,9 @@ pub struct BasketOverlayPickerDecision {
 }
 
 impl BasketOverlayPickerDecision {
-    pub fn baseline(reason: &'static str) -> Self {
+    pub fn basket_only(reason: &'static str) -> Self {
         Self {
-            mode: BasketOverlayMode::Baseline,
+            mode: BasketOverlayMode::BasketOnly,
             reason,
             active_sectors: HashSet::new(),
             long_symbols: Vec::new(),
@@ -62,8 +62,8 @@ impl BasketOverlayPickerDecision {
         reason: &'static str,
         features: &BasketOverlayPickerFeatures,
     ) -> Self {
-        if mode == BasketOverlayMode::Baseline {
-            return Self::baseline(reason);
+        if mode == BasketOverlayMode::BasketOnly {
+            return Self::basket_only(reason);
         }
         Self {
             mode,
@@ -91,15 +91,15 @@ pub trait BasketOverlayPicker {
 }
 
 #[derive(Debug, Default)]
-pub struct BaselineOverlayPicker;
+pub struct BasketOnlyOverlayPicker;
 
-impl BasketOverlayPicker for BaselineOverlayPicker {
+impl BasketOverlayPicker for BasketOnlyOverlayPicker {
     fn id(&self) -> &'static str {
-        "baseline"
+        "basket_only"
     }
 
     fn decide(&mut self, _features: &BasketOverlayPickerFeatures) -> BasketOverlayPickerDecision {
-        BasketOverlayPickerDecision::baseline("no_picker_configured")
+        BasketOverlayPickerDecision::basket_only("no_picker_configured")
     }
 }
 
@@ -135,8 +135,8 @@ pub struct RuleV1OverlayPickerConfig {
     pub recovered_return_threshold: f64,
     pub recovered_drawdown_threshold: f64,
     pub sleeve_return_ceiling: f64,
-    pub min_baseline_scale_for_sleeve: f64,
-    pub opportunistic_sleeve_min_baseline_scale: f64,
+    pub min_basket_only_scale_for_sleeve: f64,
+    pub opportunistic_sleeve_min_basket_only_scale: f64,
     pub opportunistic_sleeve_return_ceiling: f64,
     pub halve_sleeve_drawdown_threshold: f64,
     pub quarter_sleeve_drawdown_threshold: f64,
@@ -154,8 +154,8 @@ impl Default for RuleV1OverlayPickerConfig {
             recovered_return_threshold: 0.03,
             recovered_drawdown_threshold: 0.03,
             sleeve_return_ceiling: 0.03,
-            min_baseline_scale_for_sleeve: 0.70,
-            opportunistic_sleeve_min_baseline_scale: 0.85,
+            min_basket_only_scale_for_sleeve: 0.70,
+            opportunistic_sleeve_min_basket_only_scale: 0.85,
             opportunistic_sleeve_return_ceiling: 0.10,
             halve_sleeve_drawdown_threshold: 0.05,
             quarter_sleeve_drawdown_threshold: 0.10,
@@ -175,7 +175,7 @@ impl RuleV1OverlayPicker {
     pub fn new(config: RuleV1OverlayPickerConfig) -> Self {
         Self {
             config,
-            current_mode: BasketOverlayMode::Baseline,
+            current_mode: BasketOverlayMode::BasketOnly,
             dwell_remaining_days: 0,
             off_signal_days: 0,
         }
@@ -196,13 +196,13 @@ impl RuleV1OverlayPicker {
     }
 
     fn sleeve_allowed(&self, features: &BasketOverlayPickerFeatures) -> bool {
-        features.baseline_scale_if_sleeve >= self.config.min_baseline_scale_for_sleeve
+        features.basket_only_scale_if_sleeve >= self.config.min_basket_only_scale_for_sleeve
             && (self.strategy_weak(features)
                 || features.strategy_return_20d <= self.config.sleeve_return_ceiling)
     }
 
     fn opportunistic_sleeve_allowed(&self, features: &BasketOverlayPickerFeatures) -> bool {
-        features.baseline_scale_if_sleeve >= self.config.opportunistic_sleeve_min_baseline_scale
+        features.basket_only_scale_if_sleeve >= self.config.opportunistic_sleeve_min_basket_only_scale
             && features.strategy_return_20d <= self.config.opportunistic_sleeve_return_ceiling
             && features.leadership_short_conflict_ratio < self.config.suppress_conflict_on_threshold
     }
@@ -264,10 +264,10 @@ impl BasketOverlayPicker for RuleV1OverlayPicker {
 
         let leadership_on = Self::leadership_on(features);
         match self.current_mode {
-            BasketOverlayMode::Baseline => {
+            BasketOverlayMode::BasketOnly => {
                 self.off_signal_days = 0;
                 if !leadership_on {
-                    return BasketOverlayPickerDecision::baseline("no_leadership");
+                    return BasketOverlayPickerDecision::basket_only("no_leadership");
                 }
                 let material_short_conflict = features.leadership_short_conflict_ratio
                     >= self.config.suppress_conflict_on_threshold;
@@ -289,9 +289,9 @@ impl BasketOverlayPicker for RuleV1OverlayPicker {
                             .with_sleeve_scale(self.sleeve_scale(features));
                     }
                     if !self.strategy_weak(features) {
-                        return BasketOverlayPickerDecision::baseline("leadership_basket_healthy");
+                        return BasketOverlayPickerDecision::basket_only("leadership_basket_healthy");
                     }
-                    return BasketOverlayPickerDecision::baseline("sleeve_crowds_baseline");
+                    return BasketOverlayPickerDecision::basket_only("sleeve_crowds_basket_only");
                 }
                 self.enter(
                     BasketOverlayMode::AddCappedLongSleeve,
@@ -310,9 +310,9 @@ impl BasketOverlayPicker for RuleV1OverlayPicker {
                     self.off_signal_days = 0;
                 }
                 if self.off_signal_days >= self.config.off_confirmation_days {
-                    self.current_mode = BasketOverlayMode::Baseline;
+                    self.current_mode = BasketOverlayMode::BasketOnly;
                     self.off_signal_days = 0;
-                    return BasketOverlayPickerDecision::baseline("suppress_signal_cleared");
+                    return BasketOverlayPickerDecision::basket_only("suppress_signal_cleared");
                 }
                 self.hold("suppress_signal_still_active", features)
             }
@@ -323,23 +323,23 @@ impl BasketOverlayPicker for RuleV1OverlayPicker {
                     self.off_signal_days = 0;
                 }
                 if self.off_signal_days >= self.config.off_confirmation_days {
-                    self.current_mode = BasketOverlayMode::Baseline;
+                    self.current_mode = BasketOverlayMode::BasketOnly;
                     self.off_signal_days = 0;
-                    return BasketOverlayPickerDecision::baseline("sleeve_signal_cleared");
+                    return BasketOverlayPickerDecision::basket_only("sleeve_signal_cleared");
                 }
                 self.hold("sleeve_signal_still_active", features)
                     .with_sleeve_scale(self.sleeve_scale(features))
             }
             BasketOverlayMode::ReplaceWithLongOnly => {
-                self.current_mode = BasketOverlayMode::Baseline;
-                BasketOverlayPickerDecision::baseline("replace_not_allowed")
+                self.current_mode = BasketOverlayMode::BasketOnly;
+                BasketOverlayPickerDecision::basket_only("replace_not_allowed")
             }
         }
     }
 }
 
 pub enum BasketOverlayPickerHandle {
-    Baseline(BaselineOverlayPicker),
+    BasketOnly(BasketOnlyOverlayPicker),
     Fixed(FixedOverlayPicker),
     RuleV1(RuleV1OverlayPicker),
 }
@@ -354,7 +354,7 @@ impl BasketOverlayPickerHandle {
             BasketOverlayPickerKind::Fixed => configured_mode
                 .map(FixedOverlayPicker::new)
                 .map(Self::Fixed)
-                .unwrap_or_else(|| Self::Baseline(BaselineOverlayPicker)),
+                .unwrap_or_else(|| Self::BasketOnly(BasketOnlyOverlayPicker)),
             BasketOverlayPickerKind::RuleV1 => {
                 Self::RuleV1(RuleV1OverlayPicker::new(rule_v1_config.unwrap_or_default()))
             }
@@ -380,7 +380,7 @@ impl BasketOverlayPickerHandle {
                 *picker = rule_state;
                 Ok(true)
             }
-            (Self::Baseline(_), None) | (Self::Fixed(_), None) => Ok(true),
+            (Self::BasketOnly(_), None) | (Self::Fixed(_), None) => Ok(true),
             _ => Ok(false),
         }
     }
@@ -394,7 +394,7 @@ impl BasketOverlayPickerHandle {
             picker_id: self.id().to_string(),
             rule_v1: match self {
                 Self::RuleV1(picker) => Some(picker.clone()),
-                Self::Baseline(_) | Self::Fixed(_) => None,
+                Self::BasketOnly(_) | Self::Fixed(_) => None,
             },
         };
         let content = serde_json::to_string_pretty(&state)
@@ -416,7 +416,7 @@ struct BasketOverlayPickerState {
 impl BasketOverlayPicker for BasketOverlayPickerHandle {
     fn id(&self) -> &'static str {
         match self {
-            Self::Baseline(picker) => picker.id(),
+            Self::BasketOnly(picker) => picker.id(),
             Self::Fixed(picker) => picker.id(),
             Self::RuleV1(picker) => picker.id(),
         }
@@ -424,7 +424,7 @@ impl BasketOverlayPicker for BasketOverlayPickerHandle {
 
     fn decide(&mut self, features: &BasketOverlayPickerFeatures) -> BasketOverlayPickerDecision {
         match self {
-            Self::Baseline(picker) => picker.decide(features),
+            Self::BasketOnly(picker) => picker.decide(features),
             Self::Fixed(picker) => picker.decide(features),
             Self::RuleV1(picker) => picker.decide(features),
         }
@@ -436,20 +436,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn baseline_picker_ignores_feature_payload() {
+    fn basket_only_picker_ignores_feature_payload() {
         let features = BasketOverlayPickerFeatures {
             active_sectors: HashSet::from(["chips".to_string()]),
             long_symbols: vec!["NVDA".to_string()],
             leadership_short_conflict_ratio: 0.0,
             strategy_return_20d: 0.0,
             strategy_drawdown_20d: 0.0,
-            baseline_scale_if_sleeve: 1.0,
+            basket_only_scale_if_sleeve: 1.0,
         };
 
-        let mut picker = BaselineOverlayPicker;
+        let mut picker = BasketOnlyOverlayPicker;
         let decision = picker.decide(&features);
 
-        assert_eq!(decision.mode, BasketOverlayMode::Baseline);
+        assert_eq!(decision.mode, BasketOverlayMode::BasketOnly);
         assert!(decision.active_sectors.is_empty());
         assert!(decision.long_symbols.is_empty());
     }
@@ -462,7 +462,7 @@ mod tests {
             leadership_short_conflict_ratio: 0.0,
             strategy_return_20d: 0.0,
             strategy_drawdown_20d: 0.0,
-            baseline_scale_if_sleeve: 1.0,
+            basket_only_scale_if_sleeve: 1.0,
         };
 
         let mut picker = FixedOverlayPicker::new(BasketOverlayMode::AddCappedLongSleeve);
@@ -488,7 +488,7 @@ mod tests {
             leadership_short_conflict_ratio: 0.25,
             strategy_return_20d: 0.10,
             strategy_drawdown_20d: 0.0,
-            baseline_scale_if_sleeve: 1.0,
+            basket_only_scale_if_sleeve: 1.0,
         };
 
         let decision = picker.decide(&features);
@@ -512,7 +512,7 @@ mod tests {
             leadership_short_conflict_ratio: 0.0,
             strategy_return_20d: -0.02,
             strategy_drawdown_20d: 0.06,
-            baseline_scale_if_sleeve: 0.75,
+            basket_only_scale_if_sleeve: 0.75,
         };
 
         let decision = picker.decide(&features);
@@ -522,7 +522,7 @@ mod tests {
     }
 
     #[test]
-    fn rule_v1_stays_baseline_when_basket_is_healthy() {
+    fn rule_v1_stays_basket_only_when_basket_is_healthy() {
         let mut picker = RuleV1OverlayPicker::new(RuleV1OverlayPickerConfig {
             min_dwell_days: 0,
             off_confirmation_days: 2,
@@ -536,12 +536,12 @@ mod tests {
             leadership_short_conflict_ratio: 0.0,
             strategy_return_20d: 0.07,
             strategy_drawdown_20d: 0.01,
-            baseline_scale_if_sleeve: 0.75,
+            basket_only_scale_if_sleeve: 0.75,
         };
 
         let decision = picker.decide(&features);
 
-        assert_eq!(decision.mode, BasketOverlayMode::Baseline);
+        assert_eq!(decision.mode, BasketOverlayMode::BasketOnly);
         assert_eq!(decision.reason, "leadership_basket_healthy");
     }
 
@@ -558,7 +558,7 @@ mod tests {
             leadership_short_conflict_ratio: 0.10,
             strategy_return_20d: 0.08,
             strategy_drawdown_20d: 0.01,
-            baseline_scale_if_sleeve: 0.90,
+            basket_only_scale_if_sleeve: 0.90,
         };
 
         let decision = picker.decide(&features);
@@ -580,12 +580,12 @@ mod tests {
             leadership_short_conflict_ratio: 0.10,
             strategy_return_20d: 0.12,
             strategy_drawdown_20d: 0.01,
-            baseline_scale_if_sleeve: 0.90,
+            basket_only_scale_if_sleeve: 0.90,
         };
 
         let decision = picker.decide(&features);
 
-        assert_eq!(decision.mode, BasketOverlayMode::Baseline);
+        assert_eq!(decision.mode, BasketOverlayMode::BasketOnly);
         assert_eq!(decision.reason, "leadership_basket_healthy");
     }
 
@@ -602,7 +602,7 @@ mod tests {
             leadership_short_conflict_ratio: 0.18,
             strategy_return_20d: 0.08,
             strategy_drawdown_20d: 0.01,
-            baseline_scale_if_sleeve: 0.90,
+            basket_only_scale_if_sleeve: 0.90,
         };
 
         let decision = picker.decide(&features);
@@ -624,7 +624,7 @@ mod tests {
             leadership_short_conflict_ratio: 0.0,
             strategy_return_20d: -0.02,
             strategy_drawdown_20d: 0.04,
-            baseline_scale_if_sleeve: 0.90,
+            basket_only_scale_if_sleeve: 0.90,
         };
         let recovered_features = BasketOverlayPickerFeatures {
             active_sectors: HashSet::from(["faang".to_string()]),
@@ -632,7 +632,7 @@ mod tests {
             leadership_short_conflict_ratio: 0.0,
             strategy_return_20d: 0.12,
             strategy_drawdown_20d: 0.0,
-            baseline_scale_if_sleeve: 0.90,
+            basket_only_scale_if_sleeve: 0.90,
         };
 
         assert_eq!(
@@ -660,7 +660,7 @@ mod tests {
             leadership_short_conflict_ratio: 0.25,
             strategy_return_20d: -0.01,
             strategy_drawdown_20d: 0.04,
-            baseline_scale_if_sleeve: 0.90,
+            basket_only_scale_if_sleeve: 0.90,
         };
 
         let decision = picker.decide(&features);
@@ -682,7 +682,7 @@ mod tests {
             leadership_short_conflict_ratio: 0.0,
             strategy_return_20d: 0.02,
             strategy_drawdown_20d: 0.08,
-            baseline_scale_if_sleeve: 0.90,
+            basket_only_scale_if_sleeve: 0.90,
         };
 
         let decision = picker.decide(&features);
@@ -704,7 +704,7 @@ mod tests {
             leadership_short_conflict_ratio: 0.0,
             strategy_return_20d: -0.02,
             strategy_drawdown_20d: 0.08,
-            baseline_scale_if_sleeve: 0.90,
+            basket_only_scale_if_sleeve: 0.90,
         };
 
         let decision = picker.decide(&features);
@@ -723,7 +723,7 @@ mod tests {
             leadership_short_conflict_ratio: 0.25,
             strategy_return_20d: 0.08,
             strategy_drawdown_20d: 0.01,
-            baseline_scale_if_sleeve: 0.75,
+            basket_only_scale_if_sleeve: 0.75,
         };
         let mut picker =
             BasketOverlayPickerHandle::from_kind(BasketOverlayPickerKind::RuleV1, None, None);

--- a/engine/crates/runner/src/main.rs
+++ b/engine/crates/runner/src/main.rs
@@ -148,11 +148,6 @@ struct StreamArgs {
     #[arg(long)]
     universe: Option<PathBuf>,
 
-    /// Optional alternate basket universe TOML selected when the regime-switch
-    /// signal is ON at startup.
-    #[arg(long)]
-    alternate_universe: Option<PathBuf>,
-
     /// Directory containing per-symbol 1-min parquets. Required when --engine basket.
     /// Defaults to $QUANT_DATA_DIR if set, else `~/quant-data/bars/v3_sp500_2024-2026_1min_adjusted`.
     #[arg(long)]
@@ -173,24 +168,6 @@ struct StreamArgs {
     #[arg(long)]
     fit_artifact: Option<PathBuf>,
 
-    /// Optional basket regime-switch symbol set used to decide whether to
-    /// launch the primary universe or `--alternate-universe`.
-    #[arg(long, value_delimiter = ',')]
-    regime_switch_symbols: Vec<String>,
-
-    /// Activate the alternate universe when the regime-switch basket's 5d
-    /// equal-weight return is at or above this threshold.
-    #[arg(long)]
-    regime_switch_ret5d_threshold: Option<f64>,
-
-    /// Activate the alternate universe when the regime-switch basket's breadth
-    /// fraction above SMA is at or above this threshold.
-    #[arg(long)]
-    regime_switch_breadth_threshold: Option<f64>,
-
-    /// Breadth lookback window in trading days for the regime-switch basket.
-    #[arg(long)]
-    regime_switch_sma_window: Option<usize>,
 
     /// Persisted basket engine state. Defaults to `<fit-artifact>.state.json`.
     #[arg(long)]
@@ -309,11 +286,6 @@ struct ReplayArgs {
     #[arg(long)]
     universe: Option<PathBuf>,
 
-    /// Optional alternate basket universe TOML selected when the regime-switch
-    /// signal is ON at startup.
-    #[arg(long)]
-    alternate_universe: Option<PathBuf>,
-
     /// Directory containing per-symbol 1-min parquets. Required when --engine basket.
     /// Defaults to $QUANT_DATA_DIR if set, else /Users/$USER/quant-data/bars/v3_sp500_2024-2026_1min_adjusted
     #[arg(long)]
@@ -362,24 +334,6 @@ struct ReplayArgs {
     #[arg(long)]
     report_tsv: Option<PathBuf>,
 
-    /// Optional basket regime-switch symbol set used to decide whether to
-    /// launch the primary universe or `--alternate-universe`.
-    #[arg(long, value_delimiter = ',')]
-    regime_switch_symbols: Vec<String>,
-
-    /// Activate the alternate universe when the regime-switch basket's 5d
-    /// equal-weight return is at or above this threshold.
-    #[arg(long)]
-    regime_switch_ret5d_threshold: Option<f64>,
-
-    /// Activate the alternate universe when the regime-switch basket's breadth
-    /// fraction above SMA is at or above this threshold.
-    #[arg(long)]
-    regime_switch_breadth_threshold: Option<f64>,
-
-    /// Breadth lookback window in trading days for the regime-switch basket.
-    #[arg(long)]
-    regime_switch_sma_window: Option<usize>,
 
     /// Ignore leadership overlay defaults from the universe TOML for this run.
     #[arg(long, default_value_t = false)]
@@ -529,22 +483,6 @@ struct LeadershipOverlayBuildArgs<'a> {
     long_only_leverage: f64,
 }
 
-struct UniverseSwitchArgs<'a> {
-    primary_universe_path: &'a Path,
-    alternate_universe_path: Option<&'a Path>,
-    regime_switch_symbols: &'a [String],
-    regime_switch_ret5d_threshold: Option<f64>,
-    regime_switch_breadth_threshold: Option<f64>,
-    regime_switch_sma_window: Option<usize>,
-}
-
-#[derive(Debug, Clone, Copy)]
-struct RegimeSignalMetrics {
-    ret5d: f64,
-    breadth: f64,
-    ret_symbol_count: usize,
-    breadth_symbol_count: usize,
-}
 
 fn resolve_stream_execution(
     requested: Option<&str>,
@@ -824,160 +762,6 @@ fn build_leadership_overlay_config(
     })
 }
 
-fn maybe_resolve_regime_switch_universe(
-    bars_dir: &Path,
-    as_of: chrono::NaiveDate,
-    args: UniverseSwitchArgs<'_>,
-) -> PathBuf {
-    let primary = args.primary_universe_path.to_path_buf();
-    let Some(alternate) = args.alternate_universe_path else {
-        return primary;
-    };
-
-    let has_switch_overrides = !args.regime_switch_symbols.is_empty()
-        || args.regime_switch_ret5d_threshold.is_some()
-        || args.regime_switch_breadth_threshold.is_some()
-        || args.regime_switch_sma_window.is_some();
-    if !has_switch_overrides {
-        return primary;
-    }
-
-    if args.regime_switch_symbols.is_empty()
-        || args.regime_switch_ret5d_threshold.is_none()
-        || args.regime_switch_breadth_threshold.is_none()
-    {
-        error!(
-            "regime switch requires --alternate-universe, --regime-switch-symbols, --regime-switch-ret5d-threshold, and --regime-switch-breadth-threshold"
-        );
-        std::process::exit(2);
-    }
-
-    let ret5d_threshold = args.regime_switch_ret5d_threshold.unwrap();
-    let breadth_threshold = args.regime_switch_breadth_threshold.unwrap();
-    let sma_window = args.regime_switch_sma_window.unwrap_or(20);
-    if !ret5d_threshold.is_finite() {
-        error!("regime-switch ret5d threshold must be finite");
-        std::process::exit(2);
-    }
-    if !breadth_threshold.is_finite() || !(0.0..=1.0).contains(&breadth_threshold) {
-        error!("regime-switch breadth threshold must be finite and in [0, 1]");
-        std::process::exit(2);
-    }
-    if sma_window == 0 {
-        error!("regime-switch SMA window must be > 0");
-        std::process::exit(2);
-    }
-
-    let switch_window_days = (sma_window.max(20) + 10) as i64;
-    let closes = match crate::basket_live::load_warmup_closes_as_of(
-        bars_dir,
-        args.regime_switch_symbols,
-        switch_window_days,
-        as_of,
-    ) {
-        Ok(c) => c,
-        Err(e) => {
-            warn!(
-                error = %e,
-                universe = %primary.display(),
-                alternate_universe = %alternate.display(),
-                "regime-switch warmup load failed — staying on primary universe"
-            );
-            return primary;
-        }
-    };
-
-    let Some(metrics) = compute_regime_signal_metrics(
-        &closes,
-        args.regime_switch_symbols,
-        sma_window,
-    ) else {
-        warn!(
-            symbols = args.regime_switch_symbols.len(),
-            universe = %primary.display(),
-            alternate_universe = %alternate.display(),
-            "regime-switch signal had insufficient history — staying on primary universe"
-        );
-        return primary;
-    };
-
-    let switch_on = metrics.ret5d >= ret5d_threshold && metrics.breadth >= breadth_threshold;
-    info!(
-        as_of = %as_of,
-        primary_universe = %primary.display(),
-        alternate_universe = %alternate.display(),
-        switch_symbols = ?args.regime_switch_symbols,
-        ret5d = %format!("{:+.4}", metrics.ret5d),
-        breadth = %format!("{:.4}", metrics.breadth),
-        ret_symbol_count = metrics.ret_symbol_count,
-        breadth_symbol_count = metrics.breadth_symbol_count,
-        ret5d_threshold = %format!("{:+.4}", ret5d_threshold),
-        breadth_threshold = %format!("{:.4}", breadth_threshold),
-        sma_window,
-        switch_on,
-        "basket regime-switch evaluated"
-    );
-
-    if switch_on {
-        alternate.to_path_buf()
-    } else {
-        primary
-    }
-}
-
-fn compute_regime_signal_metrics(
-    closes: &std::collections::HashMap<String, Vec<(chrono::NaiveDate, f64)>>,
-    switch_symbols: &[String],
-    sma_window: usize,
-) -> Option<RegimeSignalMetrics> {
-    if sma_window == 0 {
-        return None;
-    }
-
-    let mut ret_sum = 0.0;
-    let mut ret_count = 0usize;
-    let mut breadth_count = 0usize;
-    let mut breadth_above = 0usize;
-
-    for symbol in switch_symbols {
-        let Some(series) = closes.get(symbol) else {
-            continue;
-        };
-        if series.len() >= 6 {
-            let last = series.last().map(|(_, px)| *px).unwrap_or(0.0);
-            let base = series[series.len() - 6].1;
-            if last.is_finite() && base.is_finite() && last > 0.0 && base > 0.0 {
-                ret_sum += last / base - 1.0;
-                ret_count += 1;
-            }
-        }
-        if series.len() >= sma_window {
-            let last = series.last().map(|(_, px)| *px).unwrap_or(0.0);
-            let sma = series[series.len() - sma_window..]
-                .iter()
-                .map(|(_, px)| *px)
-                .sum::<f64>()
-                / sma_window as f64;
-            if last.is_finite() && sma.is_finite() && last > 0.0 && sma > 0.0 {
-                breadth_count += 1;
-                if last > sma {
-                    breadth_above += 1;
-                }
-            }
-        }
-    }
-
-    if ret_count == 0 || breadth_count == 0 {
-        return None;
-    }
-
-    Some(RegimeSignalMetrics {
-        ret5d: ret_sum / ret_count as f64,
-        breadth: breadth_above as f64 / breadth_count as f64,
-        ret_symbol_count: ret_count,
-        breadth_symbol_count: breadth_count,
-    })
-}
 
 fn leadership_overlay_fingerprint(cfg: &basket_live::LeadershipOverlayConfig) -> String {
     let mode = match cfg.mode {
@@ -1247,7 +1031,7 @@ async fn main() {
 // ── Basket live/paper dispatch ──────────────────────────────────────
 
 async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
-    let requested_universe_path = args
+    let universe_path = args
         .universe
         .clone()
         .or_else(|| args.engine.universe_path().map(PathBuf::from))
@@ -1264,18 +1048,6 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
                 PathBuf::from(home).join("quant-data/bars/v3_sp500_2024-2026_1min_adjusted")
             })
     });
-    let universe_path = maybe_resolve_regime_switch_universe(
-        &bars_dir,
-        chrono::Utc::now().date_naive(),
-        UniverseSwitchArgs {
-            primary_universe_path: &requested_universe_path,
-            alternate_universe_path: args.alternate_universe.as_deref(),
-            regime_switch_symbols: &args.regime_switch_symbols,
-            regime_switch_ret5d_threshold: args.regime_switch_ret5d_threshold,
-            regime_switch_breadth_threshold: args.regime_switch_breadth_threshold,
-            regime_switch_sma_window: args.regime_switch_sma_window,
-        },
-    );
     let fit_artifact_path = args
         .fit_artifact
         .clone()
@@ -2112,7 +1884,7 @@ fn log_intent(intent: &openquant_core::pairs::PairOrderIntent, side: &str) {
 // entirely at the call site.
 
 async fn run_basket_replay_live_path(args: ReplayArgs) {
-    let requested_universe_path = args
+    let universe_path = args
         .universe
         .clone()
         .or_else(|| args.engine.universe_path().map(PathBuf::from))
@@ -2144,19 +1916,6 @@ async fn run_basket_replay_live_path(args: ReplayArgs) {
         error!(start = %start, end = %end, "--end must be on or after --start");
         std::process::exit(1);
     }
-
-    let universe_path = maybe_resolve_regime_switch_universe(
-        &bars_dir,
-        start,
-        UniverseSwitchArgs {
-            primary_universe_path: &requested_universe_path,
-            alternate_universe_path: args.alternate_universe.as_deref(),
-            regime_switch_symbols: &args.regime_switch_symbols,
-            regime_switch_ret5d_threshold: args.regime_switch_ret5d_threshold,
-            regime_switch_breadth_threshold: args.regime_switch_breadth_threshold,
-            regime_switch_sma_window: args.regime_switch_sma_window,
-        },
-    );
 
     // Replay state isolation: never touch the live default state path.
     let state_path = args.state_path.clone().unwrap_or_else(|| {
@@ -2449,8 +2208,6 @@ fn cleanup_old_engine_logs(journal_dir: &Path, retention_days: u64) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::NaiveDate;
-    use std::collections::HashMap;
 
     #[test]
     fn stream_state_defaults_under_data_state() {
@@ -2476,46 +2233,4 @@ mod tests {
         );
     }
 
-    #[test]
-    fn compute_regime_signal_metrics_turns_on_for_strong_breadth_and_return() {
-        let mut closes: HashMap<String, Vec<(NaiveDate, f64)>> = HashMap::new();
-        let mk = |vals: &[f64]| {
-            vals.iter()
-                .enumerate()
-                .map(|(i, v)| {
-                    (
-                        NaiveDate::from_ymd_opt(2026, 1, 1).unwrap()
-                            + chrono::Days::new(i as u64),
-                        *v,
-                    )
-                })
-                .collect::<Vec<_>>()
-        };
-        closes.insert("A".to_string(), mk(&[
-            100.0, 101.0, 102.0, 103.0, 104.0, 110.0, 111.0, 112.0, 113.0, 114.0,
-            115.0, 116.0, 117.0, 118.0, 119.0, 120.0, 121.0, 122.0, 123.0, 124.0,
-            125.0,
-        ]));
-        closes.insert("B".to_string(), mk(&[
-            50.0, 50.5, 51.0, 51.5, 52.0, 55.0, 55.5, 56.0, 56.5, 57.0, 57.5, 58.0,
-            58.5, 59.0, 59.5, 60.0, 60.5, 61.0, 61.5, 62.0, 62.5,
-        ]));
-        let symbols = vec!["A".to_string(), "B".to_string()];
-        let metrics = compute_regime_signal_metrics(&closes, &symbols, 20).unwrap();
-        assert!(metrics.ret5d > 0.02);
-        assert_eq!(metrics.breadth, 1.0);
-    }
-
-    #[test]
-    fn compute_regime_signal_metrics_returns_none_without_enough_history() {
-        let closes: HashMap<String, Vec<(NaiveDate, f64)>> = HashMap::from([(
-            "A".to_string(),
-            vec![
-                (NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(), 100.0),
-                (NaiveDate::from_ymd_opt(2026, 1, 2).unwrap(), 101.0),
-            ],
-        )]);
-        let symbols = vec!["A".to_string()];
-        assert!(compute_regime_signal_metrics(&closes, &symbols, 20).is_none());
-    }
 }

--- a/engine/crates/runner/src/main.rs
+++ b/engine/crates/runner/src/main.rs
@@ -96,14 +96,14 @@ enum Engine {
     /// Metals — curated structurally-similar pairs, lab pipeline (structural gates relaxed).
     Metals,
     /// Basket spread strategy — OU/Bertram symmetric state machine.
-    /// Defaults to `config/basket_universe_v1.toml`; override with `--universe`.
+    /// Defaults vary by command; override with `--universe`.
     #[default]
     Basket,
     // Future: Bitcoin, etc.
 }
 
 impl Engine {
-    /// Default basket universe TOML. `--universe` overrides.
+    /// Default basket universe TOML for replay/fits. `--universe` overrides.
     /// Only meaningful for `Basket`; pair engines ignore this.
     fn universe_path(&self) -> Option<&'static str> {
         match self {
@@ -114,6 +114,19 @@ impl Engine {
 
     fn is_basket(&self) -> bool {
         matches!(self, Engine::Basket)
+    }
+}
+
+fn default_stream_universe_path(engine: Engine, is_live_command: bool) -> Option<&'static str> {
+    match engine {
+        Engine::Snp500 | Engine::Metals => None,
+        Engine::Basket => {
+            if is_live_command {
+                Some("config/basket_universe_v1.toml")
+            } else {
+                Some("config/basket_universe_v2.toml")
+            }
+        }
     }
 }
 
@@ -144,7 +157,9 @@ struct StreamArgs {
     #[arg(long)]
     pipeline: Option<String>,
 
-    /// Basket universe TOML file. Defaults to `config/basket_universe_v1.toml` when --engine basket.
+    /// Basket universe TOML file. For basket paper, defaults to
+    /// `config/basket_universe_v2.toml`. For basket live/replay/fits, defaults
+    /// to `config/basket_universe_v1.toml`.
     #[arg(long)]
     universe: Option<PathBuf>,
 
@@ -282,7 +297,8 @@ struct ReplayArgs {
     #[arg(long)]
     bar_cache: Option<PathBuf>,
 
-    /// Basket universe TOML file. Defaults to `config/basket_universe_v1.toml` when --engine basket.
+    /// Basket universe TOML file. Defaults to `config/basket_universe_v1.toml`
+    /// when --engine basket.
     #[arg(long)]
     universe: Option<PathBuf>,
 
@@ -1034,7 +1050,7 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
     let universe_path = args
         .universe
         .clone()
-        .or_else(|| args.engine.universe_path().map(PathBuf::from))
+        .or_else(|| default_stream_universe_path(args.engine, is_live_command).map(PathBuf::from))
         .unwrap_or_else(|| {
             error!("--universe is required when --engine basket");
             std::process::exit(1);

--- a/engine/crates/runner/src/main.rs
+++ b/engine/crates/runner/src/main.rs
@@ -148,6 +148,11 @@ struct StreamArgs {
     #[arg(long)]
     universe: Option<PathBuf>,
 
+    /// Optional alternate basket universe TOML selected when the regime-switch
+    /// signal is ON at startup.
+    #[arg(long)]
+    alternate_universe: Option<PathBuf>,
+
     /// Directory containing per-symbol 1-min parquets. Required when --engine basket.
     /// Defaults to $QUANT_DATA_DIR if set, else `~/quant-data/bars/v3_sp500_2024-2026_1min_adjusted`.
     #[arg(long)]
@@ -167,6 +172,25 @@ struct StreamArgs {
     /// Frozen basket fit artifact. Defaults to `<universe>.fits.json`.
     #[arg(long)]
     fit_artifact: Option<PathBuf>,
+
+    /// Optional basket regime-switch symbol set used to decide whether to
+    /// launch the primary universe or `--alternate-universe`.
+    #[arg(long, value_delimiter = ',')]
+    regime_switch_symbols: Vec<String>,
+
+    /// Activate the alternate universe when the regime-switch basket's 5d
+    /// equal-weight return is at or above this threshold.
+    #[arg(long)]
+    regime_switch_ret5d_threshold: Option<f64>,
+
+    /// Activate the alternate universe when the regime-switch basket's breadth
+    /// fraction above SMA is at or above this threshold.
+    #[arg(long)]
+    regime_switch_breadth_threshold: Option<f64>,
+
+    /// Breadth lookback window in trading days for the regime-switch basket.
+    #[arg(long)]
+    regime_switch_sma_window: Option<usize>,
 
     /// Persisted basket engine state. Defaults to `<fit-artifact>.state.json`.
     #[arg(long)]
@@ -285,6 +309,11 @@ struct ReplayArgs {
     #[arg(long)]
     universe: Option<PathBuf>,
 
+    /// Optional alternate basket universe TOML selected when the regime-switch
+    /// signal is ON at startup.
+    #[arg(long)]
+    alternate_universe: Option<PathBuf>,
+
     /// Directory containing per-symbol 1-min parquets. Required when --engine basket.
     /// Defaults to $QUANT_DATA_DIR if set, else /Users/$USER/quant-data/bars/v3_sp500_2024-2026_1min_adjusted
     #[arg(long)]
@@ -332,6 +361,25 @@ struct ReplayArgs {
     /// to the given path after replay completes.
     #[arg(long)]
     report_tsv: Option<PathBuf>,
+
+    /// Optional basket regime-switch symbol set used to decide whether to
+    /// launch the primary universe or `--alternate-universe`.
+    #[arg(long, value_delimiter = ',')]
+    regime_switch_symbols: Vec<String>,
+
+    /// Activate the alternate universe when the regime-switch basket's 5d
+    /// equal-weight return is at or above this threshold.
+    #[arg(long)]
+    regime_switch_ret5d_threshold: Option<f64>,
+
+    /// Activate the alternate universe when the regime-switch basket's breadth
+    /// fraction above SMA is at or above this threshold.
+    #[arg(long)]
+    regime_switch_breadth_threshold: Option<f64>,
+
+    /// Breadth lookback window in trading days for the regime-switch basket.
+    #[arg(long)]
+    regime_switch_sma_window: Option<usize>,
 
     /// Ignore leadership overlay defaults from the universe TOML for this run.
     #[arg(long, default_value_t = false)]
@@ -481,6 +529,23 @@ struct LeadershipOverlayBuildArgs<'a> {
     long_only_leverage: f64,
 }
 
+struct UniverseSwitchArgs<'a> {
+    primary_universe_path: &'a Path,
+    alternate_universe_path: Option<&'a Path>,
+    regime_switch_symbols: &'a [String],
+    regime_switch_ret5d_threshold: Option<f64>,
+    regime_switch_breadth_threshold: Option<f64>,
+    regime_switch_sma_window: Option<usize>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RegimeSignalMetrics {
+    ret5d: f64,
+    breadth: f64,
+    ret_symbol_count: usize,
+    breadth_symbol_count: usize,
+}
+
 fn resolve_stream_execution(
     requested: Option<&str>,
     is_live_command: bool,
@@ -519,8 +584,8 @@ fn rule_v1_picker_config_from_universe(
         recovered_return_threshold: cfg.recovered_return_threshold,
         recovered_drawdown_threshold: cfg.recovered_drawdown_threshold,
         sleeve_return_ceiling: cfg.sleeve_return_ceiling,
-        min_baseline_scale_for_sleeve: cfg.min_baseline_scale_for_sleeve,
-        opportunistic_sleeve_min_baseline_scale: cfg.opportunistic_sleeve_min_baseline_scale,
+        min_basket_only_scale_for_sleeve: cfg.min_basket_only_scale_for_sleeve,
+        opportunistic_sleeve_min_basket_only_scale: cfg.opportunistic_sleeve_min_basket_only_scale,
         opportunistic_sleeve_return_ceiling: cfg.opportunistic_sleeve_return_ceiling,
         halve_sleeve_drawdown_threshold: cfg.halve_sleeve_drawdown_threshold,
         quarter_sleeve_drawdown_threshold: cfg.quarter_sleeve_drawdown_threshold,
@@ -593,7 +658,7 @@ fn resolve_basket_runtime(
         };
         let mode = overrides.leadership_mode.or_else(|| {
             overlay_defaults.and_then(|cfg| match cfg.mode {
-                UniverseLeadershipOverlayModeConfig::Baseline => None,
+                UniverseLeadershipOverlayModeConfig::BasketOnly => None,
                 UniverseLeadershipOverlayModeConfig::SuppressShorts => {
                     Some(LeadershipModeArg::SuppressShorts)
                 }
@@ -754,14 +819,169 @@ fn build_leadership_overlay_config(
                     basket_overlay_picker::BasketOverlayMode::AddCappedLongSleeve
                 }
             })
-            .unwrap_or(basket_overlay_picker::BasketOverlayMode::Baseline),
+            .unwrap_or(basket_overlay_picker::BasketOverlayMode::BasketOnly),
         long_only_leverage: args.long_only_leverage,
+    })
+}
+
+fn maybe_resolve_regime_switch_universe(
+    bars_dir: &Path,
+    as_of: chrono::NaiveDate,
+    args: UniverseSwitchArgs<'_>,
+) -> PathBuf {
+    let primary = args.primary_universe_path.to_path_buf();
+    let Some(alternate) = args.alternate_universe_path else {
+        return primary;
+    };
+
+    let has_switch_overrides = !args.regime_switch_symbols.is_empty()
+        || args.regime_switch_ret5d_threshold.is_some()
+        || args.regime_switch_breadth_threshold.is_some()
+        || args.regime_switch_sma_window.is_some();
+    if !has_switch_overrides {
+        return primary;
+    }
+
+    if args.regime_switch_symbols.is_empty()
+        || args.regime_switch_ret5d_threshold.is_none()
+        || args.regime_switch_breadth_threshold.is_none()
+    {
+        error!(
+            "regime switch requires --alternate-universe, --regime-switch-symbols, --regime-switch-ret5d-threshold, and --regime-switch-breadth-threshold"
+        );
+        std::process::exit(2);
+    }
+
+    let ret5d_threshold = args.regime_switch_ret5d_threshold.unwrap();
+    let breadth_threshold = args.regime_switch_breadth_threshold.unwrap();
+    let sma_window = args.regime_switch_sma_window.unwrap_or(20);
+    if !ret5d_threshold.is_finite() {
+        error!("regime-switch ret5d threshold must be finite");
+        std::process::exit(2);
+    }
+    if !breadth_threshold.is_finite() || !(0.0..=1.0).contains(&breadth_threshold) {
+        error!("regime-switch breadth threshold must be finite and in [0, 1]");
+        std::process::exit(2);
+    }
+    if sma_window == 0 {
+        error!("regime-switch SMA window must be > 0");
+        std::process::exit(2);
+    }
+
+    let switch_window_days = (sma_window.max(20) + 10) as i64;
+    let closes = match crate::basket_live::load_warmup_closes_as_of(
+        bars_dir,
+        args.regime_switch_symbols,
+        switch_window_days,
+        as_of,
+    ) {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(
+                error = %e,
+                universe = %primary.display(),
+                alternate_universe = %alternate.display(),
+                "regime-switch warmup load failed — staying on primary universe"
+            );
+            return primary;
+        }
+    };
+
+    let Some(metrics) = compute_regime_signal_metrics(
+        &closes,
+        args.regime_switch_symbols,
+        sma_window,
+    ) else {
+        warn!(
+            symbols = args.regime_switch_symbols.len(),
+            universe = %primary.display(),
+            alternate_universe = %alternate.display(),
+            "regime-switch signal had insufficient history — staying on primary universe"
+        );
+        return primary;
+    };
+
+    let switch_on = metrics.ret5d >= ret5d_threshold && metrics.breadth >= breadth_threshold;
+    info!(
+        as_of = %as_of,
+        primary_universe = %primary.display(),
+        alternate_universe = %alternate.display(),
+        switch_symbols = ?args.regime_switch_symbols,
+        ret5d = %format!("{:+.4}", metrics.ret5d),
+        breadth = %format!("{:.4}", metrics.breadth),
+        ret_symbol_count = metrics.ret_symbol_count,
+        breadth_symbol_count = metrics.breadth_symbol_count,
+        ret5d_threshold = %format!("{:+.4}", ret5d_threshold),
+        breadth_threshold = %format!("{:.4}", breadth_threshold),
+        sma_window,
+        switch_on,
+        "basket regime-switch evaluated"
+    );
+
+    if switch_on {
+        alternate.to_path_buf()
+    } else {
+        primary
+    }
+}
+
+fn compute_regime_signal_metrics(
+    closes: &std::collections::HashMap<String, Vec<(chrono::NaiveDate, f64)>>,
+    switch_symbols: &[String],
+    sma_window: usize,
+) -> Option<RegimeSignalMetrics> {
+    if sma_window == 0 {
+        return None;
+    }
+
+    let mut ret_sum = 0.0;
+    let mut ret_count = 0usize;
+    let mut breadth_count = 0usize;
+    let mut breadth_above = 0usize;
+
+    for symbol in switch_symbols {
+        let Some(series) = closes.get(symbol) else {
+            continue;
+        };
+        if series.len() >= 6 {
+            let last = series.last().map(|(_, px)| *px).unwrap_or(0.0);
+            let base = series[series.len() - 6].1;
+            if last.is_finite() && base.is_finite() && last > 0.0 && base > 0.0 {
+                ret_sum += last / base - 1.0;
+                ret_count += 1;
+            }
+        }
+        if series.len() >= sma_window {
+            let last = series.last().map(|(_, px)| *px).unwrap_or(0.0);
+            let sma = series[series.len() - sma_window..]
+                .iter()
+                .map(|(_, px)| *px)
+                .sum::<f64>()
+                / sma_window as f64;
+            if last.is_finite() && sma.is_finite() && last > 0.0 && sma > 0.0 {
+                breadth_count += 1;
+                if last > sma {
+                    breadth_above += 1;
+                }
+            }
+        }
+    }
+
+    if ret_count == 0 || breadth_count == 0 {
+        return None;
+    }
+
+    Some(RegimeSignalMetrics {
+        ret5d: ret_sum / ret_count as f64,
+        breadth: breadth_above as f64 / breadth_count as f64,
+        ret_symbol_count: ret_count,
+        breadth_symbol_count: breadth_count,
     })
 }
 
 fn leadership_overlay_fingerprint(cfg: &basket_live::LeadershipOverlayConfig) -> String {
     let mode = match cfg.mode {
-        basket_overlay_picker::BasketOverlayMode::Baseline => "baseline",
+        basket_overlay_picker::BasketOverlayMode::BasketOnly => "basket_only",
         basket_overlay_picker::BasketOverlayMode::SuppressShorts => "suppress",
         basket_overlay_picker::BasketOverlayMode::ReplaceWithLongOnly => "replace",
         basket_overlay_picker::BasketOverlayMode::AddCappedLongSleeve => "sleeve",
@@ -1027,7 +1247,7 @@ async fn main() {
 // ── Basket live/paper dispatch ──────────────────────────────────────
 
 async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
-    let universe_path = args
+    let requested_universe_path = args
         .universe
         .clone()
         .or_else(|| args.engine.universe_path().map(PathBuf::from))
@@ -1044,6 +1264,18 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
                 PathBuf::from(home).join("quant-data/bars/v3_sp500_2024-2026_1min_adjusted")
             })
     });
+    let universe_path = maybe_resolve_regime_switch_universe(
+        &bars_dir,
+        chrono::Utc::now().date_naive(),
+        UniverseSwitchArgs {
+            primary_universe_path: &requested_universe_path,
+            alternate_universe_path: args.alternate_universe.as_deref(),
+            regime_switch_symbols: &args.regime_switch_symbols,
+            regime_switch_ret5d_threshold: args.regime_switch_ret5d_threshold,
+            regime_switch_breadth_threshold: args.regime_switch_breadth_threshold,
+            regime_switch_sma_window: args.regime_switch_sma_window,
+        },
+    );
     let fit_artifact_path = args
         .fit_artifact
         .clone()
@@ -1880,7 +2112,7 @@ fn log_intent(intent: &openquant_core::pairs::PairOrderIntent, side: &str) {
 // entirely at the call site.
 
 async fn run_basket_replay_live_path(args: ReplayArgs) {
-    let universe_path = args
+    let requested_universe_path = args
         .universe
         .clone()
         .or_else(|| args.engine.universe_path().map(PathBuf::from))
@@ -1898,6 +2130,34 @@ async fn run_basket_replay_live_path(args: ReplayArgs) {
             })
     });
 
+    // Parse start/end.
+    let parse_date = |s: &str, name: &str| match chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
+        Ok(d) => d,
+        Err(e) => {
+            error!(error = %e, value = %s, "invalid --{name} date (expected YYYY-MM-DD)");
+            std::process::exit(1);
+        }
+    };
+    let start = parse_date(&args.start, "start");
+    let end = parse_date(&args.end, "end");
+    if end < start {
+        error!(start = %start, end = %end, "--end must be on or after --start");
+        std::process::exit(1);
+    }
+
+    let universe_path = maybe_resolve_regime_switch_universe(
+        &bars_dir,
+        start,
+        UniverseSwitchArgs {
+            primary_universe_path: &requested_universe_path,
+            alternate_universe_path: args.alternate_universe.as_deref(),
+            regime_switch_symbols: &args.regime_switch_symbols,
+            regime_switch_ret5d_threshold: args.regime_switch_ret5d_threshold,
+            regime_switch_breadth_threshold: args.regime_switch_breadth_threshold,
+            regime_switch_sma_window: args.regime_switch_sma_window,
+        },
+    );
+
     // Replay state isolation: never touch the live default state path.
     let state_path = args.state_path.clone().unwrap_or_else(|| {
         let stem = universe_path
@@ -1908,10 +2168,6 @@ async fn run_basket_replay_live_path(args: ReplayArgs) {
             .join("replay")
             .join(format!("{stem}.state.json"))
     });
-    // `BasketEngine::save_state_with_day` calls `fs::write(path, ...)`
-    // which fails if the parent directory does not exist. Ensure it
-    // does up front so the first session-close persistence in a clean
-    // checkout doesn't blow up mid-replay (#302 review finding).
     if let Some(parent) = state_path.parent() {
         if let Err(e) = std::fs::create_dir_all(parent) {
             error!(
@@ -1923,12 +2179,6 @@ async fn run_basket_replay_live_path(args: ReplayArgs) {
         }
     }
 
-    // Replay freshness contract: by default, every replay run starts
-    // from empty engine + simulated broker state, regardless of whether
-    // a prior replay's snapshot exists at `state_path`. This makes
-    // replay results deterministic across re-runs. To resume from a
-    // snapshot (e.g., for debugging mid-replay state), pass
-    // `--resume-state`.
     if !args.resume_state {
         for path in [
             state_path.clone(),
@@ -1951,21 +2201,6 @@ async fn run_basket_replay_live_path(args: ReplayArgs) {
                 std::process::exit(1);
             }
         }
-    }
-
-    // Parse start/end.
-    let parse_date = |s: &str, name: &str| match chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
-        Ok(d) => d,
-        Err(e) => {
-            error!(error = %e, value = %s, "invalid --{name} date (expected YYYY-MM-DD)");
-            std::process::exit(1);
-        }
-    };
-    let start = parse_date(&args.start, "start");
-    let end = parse_date(&args.end, "end");
-    if end < start {
-        error!(start = %start, end = %end, "--end must be on or after --start");
-        std::process::exit(1);
     }
 
     let universe = match basket_picker::load_universe(&universe_path) {
@@ -2214,6 +2449,8 @@ fn cleanup_old_engine_logs(journal_dir: &Path, retention_days: u64) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::NaiveDate;
+    use std::collections::HashMap;
 
     #[test]
     fn stream_state_defaults_under_data_state() {
@@ -2237,5 +2474,48 @@ mod tests {
             path,
             PathBuf::from("data/state/basket_universe_v1.fits.state.leadership-rule-v1.json")
         );
+    }
+
+    #[test]
+    fn compute_regime_signal_metrics_turns_on_for_strong_breadth_and_return() {
+        let mut closes: HashMap<String, Vec<(NaiveDate, f64)>> = HashMap::new();
+        let mk = |vals: &[f64]| {
+            vals.iter()
+                .enumerate()
+                .map(|(i, v)| {
+                    (
+                        NaiveDate::from_ymd_opt(2026, 1, 1).unwrap()
+                            + chrono::Days::new(i as u64),
+                        *v,
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+        closes.insert("A".to_string(), mk(&[
+            100.0, 101.0, 102.0, 103.0, 104.0, 110.0, 111.0, 112.0, 113.0, 114.0,
+            115.0, 116.0, 117.0, 118.0, 119.0, 120.0, 121.0, 122.0, 123.0, 124.0,
+            125.0,
+        ]));
+        closes.insert("B".to_string(), mk(&[
+            50.0, 50.5, 51.0, 51.5, 52.0, 55.0, 55.5, 56.0, 56.5, 57.0, 57.5, 58.0,
+            58.5, 59.0, 59.5, 60.0, 60.5, 61.0, 61.5, 62.0, 62.5,
+        ]));
+        let symbols = vec!["A".to_string(), "B".to_string()];
+        let metrics = compute_regime_signal_metrics(&closes, &symbols, 20).unwrap();
+        assert!(metrics.ret5d > 0.02);
+        assert_eq!(metrics.breadth, 1.0);
+    }
+
+    #[test]
+    fn compute_regime_signal_metrics_returns_none_without_enough_history() {
+        let closes: HashMap<String, Vec<(NaiveDate, f64)>> = HashMap::from([(
+            "A".to_string(),
+            vec![
+                (NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(), 100.0),
+                (NaiveDate::from_ymd_opt(2026, 1, 2).unwrap(), 101.0),
+            ],
+        )]);
+        let symbols = vec!["A".to_string()];
+        assert!(compute_regime_signal_metrics(&closes, &symbols, 20).is_none());
     }
 }

--- a/scripts/analyze_basket_drawdown.py
+++ b/scripts/analyze_basket_drawdown.py
@@ -54,7 +54,10 @@ def parse_log(log_path: Path) -> dict[str, object]:
                 sectors = SECTOR_RE.search(line)
                 if sectors:
                     sectors_by_date[date] = sectors.group(1).replace('"', "")
-        if "leadership overlay transformed baseline basket portfolio" in line:
+        if (
+            "leadership overlay transformed baseline basket portfolio" in line
+            or "leadership overlay transformed basket-only basket portfolio" in line
+        ):
             m = FAILED_RE.search(line)
             if m and m.group("date") not in replacement_lines_by_date:
                 replacement_lines_by_date[m.group("date")] = line

--- a/scripts/query_basket_journal.sh
+++ b/scripts/query_basket_journal.sh
@@ -14,6 +14,18 @@ if [[ -z "$db" || ! -f "$db" ]]; then
   exit 1
 fi
 
+picker_scale_expr() {
+  local cols
+  cols="$(sqlite3 "$db" "PRAGMA table_info(basket_picker_decisions);" | cut -d'|' -f2)"
+  if grep -qx 'basket_only_scale_if_sleeve' <<<"$cols"; then
+    printf '%s' 'ROUND(basket_only_scale_if_sleeve, 4) AS basket_only_scale'
+  elif grep -qx 'baseline_scale_if_sleeve' <<<"$cols"; then
+    printf '%s' 'ROUND(baseline_scale_if_sleeve, 4) AS basket_only_scale'
+  else
+    printf '%s' 'NULL AS basket_only_scale'
+  fi
+}
+
 case "$view" in
   summary)
     sqlite3 -header -column "$db" "
@@ -59,13 +71,14 @@ case "$view" in
     "
     ;;
   picker)
+    scale_expr="$(picker_scale_expr)"
     sqlite3 -header -column "$db" "
       SELECT trading_day, picker_id, mode, reason,
              active_sectors_json, active_symbols_json,
              ROUND(leadership_short_conflict_ratio, 4) AS short_conflict,
              ROUND(strategy_return_20d, 4) AS ret20d,
              ROUND(strategy_drawdown_20d, 4) AS dd20d,
-             ROUND(baseline_scale_if_sleeve, 4) AS baseline_scale,
+             $scale_expr,
              ROUND(sleeve_leverage_scale, 4) AS sleeve_scale,
              created_at_utc
         FROM basket_picker_decisions

--- a/scripts/run_basket_overlay_benchmark.py
+++ b/scripts/run_basket_overlay_benchmark.py
@@ -52,7 +52,7 @@ WINDOWS = [
 ]
 
 VARIANTS = [
-    Variant("baseline", ("--disable-leadership-overlay",)),
+    Variant("basket_only", ("--disable-leadership-overlay",)),
     Variant(
         "fixed_suppress",
         (
@@ -137,16 +137,16 @@ def main() -> int:
             )
 
     print(
-        "\nwindow\tbaseline\tfixed_suppress\tfixed_sleeve\t"
+        "\nwindow\tbasket_only\tfixed_suppress\tfixed_sleeve\t"
         "rule_v1\tbest_fixed\trule_vs_best_fixed"
     )
     for window in WINDOWS:
-        baseline = results[(window.name, "baseline")]
+        basket_only = results[(window.name, "basket_only")]
         suppress = results[(window.name, "fixed_suppress")]
         sleeve = results[(window.name, "fixed_sleeve")]
         rule = results[(window.name, "rule_v1")]
         fixed = {
-            "baseline": baseline,
+            "basket_only": basket_only,
             "fixed_suppress": suppress,
             "fixed_sleeve": sleeve,
         }
@@ -155,7 +155,7 @@ def main() -> int:
             "\t".join(
                 [
                     window.name,
-                    f"{fmt_pct(baseline.cum_return)} / DD {fmt_dd(baseline.max_dd)}",
+                    f"{fmt_pct(basket_only.cum_return)} / DD {fmt_dd(basket_only.max_dd)}",
                     f"{fmt_pct(suppress.cum_return)} / DD {fmt_dd(suppress.max_dd)}",
                     f"{fmt_pct(sleeve.cum_return)} / DD {fmt_dd(sleeve.max_dd)}",
                     f"{fmt_pct(rule.cum_return)} / DD {fmt_dd(rule.max_dd)}",

--- a/scripts/run_basket_replay_quiet.sh
+++ b/scripts/run_basket_replay_quiet.sh
@@ -7,7 +7,7 @@ Usage:
   scripts/run_basket_replay_quiet.sh <name> <start> <end> [extra replay args...]
 
 Example:
-  scripts/run_basket_replay_quiet.sh 2026_ytd_baseline 2026-01-02 2026-04-30
+  scripts/run_basket_replay_quiet.sh 2026_ytd_basket_only 2026-01-02 2026-04-30
 
   scripts/run_basket_replay_quiet.sh 2026_ytd_classifier 2026-01-02 2026-04-30 \
     --leadership-overlay-sectors faang,chips \


### PR DESCRIPTION
## Summary
- promote basket paper trading to use the v2 basket universe by default
- rename the neutral overlay mode from `baseline` to `basket_only`
- add a regime overlay playbook and clean related docs/scripts
- keep replay/live defaulting to v1 while paper runs move to v2

## Validation
- cargo build -p openquant-runner
- cargo test -p openquant-runner
- python3 -m py_compile scripts/run_basket_overlay_benchmark.py
