### PR TITLE
basket: add v1 gated entry-exit policy

### DIFF
--- a/engine/crates/basket-engine/src/engine.rs
+++ b/engine/crates/basket-engine/src/engine.rs
@@ -9,7 +9,8 @@ use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, trace, warn};
 
-use crate::intent::{PositionIntent, TransitionReason};
+use crate::gates::{evaluate_gate, GatePolicyKind};
+use crate::intent::PositionIntent;
 use crate::state::BasketState;
 use crate::DailyBar;
 
@@ -55,6 +56,9 @@ pub struct EngineSnapshot {
     pub params: Vec<BasketParams>,
     /// Per-basket runtime state.
     pub states: HashMap<String, BasketState>,
+    /// Signal / transition policy used to produce the persisted state.
+    #[serde(default)]
+    pub gate_policy: GatePolicyKind,
     /// Last trading day that the runner fully processed. Optional so older
     /// snapshots remain readable.
     #[serde(default)]
@@ -68,11 +72,17 @@ pub struct BasketEngine {
     params: HashMap<String, BasketParams>,
     /// Per-basket runtime state.
     states: HashMap<String, BasketState>,
+    /// Signal / transition policy.
+    gate_policy: GatePolicyKind,
 }
 
 impl BasketEngine {
     /// Create a new engine from validated basket fits.
     pub fn new(fits: &[BasketFit]) -> Self {
+        Self::with_gate_policy(fits, GatePolicyKind::BertramFrozen)
+    }
+
+    pub fn with_gate_policy(fits: &[BasketFit], gate_policy: GatePolicyKind) -> Self {
         let mut params = HashMap::new();
         let mut states = HashMap::new();
 
@@ -84,7 +94,11 @@ impl BasketEngine {
             }
         }
 
-        Self { params, states }
+        Self {
+            params,
+            states,
+            gate_policy,
+        }
     }
 
     /// Get the number of active baskets.
@@ -96,6 +110,19 @@ impl BasketEngine {
     ///
     /// All bars must have the same date. Returns empty if bars have mixed dates.
     pub fn on_bars(&mut self, bars: &[DailyBar]) -> Vec<PositionIntent> {
+        self.on_bars_with_transition_mode(bars, true)
+    }
+
+    /// Warm signal state from historical bars without generating entries/exits.
+    pub fn warm_on_bars(&mut self, bars: &[DailyBar]) {
+        let _ = self.on_bars_with_transition_mode(bars, false);
+    }
+
+    fn on_bars_with_transition_mode(
+        &mut self,
+        bars: &[DailyBar],
+        apply_transitions: bool,
+    ) -> Vec<PositionIntent> {
         if bars.is_empty() {
             return vec![];
         }
@@ -194,7 +221,6 @@ impl BasketEngine {
 
             // Compute spread = log(target) - mean(log(peers))
             let spread = target_price.ln() - peer_log_sum / peer_count as f64;
-            state.record_spread(spread);
 
             // Compute z-score using frozen OU parameters
             let z = (spread - params.ou.mu) / params.ou.sigma_eq;
@@ -215,13 +241,17 @@ impl BasketEngine {
             }
 
             evaluated += 1;
-            let k = params.threshold_k;
             let old_pos = state.position;
+            let evaluation = evaluate_gate(&self.gate_policy, state, params, spread, z);
+            state.last_signal_score = evaluation.signal_score;
+            state.record_spread(spread);
+            let signal_score = evaluation.signal_score.unwrap_or(z);
+            let entry_threshold = evaluation.entry_threshold;
 
             // Near-threshold counter — any basket with |z| > 0.75k is "close
             // to firing." Tracking this gives us a pulse on whether the
             // strategy is actually seeing opportunity vs. sitting flat.
-            if z.abs() > 0.75 * k {
+            if signal_score.abs() > 0.75 * entry_threshold {
                 near_threshold += 1;
             }
 
@@ -233,7 +263,9 @@ impl BasketEngine {
                 peer_count,
                 spread = %format!("{:.6}", spread),
                 z = %format!("{:.4}", z),
-                threshold_k = k,
+                signal_score = %format!("{:.4}", signal_score),
+                threshold_k = entry_threshold,
+                exit_threshold = ?evaluation.exit_threshold.map(|v| format!("{v:.4}")),
                 position = old_pos,
                 date = %date,
                 "basket evaluation"
@@ -243,70 +275,54 @@ impl BasketEngine {
             debug!(
                 basket_id = %basket_id,
                 z = %format!("{:.4}", z),
-                k = %format!("{:.4}", k),
+                signal_score = %format!("{:.4}", signal_score),
+                k = %format!("{:.4}", entry_threshold),
                 pos = old_pos,
                 "basket z-check"
             );
-
-            // Bertram symmetric state machine
-            let (new_pos, reason) = match old_pos {
-                0 => {
-                    // Flat: enter on threshold breach
-                    if z < -k {
-                        (1, Some(TransitionReason::InitialEntryLong))
-                    } else if z > k {
-                        (-1, Some(TransitionReason::InitialEntryShort))
-                    } else {
-                        (0, None)
-                    }
-                }
-                1 => {
-                    // Long: flip to short when z > k
-                    if z > k {
-                        (-1, Some(TransitionReason::FlipLongToShort))
-                    } else {
-                        (1, None)
-                    }
-                }
-                -1 => {
-                    // Short: flip to long when z < -k
-                    if z < -k {
-                        (1, Some(TransitionReason::FlipShortToLong))
-                    } else {
-                        (-1, None)
-                    }
-                }
-                _ => (old_pos, None),
-            };
+            let new_pos = evaluation.next_position;
+            let reason = evaluation.reason;
 
             // Apply state transition if any
-            if let Some(reason) = reason {
-                if old_pos == 0 {
-                    state.enter(new_pos, date, spread);
-                } else {
-                    state.flip(date, spread);
+            if apply_transitions {
+                if let Some(reason) = reason {
+                    if new_pos == 0 {
+                        state.flatten();
+                    } else if old_pos == 0 {
+                        state.enter(new_pos, date, spread);
+                    } else {
+                        state.flip(date, spread);
+                    }
+
+                    transitioned += 1;
+
+                    info!(
+                        basket_id = %basket_id,
+                        z_score = %format!("{:.4}", z),
+                        signal_score = %format!("{:.4}", signal_score),
+                        old_pos = old_pos,
+                        new_pos = new_pos,
+                        spread = %format!("{:.6}", spread),
+                        reason = %reason.as_str(),
+                        "position_transition"
+                    );
+
+                    intents.push(PositionIntent::new(
+                        basket_id.clone(),
+                        new_pos,
+                        reason,
+                        signal_score,
+                        spread,
+                        date,
+                    ));
                 }
-
-                transitioned += 1;
-
-                info!(
+            } else if reason.is_some() {
+                debug!(
                     basket_id = %basket_id,
-                    z_score = %format!("{:.4}", z),
-                    old_pos = old_pos,
-                    new_pos = new_pos,
-                    spread = %format!("{:.6}", spread),
-                    reason = %reason.as_str(),
-                    "position_transition"
+                    signal_score = %format!("{:.4}", signal_score),
+                    date = %date,
+                    "warmup suppressed a transition candidate"
                 );
-
-                intents.push(PositionIntent::new(
-                    basket_id.clone(),
-                    new_pos,
-                    reason,
-                    z,
-                    spread,
-                    date,
-                ));
             }
         }
 
@@ -324,6 +340,7 @@ impl BasketEngine {
             near_threshold,
             transitioned,
             intents_emitted = intents.len(),
+            apply_transitions,
             "on_bars summary"
         );
 
@@ -344,6 +361,7 @@ impl BasketEngine {
         let snapshot = EngineSnapshot {
             params: self.params.values().cloned().collect(),
             states: self.states.clone(),
+            gate_policy: self.gate_policy.clone(),
             last_processed_trading_day,
         };
         let json = serde_json::to_string_pretty(&snapshot)
@@ -375,6 +393,7 @@ impl BasketEngine {
         Ok(Self {
             params,
             states: snapshot.states,
+            gate_policy: snapshot.gate_policy,
         })
     }
 
@@ -383,6 +402,7 @@ impl BasketEngine {
         let snapshot = EngineSnapshot {
             params: self.params.values().cloned().collect(),
             states,
+            gate_policy: self.gate_policy.clone(),
             last_processed_trading_day: None,
         };
         Self::validate_snapshot(&snapshot)?;
@@ -405,6 +425,10 @@ impl BasketEngine {
         self.params.iter()
     }
 
+    pub fn gate_policy(&self) -> &GatePolicyKind {
+        &self.gate_policy
+    }
+
     /// Flatten a set of baskets so portfolio admission and engine state stay aligned.
     pub fn flatten_baskets(&mut self, basket_ids: &[String]) {
         for basket_id in basket_ids {
@@ -415,6 +439,7 @@ impl BasketEngine {
     }
 
     fn validate_snapshot(snapshot: &EngineSnapshot) -> Result<(), String> {
+        snapshot.gate_policy.validate()?;
         let mut params = HashMap::new();
         for p in &snapshot.params {
             params.insert(p.basket_id.clone(), p);
@@ -438,6 +463,7 @@ impl BasketEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::TransitionReason;
     use basket_picker::{BasketCandidate, BertramResult};
     use chrono::NaiveDate;
 

--- a/engine/crates/basket-engine/src/gates/mod.rs
+++ b/engine/crates/basket-engine/src/gates/mod.rs
@@ -4,16 +4,11 @@ use crate::engine::BasketParams;
 use crate::intent::TransitionReason;
 use crate::state::{BasketState, MAX_SPREAD_HISTORY};
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub enum GatePolicyKind {
+    #[default]
     BertramFrozen,
     RollingSScoreV1(RollingSScoreV1Config),
-}
-
-impl Default for GatePolicyKind {
-    fn default() -> Self {
-        Self::BertramFrozen
-    }
 }
 
 impl GatePolicyKind {

--- a/engine/crates/basket-engine/src/gates/mod.rs
+++ b/engine/crates/basket-engine/src/gates/mod.rs
@@ -48,6 +48,13 @@ impl GatePolicyKind {
                         "rolling_s_score_v1 min_history must be in [1, lookback]".to_string()
                     );
                 }
+                if config.entry_confirmation_bars == 0
+                    || config.entry_confirmation_bars > MAX_SPREAD_HISTORY
+                {
+                    return Err(format!(
+                        "rolling_s_score_v1 entry_confirmation_bars must be in [1, {MAX_SPREAD_HISTORY}]"
+                    ));
+                }
                 if !config.exit_threshold.is_finite() || config.exit_threshold < 0.0 {
                     return Err(
                         "rolling_s_score_v1 exit_threshold must be finite and non-negative"
@@ -67,6 +74,7 @@ pub struct RollingSScoreV1Config {
     pub exit_threshold: f64,
     pub direct_flip: bool,
     pub entry_mode: RollingEntryMode,
+    pub entry_confirmation_bars: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -83,6 +91,7 @@ impl Default for RollingSScoreV1Config {
             exit_threshold: 0.5,
             direct_flip: true,
             entry_mode: RollingEntryMode::RollingScore,
+            entry_confirmation_bars: 1,
         }
     }
 }
@@ -117,6 +126,72 @@ pub struct RollingSScoreV1Policy {
 impl RollingSScoreV1Policy {
     pub fn new(config: RollingSScoreV1Config) -> Self {
         Self { config }
+    }
+
+    fn compute_recent_entry_scores(
+        &self,
+        state: &BasketState,
+        params: &BasketParams,
+        current_spread: f64,
+    ) -> Vec<f64> {
+        let mut spreads: Vec<f64> = state.spread_history.iter().copied().collect();
+        spreads.push(current_spread);
+        let want = self.config.entry_confirmation_bars.max(1);
+        match self.config.entry_mode {
+            RollingEntryMode::RawZScore => spreads
+                .iter()
+                .rev()
+                .take(want)
+                .map(|spread| (spread - params.ou.mu) / params.ou.sigma_eq)
+                .collect::<Vec<_>>()
+                .into_iter()
+                .rev()
+                .collect(),
+            RollingEntryMode::RollingScore => {
+                let mut scores = Vec::new();
+                for idx in 0..spreads.len() {
+                    let start = idx.saturating_sub(self.config.lookback);
+                    let history = &spreads[start..idx];
+                    if history.len() < self.config.min_history {
+                        continue;
+                    }
+                    let mean = history.iter().sum::<f64>() / history.len() as f64;
+                    let variance = history
+                        .iter()
+                        .map(|v| {
+                            let d = *v - mean;
+                            d * d
+                        })
+                        .sum::<f64>()
+                        / history.len() as f64;
+                    let std_dev = variance.sqrt();
+                    if !std_dev.is_finite() || std_dev <= f64::EPSILON {
+                        continue;
+                    }
+                    scores.push((spreads[idx] - mean) / std_dev);
+                }
+                scores
+                    .into_iter()
+                    .rev()
+                    .take(want)
+                    .collect::<Vec<_>>()
+                    .into_iter()
+                    .rev()
+                    .collect()
+            }
+        }
+    }
+
+    fn entry_confirmation_passes(&self, scores: &[f64], threshold: f64, direction: i8) -> bool {
+        let need = self.config.entry_confirmation_bars.max(1);
+        if scores.len() < need {
+            return false;
+        }
+        match direction {
+            1 => scores.iter().all(|score| *score <= -threshold),
+            -1 => scores.iter().all(|score| *score >= threshold),
+            _ => false,
+        }
     }
 }
 
@@ -220,15 +295,18 @@ impl GatePolicy for RollingSScoreV1Policy {
             RollingEntryMode::RollingScore => s_score,
             RollingEntryMode::RawZScore => raw_z,
         };
+        let recent_entry_scores = self.compute_recent_entry_scores(state, params, spread);
+        let long_confirmed = self.entry_confirmation_passes(&recent_entry_scores, k, 1);
+        let short_confirmed = self.entry_confirmation_passes(&recent_entry_scores, k, -1);
         let (next_position, reason, signal_score) = match old_pos {
             0 => {
-                if entry_score <= -k {
+                if entry_score <= -k && long_confirmed {
                     (
                         1,
                         Some(TransitionReason::InitialEntryLong),
                         Some(entry_score),
                     )
-                } else if entry_score >= k {
+                } else if entry_score >= k && short_confirmed {
                     (
                         -1,
                         Some(TransitionReason::InitialEntryShort),
@@ -239,7 +317,7 @@ impl GatePolicy for RollingSScoreV1Policy {
                 }
             }
             1 => {
-                if self.config.direct_flip && entry_score >= k {
+                if self.config.direct_flip && entry_score >= k && short_confirmed {
                     (
                         -1,
                         Some(TransitionReason::FlipLongToShort),
@@ -252,7 +330,7 @@ impl GatePolicy for RollingSScoreV1Policy {
                 }
             }
             -1 => {
-                if self.config.direct_flip && entry_score <= -k {
+                if self.config.direct_flip && entry_score <= -k && long_confirmed {
                     (
                         1,
                         Some(TransitionReason::FlipShortToLong),
@@ -348,6 +426,7 @@ mod tests {
             exit_threshold: 0.5,
             direct_flip: true,
             entry_mode: RollingEntryMode::RollingScore,
+            entry_confirmation_bars: 1,
         };
         let mut state = BasketState::default();
         state.spread_history = (0..20).map(|i| i as f64 * 0.1).collect();
@@ -369,11 +448,36 @@ mod tests {
             exit_threshold: 0.5,
             direct_flip: true,
             entry_mode: RollingEntryMode::RawZScore,
+            entry_confirmation_bars: 1,
         };
         let mut state = BasketState::default();
         state.spread_history = (0..20).map(|i| i as f64 * 0.1).collect();
         let enter = RollingSScoreV1Policy::new(cfg).evaluate(&state, &params(), -2.0, -2.5);
         assert_eq!(enter.reason, Some(TransitionReason::InitialEntryLong));
         assert_eq!(enter.signal_score, Some(-2.5));
+    }
+
+    #[test]
+    fn rolling_policy_requires_consecutive_raw_z_confirmation_for_entry() {
+        let cfg = RollingSScoreV1Config {
+            lookback: 20,
+            min_history: 20,
+            exit_threshold: 0.5,
+            direct_flip: true,
+            entry_mode: RollingEntryMode::RawZScore,
+            entry_confirmation_bars: 2,
+        };
+        let mut state = BasketState::default();
+        state.spread_history = VecDeque::from(vec![
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.2, 0.1,
+        ]);
+        let blocked = RollingSScoreV1Policy::new(cfg).evaluate(&state, &params(), -2.0, -2.0);
+        assert_eq!(blocked.reason, None);
+
+        state.spread_history.pop_front();
+        state.spread_history.push_back(-2.0);
+        let allowed = RollingSScoreV1Policy::new(cfg).evaluate(&state, &params(), -2.1, -2.1);
+        assert_eq!(allowed.reason, Some(TransitionReason::InitialEntryLong));
     }
 }

--- a/engine/crates/basket-engine/src/gates/mod.rs
+++ b/engine/crates/basket-engine/src/gates/mod.rs
@@ -1,0 +1,340 @@
+use serde::{Deserialize, Serialize};
+
+use crate::engine::BasketParams;
+use crate::intent::TransitionReason;
+use crate::state::{BasketState, MAX_SPREAD_HISTORY};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum GatePolicyKind {
+    BertramFrozen,
+    RollingSScoreV1(RollingSScoreV1Config),
+}
+
+impl Default for GatePolicyKind {
+    fn default() -> Self {
+        Self::BertramFrozen
+    }
+}
+
+impl GatePolicyKind {
+    pub fn history_lookback(&self) -> Option<usize> {
+        match self {
+            Self::BertramFrozen => None,
+            Self::RollingSScoreV1(config) => Some(config.lookback),
+        }
+    }
+
+    pub fn signal_label(&self) -> &'static str {
+        match self {
+            Self::BertramFrozen => "z_score",
+            Self::RollingSScoreV1(_) => "s_score",
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), String> {
+        match self {
+            Self::BertramFrozen => Ok(()),
+            Self::RollingSScoreV1(config) => {
+                if config.lookback == 0 || config.lookback > MAX_SPREAD_HISTORY {
+                    return Err(format!(
+                        "rolling_s_score_v1 lookback must be in [1, {MAX_SPREAD_HISTORY}]"
+                    ));
+                }
+                if config.min_history == 0 || config.min_history > config.lookback {
+                    return Err(
+                        "rolling_s_score_v1 min_history must be in [1, lookback]".to_string(),
+                    );
+                }
+                if !config.exit_threshold.is_finite() || config.exit_threshold < 0.0 {
+                    return Err(
+                        "rolling_s_score_v1 exit_threshold must be finite and non-negative"
+                            .to_string(),
+                    );
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct RollingSScoreV1Config {
+    pub lookback: usize,
+    pub min_history: usize,
+    pub exit_threshold: f64,
+    pub direct_flip: bool,
+    pub entry_mode: RollingEntryMode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RollingEntryMode {
+    RollingScore,
+    RawZScore,
+}
+
+impl Default for RollingSScoreV1Config {
+    fn default() -> Self {
+        Self {
+            lookback: 20,
+            min_history: 20,
+            exit_threshold: 0.5,
+            direct_flip: true,
+            entry_mode: RollingEntryMode::RollingScore,
+        }
+    }
+}
+
+pub trait GatePolicy {
+    fn evaluate(
+        &self,
+        state: &BasketState,
+        params: &BasketParams,
+        spread: f64,
+        raw_z: f64,
+    ) -> GateEvaluation;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct GateEvaluation {
+    pub signal_score: Option<f64>,
+    pub entry_threshold: f64,
+    pub exit_threshold: Option<f64>,
+    pub next_position: i8,
+    pub reason: Option<TransitionReason>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BertramFrozenPolicy;
+
+#[derive(Debug, Clone, Copy)]
+pub struct RollingSScoreV1Policy {
+    config: RollingSScoreV1Config,
+}
+
+impl RollingSScoreV1Policy {
+    pub fn new(config: RollingSScoreV1Config) -> Self {
+        Self { config }
+    }
+}
+
+impl GatePolicy for BertramFrozenPolicy {
+    fn evaluate(
+        &self,
+        state: &BasketState,
+        params: &BasketParams,
+        _spread: f64,
+        raw_z: f64,
+    ) -> GateEvaluation {
+        let k = params.threshold_k;
+        let old_pos = state.position;
+        let (next_position, reason) = match old_pos {
+            0 => {
+                if raw_z < -k {
+                    (1, Some(TransitionReason::InitialEntryLong))
+                } else if raw_z > k {
+                    (-1, Some(TransitionReason::InitialEntryShort))
+                } else {
+                    (0, None)
+                }
+            }
+            1 => {
+                if raw_z > k {
+                    (-1, Some(TransitionReason::FlipLongToShort))
+                } else {
+                    (1, None)
+                }
+            }
+            -1 => {
+                if raw_z < -k {
+                    (1, Some(TransitionReason::FlipShortToLong))
+                } else {
+                    (-1, None)
+                }
+            }
+            _ => (old_pos, None),
+        };
+
+        GateEvaluation {
+            signal_score: Some(raw_z),
+            entry_threshold: k,
+            exit_threshold: None,
+            next_position,
+            reason,
+        }
+    }
+}
+
+impl GatePolicy for RollingSScoreV1Policy {
+    fn evaluate(
+        &self,
+        state: &BasketState,
+        params: &BasketParams,
+        spread: f64,
+        raw_z: f64,
+    ) -> GateEvaluation {
+        let history: Vec<f64> = state
+            .spread_history
+            .iter()
+            .rev()
+            .take(self.config.lookback)
+            .copied()
+            .collect();
+        if history.len() < self.config.min_history {
+            return GateEvaluation {
+                signal_score: None,
+                entry_threshold: params.threshold_k,
+                exit_threshold: Some(self.config.exit_threshold),
+                next_position: state.position,
+                reason: None,
+            };
+        }
+
+        let mean = history.iter().sum::<f64>() / history.len() as f64;
+        let variance = history
+            .iter()
+            .map(|v| {
+                let d = *v - mean;
+                d * d
+            })
+            .sum::<f64>()
+            / history.len() as f64;
+        let std_dev = variance.sqrt();
+        if !std_dev.is_finite() || std_dev <= f64::EPSILON {
+            return GateEvaluation {
+                signal_score: None,
+                entry_threshold: params.threshold_k,
+                exit_threshold: Some(self.config.exit_threshold),
+                next_position: state.position,
+                reason: None,
+            };
+        }
+
+        let s_score = (spread - mean) / std_dev;
+        let old_pos = state.position;
+        let k = params.threshold_k;
+        let exit = self.config.exit_threshold;
+        let entry_score = match self.config.entry_mode {
+            RollingEntryMode::RollingScore => s_score,
+            RollingEntryMode::RawZScore => raw_z,
+        };
+        let (next_position, reason) = match old_pos {
+            0 => {
+                if entry_score <= -k {
+                    (1, Some(TransitionReason::InitialEntryLong))
+                } else if entry_score >= k {
+                    (-1, Some(TransitionReason::InitialEntryShort))
+                } else {
+                    (0, None)
+                }
+            }
+            1 => {
+                if self.config.direct_flip && entry_score >= k {
+                    (-1, Some(TransitionReason::FlipLongToShort))
+                } else if s_score >= -exit {
+                    (0, Some(TransitionReason::ExitLong))
+                } else {
+                    (1, None)
+                }
+            }
+            -1 => {
+                if self.config.direct_flip && entry_score <= -k {
+                    (1, Some(TransitionReason::FlipShortToLong))
+                } else if s_score <= exit {
+                    (0, Some(TransitionReason::ExitShort))
+                } else {
+                    (-1, None)
+                }
+            }
+            _ => (old_pos, None),
+        };
+
+        GateEvaluation {
+            signal_score: Some(s_score),
+            entry_threshold: k,
+            exit_threshold: Some(exit),
+            next_position,
+            reason,
+        }
+    }
+}
+
+pub fn evaluate_gate(
+    policy: &GatePolicyKind,
+    state: &BasketState,
+    params: &BasketParams,
+    spread: f64,
+    raw_z: f64,
+) -> GateEvaluation {
+    match policy {
+        GatePolicyKind::BertramFrozen => BertramFrozenPolicy.evaluate(state, params, spread, raw_z),
+        GatePolicyKind::RollingSScoreV1(config) => {
+            RollingSScoreV1Policy::new(*config).evaluate(state, params, spread, raw_z)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use basket_picker::OuFit;
+    use std::collections::VecDeque;
+
+    fn params() -> BasketParams {
+        BasketParams {
+            basket_id: "test".to_string(),
+            target: "AAA".to_string(),
+            peers: vec!["BBB".to_string()],
+            ou: OuFit {
+                mu: 0.0,
+                sigma_eq: 1.0,
+                half_life_days: 5.0,
+                a: 0.0,
+                b: 0.0,
+                kappa: 0.1,
+                sigma: 1.0,
+            },
+            threshold_k: 1.25,
+        }
+    }
+
+    #[test]
+    fn bertram_policy_keeps_legacy_flip_behavior() {
+        let mut state = BasketState::default();
+        state.position = 1;
+        let out = BertramFrozenPolicy.evaluate(&state, &params(), 0.0, 2.0);
+        assert_eq!(out.reason, Some(TransitionReason::FlipLongToShort));
+        assert_eq!(out.next_position, -1);
+        assert_eq!(out.signal_score, Some(2.0));
+    }
+
+    #[test]
+    fn rolling_policy_waits_for_min_history() {
+        let mut state = BasketState::default();
+        state.spread_history = VecDeque::from(vec![0.0; 5]);
+        let out = RollingSScoreV1Policy::new(RollingSScoreV1Config::default())
+            .evaluate(&state, &params(), -3.0, -3.0);
+        assert_eq!(out.reason, None);
+        assert_eq!(out.signal_score, None);
+    }
+
+    #[test]
+    fn rolling_policy_enters_and_exits_using_bands() {
+        let cfg = RollingSScoreV1Config {
+            lookback: 20,
+            min_history: 20,
+            exit_threshold: 0.5,
+            direct_flip: true,
+            entry_mode: RollingEntryMode::RollingScore,
+        };
+        let mut state = BasketState::default();
+        state.spread_history = (0..20).map(|i| i as f64 * 0.1).collect();
+        let enter = RollingSScoreV1Policy::new(cfg).evaluate(&state, &params(), -2.0, -2.0);
+        assert_eq!(enter.reason, Some(TransitionReason::InitialEntryLong));
+        assert_eq!(enter.next_position, 1);
+
+        state.position = 1;
+        let exit = RollingSScoreV1Policy::new(cfg).evaluate(&state, &params(), 0.8, 0.8);
+        assert_eq!(exit.reason, Some(TransitionReason::ExitLong));
+        assert_eq!(exit.next_position, 0);
+    }
+}

--- a/engine/crates/basket-engine/src/gates/mod.rs
+++ b/engine/crates/basket-engine/src/gates/mod.rs
@@ -27,7 +27,10 @@ impl GatePolicyKind {
     pub fn signal_label(&self) -> &'static str {
         match self {
             Self::BertramFrozen => "z_score",
-            Self::RollingSScoreV1(_) => "s_score",
+            Self::RollingSScoreV1(config) => match config.entry_mode {
+                RollingEntryMode::RollingScore => "s_score",
+                RollingEntryMode::RawZScore => "z_score",
+            },
         }
     }
 
@@ -42,7 +45,7 @@ impl GatePolicyKind {
                 }
                 if config.min_history == 0 || config.min_history > config.lookback {
                     return Err(
-                        "rolling_s_score_v1 min_history must be in [1, lookback]".to_string(),
+                        "rolling_s_score_v1 min_history must be in [1, lookback]".to_string()
                     );
                 }
                 if !config.exit_threshold.is_finite() || config.exit_threshold < 0.0 {
@@ -217,39 +220,55 @@ impl GatePolicy for RollingSScoreV1Policy {
             RollingEntryMode::RollingScore => s_score,
             RollingEntryMode::RawZScore => raw_z,
         };
-        let (next_position, reason) = match old_pos {
+        let (next_position, reason, signal_score) = match old_pos {
             0 => {
                 if entry_score <= -k {
-                    (1, Some(TransitionReason::InitialEntryLong))
+                    (
+                        1,
+                        Some(TransitionReason::InitialEntryLong),
+                        Some(entry_score),
+                    )
                 } else if entry_score >= k {
-                    (-1, Some(TransitionReason::InitialEntryShort))
+                    (
+                        -1,
+                        Some(TransitionReason::InitialEntryShort),
+                        Some(entry_score),
+                    )
                 } else {
-                    (0, None)
+                    (0, None, Some(entry_score))
                 }
             }
             1 => {
                 if self.config.direct_flip && entry_score >= k {
-                    (-1, Some(TransitionReason::FlipLongToShort))
+                    (
+                        -1,
+                        Some(TransitionReason::FlipLongToShort),
+                        Some(entry_score),
+                    )
                 } else if s_score >= -exit {
-                    (0, Some(TransitionReason::ExitLong))
+                    (0, Some(TransitionReason::ExitLong), Some(s_score))
                 } else {
-                    (1, None)
+                    (1, None, Some(s_score))
                 }
             }
             -1 => {
                 if self.config.direct_flip && entry_score <= -k {
-                    (1, Some(TransitionReason::FlipShortToLong))
+                    (
+                        1,
+                        Some(TransitionReason::FlipShortToLong),
+                        Some(entry_score),
+                    )
                 } else if s_score <= exit {
-                    (0, Some(TransitionReason::ExitShort))
+                    (0, Some(TransitionReason::ExitShort), Some(s_score))
                 } else {
-                    (-1, None)
+                    (-1, None, Some(s_score))
                 }
             }
-            _ => (old_pos, None),
+            _ => (old_pos, None, None),
         };
 
         GateEvaluation {
-            signal_score: Some(s_score),
+            signal_score,
             entry_threshold: k,
             exit_threshold: Some(exit),
             next_position,
@@ -311,8 +330,12 @@ mod tests {
     fn rolling_policy_waits_for_min_history() {
         let mut state = BasketState::default();
         state.spread_history = VecDeque::from(vec![0.0; 5]);
-        let out = RollingSScoreV1Policy::new(RollingSScoreV1Config::default())
-            .evaluate(&state, &params(), -3.0, -3.0);
+        let out = RollingSScoreV1Policy::new(RollingSScoreV1Config::default()).evaluate(
+            &state,
+            &params(),
+            -3.0,
+            -3.0,
+        );
         assert_eq!(out.reason, None);
         assert_eq!(out.signal_score, None);
     }
@@ -336,5 +359,21 @@ mod tests {
         let exit = RollingSScoreV1Policy::new(cfg).evaluate(&state, &params(), 0.8, 0.8);
         assert_eq!(exit.reason, Some(TransitionReason::ExitLong));
         assert_eq!(exit.next_position, 0);
+    }
+
+    #[test]
+    fn rolling_policy_raw_z_entry_mode_reports_raw_z_on_entry() {
+        let cfg = RollingSScoreV1Config {
+            lookback: 20,
+            min_history: 20,
+            exit_threshold: 0.5,
+            direct_flip: true,
+            entry_mode: RollingEntryMode::RawZScore,
+        };
+        let mut state = BasketState::default();
+        state.spread_history = (0..20).map(|i| i as f64 * 0.1).collect();
+        let enter = RollingSScoreV1Policy::new(cfg).evaluate(&state, &params(), -2.0, -2.5);
+        assert_eq!(enter.reason, Some(TransitionReason::InitialEntryLong));
+        assert_eq!(enter.signal_score, Some(-2.5));
     }
 }

--- a/engine/crates/basket-engine/src/intent.rs
+++ b/engine/crates/basket-engine/src/intent.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 /// Reason for a position transition.
 ///
-/// Deliberately limited to exactly 4 valid transitions per Bertram symmetric.
+/// Deliberately limited to directional entries, exits, and flips.
 /// No stop-loss, time-exit, or de-risk variants.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TransitionReason {
@@ -16,6 +16,10 @@ pub enum TransitionReason {
     FlipLongToShort,
     /// Flip from short to long.
     FlipShortToLong,
+    /// Exit a long back to flat.
+    ExitLong,
+    /// Exit a short back to flat.
+    ExitShort,
 }
 
 impl TransitionReason {
@@ -26,6 +30,8 @@ impl TransitionReason {
             Self::InitialEntryShort => "initial_entry_short",
             Self::FlipLongToShort => "flip_long_to_short",
             Self::FlipShortToLong => "flip_short_to_long",
+            Self::ExitLong => "exit_long",
+            Self::ExitShort => "exit_short",
         }
     }
 }
@@ -35,12 +41,12 @@ impl TransitionReason {
 pub struct PositionIntent {
     /// Basket identifier (sector:target format).
     pub basket_id: String,
-    /// Target position: -1 (short), +1 (long). Never 0 after first entry.
+    /// Target position: -1 (short), 0 (flat), +1 (long).
     pub target_position: i8,
     /// Reason for this transition.
     pub reason: TransitionReason,
-    /// Z-score that triggered this transition.
-    pub z_score: f64,
+    /// Signal score that triggered this transition.
+    pub signal_score: f64,
     /// Spread value at transition.
     pub spread: f64,
     /// Date of the bar that triggered this transition.
@@ -53,7 +59,7 @@ impl PositionIntent {
         basket_id: String,
         target_position: i8,
         reason: TransitionReason,
-        z_score: f64,
+        signal_score: f64,
         spread: f64,
         date: chrono::NaiveDate,
     ) -> Self {
@@ -61,7 +67,7 @@ impl PositionIntent {
             basket_id,
             target_position,
             reason,
-            z_score,
+            signal_score,
             spread,
             date,
         }

--- a/engine/crates/basket-engine/src/lib.rs
+++ b/engine/crates/basket-engine/src/lib.rs
@@ -4,17 +4,19 @@
 //! position intents in response to daily bars.
 
 mod engine;
+mod gates;
 mod intent;
 mod portfolio;
 mod state;
 
 pub use engine::{BasketEngine, BasketParams, EngineSnapshot};
+pub use gates::{GatePolicyKind, RollingEntryMode, RollingSScoreV1Config};
 pub use intent::{PositionIntent, TransitionReason};
 pub use portfolio::{
-    aggregate_positions, basket_to_legs, diff_to_orders, plan_portfolio, LegNotional, OrderIntent,
-    OrderReason, PortfolioConfig, PortfolioPlan, Side,
+    aggregate_positions, basket_to_legs, diff_to_orders, plan_portfolio, AdmissionScoreKind,
+    LegNotional, OrderIntent, OrderReason, PortfolioConfig, PortfolioPlan, Side,
 };
-pub use state::BasketState;
+pub use state::{BasketState, MAX_SPREAD_HISTORY};
 
 /// A daily bar for a single symbol.
 #[derive(Debug, Clone)]

--- a/engine/crates/basket-engine/src/portfolio.rs
+++ b/engine/crates/basket-engine/src/portfolio.rs
@@ -6,6 +6,18 @@ use serde::{Deserialize, Serialize};
 
 use crate::engine::{BasketEngine, BasketParams};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AdmissionScoreKind {
+    SignalScore,
+    RawZScore,
+}
+
+impl Default for AdmissionScoreKind {
+    fn default() -> Self {
+        Self::SignalScore
+    }
+}
+
 /// Portfolio configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PortfolioConfig {
@@ -15,6 +27,9 @@ pub struct PortfolioConfig {
     pub leverage: f64,
     /// Maximum number of active baskets.
     pub n_active_baskets: usize,
+    /// Metric used to rank active baskets under the admission cap.
+    #[serde(default)]
+    pub admission_score: AdmissionScoreKind,
 }
 
 impl Default for PortfolioConfig {
@@ -23,6 +38,7 @@ impl Default for PortfolioConfig {
             capital: 100_000.0,
             leverage: 4.0,
             n_active_baskets: 10,
+            admission_score: AdmissionScoreKind::SignalScore,
         }
     }
 }
@@ -129,7 +145,14 @@ pub fn plan_portfolio(engine: &BasketEngine, config: &PortfolioConfig) -> Portfo
         if state.position == 0 {
             continue;
         }
-        active.push((basket_id.clone(), state.last_z.unwrap_or(0.0).abs()));
+        let rank_score = match config.admission_score {
+            AdmissionScoreKind::SignalScore => {
+                state.last_signal_score.or(state.last_z).unwrap_or(0.0)
+            }
+            AdmissionScoreKind::RawZScore => state.last_z.unwrap_or(0.0),
+        }
+        .abs();
+        active.push((basket_id.clone(), rank_score));
     }
 
     active.sort_by(|(a_id, a_z), (b_id, b_z)| {
@@ -378,6 +401,7 @@ mod tests {
             capital: 100_000.0,
             leverage: 4.0,
             n_active_baskets: 10,
+            admission_score: AdmissionScoreKind::SignalScore,
         };
         config.validate().unwrap();
         assert_eq!(config.notional_per_basket(), 40_000.0);
@@ -389,6 +413,7 @@ mod tests {
             capital: 100_000.0,
             leverage: 4.0,
             n_active_baskets: 0,
+            admission_score: AdmissionScoreKind::SignalScore,
         };
         let err = config.validate().unwrap_err();
         assert!(err.contains("n_active_baskets"));
@@ -460,6 +485,7 @@ mod tests {
             capital: 100_000.0,
             leverage: 4.0,
             n_active_baskets: 1,
+            admission_score: AdmissionScoreKind::SignalScore,
         };
         let plan = plan_portfolio(&engine, &config);
         assert_eq!(plan.active_baskets, 2);
@@ -467,5 +493,52 @@ mod tests {
         assert_eq!(plan.excluded_baskets.len(), 1);
         let gross: f64 = plan.symbol_notionals.values().map(|n| n.abs()).sum();
         assert!((gross - config.notional_per_basket()).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_plan_portfolio_can_rank_by_raw_z_instead_of_signal_score() {
+        let engine = make_test_engine();
+        let mut ids: Vec<String> = engine.iter_params().map(|(id, _)| id.clone()).collect();
+        ids.sort();
+        assert!(ids.len() >= 2);
+
+        let mut states = std::collections::HashMap::new();
+
+        let mut first = crate::BasketState::new();
+        first.position = 1;
+        first.last_signal_score = Some(5.0);
+        first.last_z = Some(1.0);
+        states.insert(ids[0].clone(), first);
+
+        let mut second = crate::BasketState::new();
+        second.position = 1;
+        second.last_signal_score = Some(1.0);
+        second.last_z = Some(5.0);
+        states.insert(ids[1].clone(), second);
+
+        let mut engine = engine;
+        engine.apply_states(states).unwrap();
+
+        let signal_plan = plan_portfolio(
+            &engine,
+            &PortfolioConfig {
+                capital: 100_000.0,
+                leverage: 4.0,
+                n_active_baskets: 1,
+                admission_score: AdmissionScoreKind::SignalScore,
+            },
+        );
+        assert_eq!(signal_plan.selected_baskets, vec![ids[0].clone()]);
+
+        let raw_z_plan = plan_portfolio(
+            &engine,
+            &PortfolioConfig {
+                capital: 100_000.0,
+                leverage: 4.0,
+                n_active_baskets: 1,
+                admission_score: AdmissionScoreKind::RawZScore,
+            },
+        );
+        assert_eq!(raw_z_plan.selected_baskets, vec![ids[1].clone()]);
     }
 }

--- a/engine/crates/basket-engine/src/portfolio.rs
+++ b/engine/crates/basket-engine/src/portfolio.rs
@@ -6,16 +6,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::engine::{BasketEngine, BasketParams};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum AdmissionScoreKind {
+    #[default]
     SignalScore,
     RawZScore,
-}
-
-impl Default for AdmissionScoreKind {
-    fn default() -> Self {
-        Self::SignalScore
-    }
 }
 
 /// Portfolio configuration.

--- a/engine/crates/basket-engine/src/state.rs
+++ b/engine/crates/basket-engine/src/state.rs
@@ -4,6 +4,8 @@ use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 
+pub const MAX_SPREAD_HISTORY: usize = 60;
+
 /// Per-basket runtime state.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BasketState {
@@ -18,6 +20,9 @@ pub struct BasketState {
     pub spread_history: VecDeque<f64>,
     /// Most recent z-score.
     pub last_z: Option<f64>,
+    /// Most recent signal score used by the active gate policy.
+    #[serde(default)]
+    pub last_signal_score: Option<f64>,
 }
 
 impl Default for BasketState {
@@ -28,6 +33,7 @@ impl Default for BasketState {
             entry_spread: None,
             spread_history: VecDeque::with_capacity(60),
             last_z: None,
+            last_signal_score: None,
         }
     }
 }
@@ -40,8 +46,7 @@ impl BasketState {
 
     /// Record a new spread observation.
     pub fn record_spread(&mut self, spread: f64) {
-        const MAX_HISTORY: usize = 60;
-        if self.spread_history.len() >= MAX_HISTORY {
+        if self.spread_history.len() >= MAX_SPREAD_HISTORY {
             self.spread_history.pop_front();
         }
         self.spread_history.push_back(spread);
@@ -114,7 +119,7 @@ mod tests {
         for i in 0..100 {
             state.record_spread(i as f64);
         }
-        assert_eq!(state.spread_history.len(), 60);
+        assert_eq!(state.spread_history.len(), MAX_SPREAD_HISTORY);
         assert_eq!(state.spread_history.front(), Some(&40.0));
         assert_eq!(state.spread_history.back(), Some(&99.0));
     }

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -30,8 +30,8 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use basket_engine::{
-    plan_portfolio, BasketEngine, DailyBar, OrderIntent, PortfolioConfig, PortfolioPlan,
-    PositionIntent, Side,
+    plan_portfolio, BasketEngine, DailyBar, GatePolicyKind, OrderIntent, PortfolioConfig,
+    PortfolioPlan, PositionIntent, Side,
 };
 use basket_picker::{load_universe, BasketFit};
 use chrono::{DateTime, NaiveDate, Utc};
@@ -122,6 +122,7 @@ pub struct BasketRunOptions {
     pub leadership_overlay: Option<LeadershipOverlayConfig>,
     pub overlay_picker: BasketOverlayPickerKind,
     pub rule_v1_config: Option<crate::basket_overlay_picker::RuleV1OverlayPickerConfig>,
+    pub gate_policy: GatePolicyKind,
 }
 
 impl Default for BasketRunOptions {
@@ -132,6 +133,7 @@ impl Default for BasketRunOptions {
             leadership_overlay: None,
             overlay_picker: BasketOverlayPickerKind::Fixed,
             rule_v1_config: None,
+            gate_policy: GatePolicyKind::BertramFrozen,
         }
     }
 }
@@ -472,6 +474,43 @@ fn warm_leadership_tracker(
         anchor_day = %anchor_day,
         active_sectors = ?tracker.active_sectors_for_today(),
         "leadership tracker warmed from historical close snapshots"
+    );
+    Ok(())
+}
+
+fn warm_engine_signal_history(
+    engine: &mut BasketEngine,
+    bars_dir: &Path,
+    symbols: &[String],
+    anchor_day: NaiveDate,
+) -> Result<(), String> {
+    let Some(lookback) = engine.gate_policy().history_lookback() else {
+        return Ok(());
+    };
+    let requested_warm_days = (lookback as i64 * 3).max(60);
+    let closes =
+        load_daily_closes_with_timestamps(bars_dir, symbols, requested_warm_days, Some(anchor_day))?;
+    let mut by_day: std::collections::BTreeMap<NaiveDate, Vec<DailyBar>> =
+        std::collections::BTreeMap::new();
+    for (symbol, series) in closes {
+        for (date, _ts_us, close) in series {
+            by_day.entry(date).or_default().push(DailyBar {
+                symbol: symbol.clone(),
+                date,
+                close,
+            });
+        }
+    }
+    let warm_days = by_day.len();
+    for bars in by_day.into_values() {
+        engine.warm_on_bars(&bars);
+    }
+    info!(
+        anchor_day = %anchor_day,
+        requested_warm_days,
+        warm_days,
+        gate_policy = ?engine.gate_policy(),
+        "warmed basket engine signal history"
     );
     Ok(())
 }
@@ -1434,7 +1473,9 @@ pub async fn run_basket_live(
             state_path,
             &current_shares,
             execution.alpaca_mode().is_some(),
+            options.gate_policy.clone(),
         )?;
+    info!(gate_policy = ?engine.gate_policy(), "basket signal gate policy initialized");
     let leadership_state_path = leadership_classifier_state_path(state_path);
     let can_load_sidecar_state = matches!(startup_state_source, StartupStateSource::Snapshot);
     if !can_load_sidecar_state {
@@ -1478,6 +1519,16 @@ pub async fn run_basket_live(
                 tracker.save_state(&leadership_state_path)?;
             }
             Err(e) => return Err(e),
+        }
+    }
+    if !can_load_sidecar_state {
+        let warm_anchor = if last_processed_trading_day == Some(today) {
+            Some(today)
+        } else {
+            previous_trading_day(today)
+        };
+        if let Some(anchor_day) = warm_anchor {
+            warm_engine_signal_history(&mut engine, bars_dir, &symbols, anchor_day)?;
         }
     }
     if let Some(cfg) = options.leadership_overlay.as_ref() {
@@ -1996,13 +2047,14 @@ fn initialize_engine_state(
     state_path: &Path,
     broker_shares: &HashMap<String, f64>,
     broker_execution_enabled: bool,
+    gate_policy: GatePolicyKind,
 ) -> Result<(BasketEngine, Option<NaiveDate>, StartupStateSource), String> {
     let expected_ids: std::collections::HashSet<String> = fits
         .iter()
         .filter(|f| f.valid)
         .map(|f| f.candidate.id())
         .collect();
-    let mut fresh = BasketEngine::new(fits);
+    let mut fresh = BasketEngine::with_gate_policy(fits, gate_policy.clone());
 
     if !state_path.exists() {
         if broker_execution_enabled && !broker_shares.is_empty() {
@@ -2021,6 +2073,18 @@ fn initialize_engine_state(
 
     match BasketEngine::load_snapshot(state_path) {
         Ok(snapshot) => {
+            if snapshot.gate_policy != gate_policy {
+                return recover_from_unloadable_state(
+                    fresh,
+                    state_path,
+                    broker_shares,
+                    broker_execution_enabled,
+                    format!(
+                        "state snapshot gate policy mismatch: snapshot={:?}, requested={:?}",
+                        snapshot.gate_policy, gate_policy
+                    ),
+                );
+            }
             let loaded_ids: std::collections::HashSet<String> =
                 snapshot.states.keys().cloned().collect();
             if loaded_ids != expected_ids {
@@ -3069,7 +3133,7 @@ fn log_intent(intent: &PositionIntent) {
     info!(
         basket_id = %intent.basket_id,
         target_position = intent.target_position,
-        z = %format!("{:.4}", intent.z_score),
+        score = %format!("{:.4}", intent.signal_score),
         spread = %format!("{:.6}", intent.spread),
         reason = intent.reason.as_str(),
         date = %intent.date,
@@ -3523,6 +3587,7 @@ mod tests {
             capital: 10_000.0,
             leverage: 4.0,
             n_active_baskets: 5,
+            admission_score: basket_engine::AdmissionScoreKind::SignalScore,
         };
         let overlay = LeadershipOverlayConfig {
             sectors: vec!["chips".to_string()],
@@ -3593,6 +3658,7 @@ mod tests {
             capital: 10_000.0,
             leverage: 4.0,
             n_active_baskets: 5,
+            admission_score: basket_engine::AdmissionScoreKind::SignalScore,
         };
         let overlay = LeadershipOverlayConfig {
             sectors: vec!["chips".to_string()],
@@ -3864,8 +3930,14 @@ mod tests {
         std::fs::write(&state_path, "{ definitely not json").unwrap();
 
         let broker_shares = HashMap::from([("AMD".to_string(), -12.0)]);
-        let (engine, last_processed, source) =
-            initialize_engine_state(&fits, &state_path, &broker_shares, true).unwrap();
+        let (engine, last_processed, source) = initialize_engine_state(
+            &fits,
+            &state_path,
+            &broker_shares,
+            true,
+            GatePolicyKind::BertramFrozen,
+        )
+        .unwrap();
 
         assert_eq!(source, StartupStateSource::BrokerReconciled);
         assert_eq!(last_processed, None);
@@ -3906,8 +3978,14 @@ mod tests {
         wrong_engine.apply_states(states).unwrap();
         wrong_engine.save_state(&state_path).unwrap();
 
-        let (engine, last_processed, source) =
-            initialize_engine_state(&fits, &state_path, &HashMap::new(), true).unwrap();
+        let (engine, last_processed, source) = initialize_engine_state(
+            &fits,
+            &state_path,
+            &HashMap::new(),
+            true,
+            GatePolicyKind::BertramFrozen,
+        )
+        .unwrap();
 
         assert_eq!(source, StartupStateSource::Fresh);
         assert_eq!(last_processed, None);

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -488,8 +488,12 @@ fn warm_engine_signal_history(
         return Ok(());
     };
     let requested_warm_days = (lookback as i64 * 3).max(60);
-    let closes =
-        load_daily_closes_with_timestamps(bars_dir, symbols, requested_warm_days, Some(anchor_day))?;
+    let closes = load_daily_closes_with_timestamps(
+        bars_dir,
+        symbols,
+        requested_warm_days,
+        Some(anchor_day),
+    )?;
     let mut by_day: std::collections::BTreeMap<NaiveDate, Vec<DailyBar>> =
         std::collections::BTreeMap::new();
     for (symbol, series) in closes {
@@ -2074,11 +2078,12 @@ fn initialize_engine_state(
     match BasketEngine::load_snapshot(state_path) {
         Ok(snapshot) => {
             if snapshot.gate_policy != gate_policy {
-                return recover_from_unloadable_state(
+                return recover_from_incompatible_state(
                     fresh,
                     state_path,
                     broker_shares,
                     broker_execution_enabled,
+                    false,
                     format!(
                         "state snapshot gate policy mismatch: snapshot={:?}, requested={:?}",
                         snapshot.gate_policy, gate_policy
@@ -2088,11 +2093,12 @@ fn initialize_engine_state(
             let loaded_ids: std::collections::HashSet<String> =
                 snapshot.states.keys().cloned().collect();
             if loaded_ids != expected_ids {
-                return recover_from_unloadable_state(
+                return recover_from_incompatible_state(
                     fresh,
                     state_path,
                     broker_shares,
                     broker_execution_enabled,
+                    true,
                     format!(
                         "state snapshot basket set mismatch: snapshot={}, artifact={}",
                         loaded_ids.len(),
@@ -2114,38 +2120,49 @@ fn initialize_engine_state(
                 StartupStateSource::Snapshot,
             ))
         }
-        Err(e) => recover_from_unloadable_state(
+        Err(e) => recover_from_incompatible_state(
             fresh,
             state_path,
             broker_shares,
             broker_execution_enabled,
+            true,
             format!("failed to load state snapshot: {e}"),
         ),
     }
 }
 
-fn recover_from_unloadable_state(
+fn recover_from_incompatible_state(
     mut fresh: BasketEngine,
     state_path: &Path,
     broker_shares: &HashMap<String, f64>,
     broker_execution_enabled: bool,
+    move_state_aside: bool,
     reason: String,
 ) -> Result<(BasketEngine, Option<NaiveDate>, StartupStateSource), String> {
-    let backup_path = move_state_file_aside(state_path)?;
-    bug!(
-        "engine_state_snapshot_unusable",
-        state_path = %state_path.display(),
-        backup_path = %backup_path.display(),
-        reason = %reason,
-        "state snapshot unusable — moved aside for recovery"
-    );
+    if move_state_aside {
+        let backup_path = move_state_file_aside(state_path)?;
+        bug!(
+            "engine_state_snapshot_unusable",
+            state_path = %state_path.display(),
+            backup_path = %backup_path.display(),
+            reason = %reason,
+            "state snapshot unusable — moved aside for recovery"
+        );
+    } else {
+        bug!(
+            "engine_state_snapshot_incompatible_policy",
+            state_path = %state_path.display(),
+            reason = %reason,
+            "state snapshot incompatible with requested gate policy — preserving file and recovering fresh runtime state"
+        );
+    }
 
     if broker_execution_enabled && !broker_shares.is_empty() {
         let reconciled = reconcile_engine_state_from_broker(&mut fresh, broker_shares)?;
         warn!(
             broker_positions = broker_shares.len(),
             reconciled_baskets = reconciled,
-            "recovered engine state from broker positions after unloading state snapshot"
+            "recovered engine state from broker positions after incompatible state snapshot"
         );
         Ok((fresh, None, StartupStateSource::BrokerReconciled))
     } else {
@@ -3956,6 +3973,42 @@ mod tests {
             .filter(|name| name.contains(".unusable."))
             .collect();
         assert_eq!(backups.len(), 1);
+    }
+
+    #[test]
+    fn test_initialize_engine_state_preserves_mismatched_policy_snapshot_when_broker_flat() {
+        let fits = make_test_fits();
+        let tmp = tempdir().unwrap();
+        let state_path = tmp.path().join("basket.state.json");
+
+        let wrong_engine = BasketEngine::new(&fits);
+        wrong_engine.save_state(&state_path).unwrap();
+
+        let (engine, last_processed, source) = initialize_engine_state(
+            &fits,
+            &state_path,
+            &HashMap::new(),
+            true,
+            GatePolicyKind::RollingSScoreV1(basket_engine::RollingSScoreV1Config {
+                lookback: 20,
+                min_history: 20,
+                exit_threshold: 0.5,
+                direct_flip: true,
+                entry_mode: basket_engine::RollingEntryMode::RollingScore,
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(source, StartupStateSource::Fresh);
+        assert_eq!(last_processed, None);
+        assert_eq!(
+            engine.get_state(&fits[0].candidate.id()).unwrap().position,
+            0
+        );
+        assert!(
+            state_path.exists(),
+            "policy-mismatched state should be preserved"
+        );
     }
 
     #[test]

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -3995,6 +3995,7 @@ mod tests {
                 exit_threshold: 0.5,
                 direct_flip: true,
                 entry_mode: basket_engine::RollingEntryMode::RollingScore,
+                entry_confirmation_bars: 1,
             }),
         )
         .unwrap();

--- a/engine/crates/runner/src/main.rs
+++ b/engine/crates/runner/src/main.rs
@@ -570,7 +570,9 @@ fn resolve_basket_signal_policy(
                 min_history: min_history.unwrap_or(20),
                 exit_threshold: exit_threshold.unwrap_or(0.5),
                 direct_flip: direct_flip.unwrap_or(true),
-                entry_mode: entry_mode.unwrap_or(BasketSignalEntryModeArg::RollingScore).into(),
+                entry_mode: entry_mode
+                    .unwrap_or(BasketSignalEntryModeArg::RollingScore)
+                    .into(),
             };
             let gate_policy = GatePolicyKind::RollingSScoreV1(cfg);
             gate_policy.validate()?;
@@ -915,6 +917,26 @@ fn leadership_overlay_fingerprint(cfg: &basket_live::LeadershipOverlayConfig) ->
         "leadership-{mode}-{sectors}-onr{ret}-onb{breadth}-offr{off_ret}-offb{off_breadth}-p{}-h{}-l{lev}",
         cfg.persistence_days, cfg.min_hold_days
     )
+}
+
+fn gate_policy_fingerprint(policy: &GatePolicyKind) -> Option<String> {
+    match policy {
+        GatePolicyKind::BertramFrozen => None,
+        GatePolicyKind::RollingSScoreV1(cfg) => Some(
+            format!(
+                "gate-rssv1-l{}-m{}-e{:.2}-f{}-em{}",
+                cfg.lookback,
+                cfg.min_history,
+                cfg.exit_threshold,
+                if cfg.direct_flip { 1 } else { 0 },
+                match cfg.entry_mode {
+                    RollingEntryMode::RollingScore => "s",
+                    RollingEntryMode::RawZScore => "z",
+                }
+            )
+            .replace('.', "p"),
+        ),
+    }
 }
 
 fn path_with_suffix(path: &std::path::Path, suffix: &str) -> PathBuf {
@@ -1265,20 +1287,43 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
     } else {
         warn!(path = %bars_dir.display(), "quant-data dir not found — skipping refresh");
     }
+    let gate_policy = match resolve_basket_signal_policy(
+        args.basket_signal_policy,
+        args.basket_signal_lookback,
+        args.basket_signal_min_history,
+        args.basket_signal_exit_threshold,
+        args.basket_signal_direct_flip,
+        args.basket_signal_entry_mode,
+    ) {
+        Ok(policy) => policy,
+        Err(e) => {
+            error!(error = %e, "invalid basket signal policy");
+            std::process::exit(1);
+        }
+    };
     let overlay_fingerprint = leadership_overlay
         .as_ref()
         .map(leadership_overlay_fingerprint);
+    let gate_fingerprint = gate_policy_fingerprint(&gate_policy);
     let default_state_base = default_stream_state_path(&args.data_dir, &fit_artifact_path);
     let legacy_state_base = basket_fits::default_live_state_path(&fit_artifact_path);
+    let state_base = match gate_fingerprint.as_deref() {
+        Some(fp) => path_with_suffix(&default_state_base, fp),
+        None => default_state_base,
+    };
     let state_path = match (&args.state_path, overlay_fingerprint.as_deref()) {
         (Some(path), _) => path.clone(),
-        (None, Some(fp)) => path_with_suffix(&default_state_base, fp),
-        (None, None) => default_state_base,
+        (None, Some(fp)) => path_with_suffix(&state_base, fp),
+        (None, None) => state_base,
     };
     if args.state_path.is_none() {
-        let legacy_path = match overlay_fingerprint.as_deref() {
+        let legacy_gate_base = match gate_fingerprint.as_deref() {
             Some(fp) => path_with_suffix(&legacy_state_base, fp),
             None => legacy_state_base,
+        };
+        let legacy_path = match overlay_fingerprint.as_deref() {
+            Some(fp) => path_with_suffix(&legacy_gate_base, fp),
+            None => legacy_gate_base,
         };
         maybe_migrate_legacy_stream_state(&legacy_path, &state_path);
     }
@@ -1344,21 +1389,6 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
             None => base,
         }
     });
-    let gate_policy = match resolve_basket_signal_policy(
-        args.basket_signal_policy,
-        args.basket_signal_lookback,
-        args.basket_signal_min_history,
-        args.basket_signal_exit_threshold,
-        args.basket_signal_direct_flip,
-        args.basket_signal_entry_mode,
-    ) {
-        Ok(policy) => policy,
-        Err(e) => {
-            error!(error = %e, "invalid basket signal policy");
-            std::process::exit(1);
-        }
-    };
-
     if let Err(e) = basket_live::run_basket_live(
         &alpaca,
         &bar_source,
@@ -2068,15 +2098,35 @@ async fn run_basket_replay_live_path(args: ReplayArgs) {
         std::process::exit(1);
     }
 
+    let gate_policy = match resolve_basket_signal_policy(
+        args.basket_signal_policy,
+        args.basket_signal_lookback,
+        args.basket_signal_min_history,
+        args.basket_signal_exit_threshold,
+        args.basket_signal_direct_flip,
+        args.basket_signal_entry_mode,
+    ) {
+        Ok(policy) => policy,
+        Err(e) => {
+            error!(error = %e, "invalid basket signal policy");
+            std::process::exit(1);
+        }
+    };
+
     // Replay state isolation: never touch the live default state path.
     let state_path = args.state_path.clone().unwrap_or_else(|| {
         let stem = universe_path
             .file_stem()
             .and_then(|s| s.to_str())
             .unwrap_or("basket_universe");
-        args.data_dir
+        let base = args
+            .data_dir
             .join("replay")
-            .join(format!("{stem}.state.json"))
+            .join(format!("{stem}.state.json"));
+        match gate_policy_fingerprint(&gate_policy).as_deref() {
+            Some(fp) => path_with_suffix(&base, fp),
+            None => base,
+        }
     });
     if let Some(parent) = state_path.parent() {
         if let Err(e) = std::fs::create_dir_all(parent) {
@@ -2221,20 +2271,6 @@ async fn run_basket_replay_live_path(args: ReplayArgs) {
     // reconciliation) runs identically to live. The execution flag
     // never reaches Alpaca because the broker IS our SimulatedBroker.
     let execution = basket_live::BasketExecution::Paper;
-    let gate_policy = match resolve_basket_signal_policy(
-        args.basket_signal_policy,
-        args.basket_signal_lookback,
-        args.basket_signal_min_history,
-        args.basket_signal_exit_threshold,
-        args.basket_signal_direct_flip,
-        args.basket_signal_entry_mode,
-    ) {
-        Ok(policy) => policy,
-        Err(e) => {
-            error!(error = %e, "invalid basket signal policy");
-            std::process::exit(1);
-        }
-    };
 
     let result = basket_live::run_basket_live(
         &broker,
@@ -2397,6 +2433,28 @@ mod tests {
         assert_eq!(
             path,
             PathBuf::from("data/state/basket_universe_v1.fits.state.leadership-rule-v1.json")
+        );
+    }
+
+    #[test]
+    fn non_default_gate_policy_gets_distinct_state_suffix() {
+        let fp = gate_policy_fingerprint(&GatePolicyKind::RollingSScoreV1(RollingSScoreV1Config {
+            lookback: 60,
+            min_history: 40,
+            exit_threshold: 1.0,
+            direct_flip: true,
+            entry_mode: RollingEntryMode::RawZScore,
+        }))
+        .unwrap();
+        let path = path_with_suffix(
+            Path::new("data/state/basket_universe_buildout.fits.state.json"),
+            &fp,
+        );
+        assert_eq!(
+            path,
+            PathBuf::from(
+                "data/state/basket_universe_buildout.fits.state.gate-rssv1-l60-m40-e1p00-f1-emz.json"
+            )
         );
     }
 }

--- a/engine/crates/runner/src/main.rs
+++ b/engine/crates/runner/src/main.rs
@@ -35,6 +35,7 @@ mod simulated_broker;
 mod stream;
 
 use alpaca::ExecutionMode;
+use basket_engine::{AdmissionScoreKind, GatePolicyKind, RollingEntryMode, RollingSScoreV1Config};
 use basket_picker::{
     RunnerLeadershipOverlayModeConfig as UniverseLeadershipOverlayModeConfig,
     RunnerLeadershipPickerConfig as UniverseLeadershipPickerConfig,
@@ -197,6 +198,34 @@ struct StreamArgs {
     #[arg(long)]
     n_active_baskets: Option<usize>,
 
+    /// Basket-only signal gate policy. Defaults to the legacy Bertram trigger.
+    #[arg(long, value_enum)]
+    basket_signal_policy: Option<BasketSignalPolicyArg>,
+
+    /// Rolling s-score v1: trailing spread lookback window in trading days.
+    #[arg(long)]
+    basket_signal_lookback: Option<usize>,
+
+    /// Rolling s-score v1: minimum history before signals are allowed.
+    #[arg(long)]
+    basket_signal_min_history: Option<usize>,
+
+    /// Rolling s-score v1: close band around zero for flattening open positions.
+    #[arg(long)]
+    basket_signal_exit_threshold: Option<f64>,
+
+    /// Rolling s-score v1: allow same-bar direct flips across the opposite entry threshold.
+    #[arg(long)]
+    basket_signal_direct_flip: Option<bool>,
+
+    /// Rolling s-score v1: metric used to trigger entries and direct flips.
+    #[arg(long, value_enum)]
+    basket_signal_entry_mode: Option<BasketSignalEntryModeArg>,
+
+    /// Metric used to rank active baskets under the admission cap.
+    #[arg(long, value_enum)]
+    basket_admission_score: Option<BasketAdmissionScoreArg>,
+
     /// Override the durable basket paper/live journal path.
     /// Defaults to `<data-dir>/journal/basket_live.sqlite3`.
     #[arg(long)]
@@ -319,6 +348,34 @@ struct ReplayArgs {
     /// Max active baskets (basket only, default 5).
     #[arg(long)]
     n_active_baskets: Option<usize>,
+
+    /// Basket-only signal gate policy. Defaults to the legacy Bertram trigger.
+    #[arg(long, value_enum)]
+    basket_signal_policy: Option<BasketSignalPolicyArg>,
+
+    /// Rolling s-score v1: trailing spread lookback window in trading days.
+    #[arg(long)]
+    basket_signal_lookback: Option<usize>,
+
+    /// Rolling s-score v1: minimum history before signals are allowed.
+    #[arg(long)]
+    basket_signal_min_history: Option<usize>,
+
+    /// Rolling s-score v1: close band around zero for flattening open positions.
+    #[arg(long)]
+    basket_signal_exit_threshold: Option<f64>,
+
+    /// Rolling s-score v1: allow same-bar direct flips across the opposite entry threshold.
+    #[arg(long)]
+    basket_signal_direct_flip: Option<bool>,
+
+    /// Rolling s-score v1: metric used to trigger entries and direct flips.
+    #[arg(long, value_enum)]
+    basket_signal_entry_mode: Option<BasketSignalEntryModeArg>,
+
+    /// Metric used to rank active baskets under the admission cap.
+    #[arg(long, value_enum)]
+    basket_admission_score: Option<BasketAdmissionScoreArg>,
 
     /// One-sided fill slippage in basis points (basket only, default 0).
     #[arg(long, default_value_t = 0.0)]
@@ -443,6 +500,42 @@ enum LeadershipPickerArg {
     RuleV1,
 }
 
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+enum BasketSignalPolicyArg {
+    Bertram,
+    RollingSScoreV1,
+}
+
+#[derive(Copy, Clone, Debug, clap::ValueEnum)]
+enum BasketAdmissionScoreArg {
+    SignalScore,
+    RawZScore,
+}
+
+#[derive(Copy, Clone, Debug, clap::ValueEnum)]
+enum BasketSignalEntryModeArg {
+    RollingScore,
+    RawZScore,
+}
+
+impl From<BasketSignalEntryModeArg> for RollingEntryMode {
+    fn from(value: BasketSignalEntryModeArg) -> Self {
+        match value {
+            BasketSignalEntryModeArg::RollingScore => RollingEntryMode::RollingScore,
+            BasketSignalEntryModeArg::RawZScore => RollingEntryMode::RawZScore,
+        }
+    }
+}
+
+impl From<BasketAdmissionScoreArg> for AdmissionScoreKind {
+    fn from(value: BasketAdmissionScoreArg) -> Self {
+        match value {
+            BasketAdmissionScoreArg::SignalScore => AdmissionScoreKind::SignalScore,
+            BasketAdmissionScoreArg::RawZScore => AdmissionScoreKind::RawZScore,
+        }
+    }
+}
+
 impl From<LeadershipPickerArg> for basket_overlay_picker::BasketOverlayPickerKind {
     fn from(value: LeadershipPickerArg) -> Self {
         match value {
@@ -461,9 +554,35 @@ impl From<UniverseLeadershipPickerConfig> for LeadershipPickerArg {
     }
 }
 
+fn resolve_basket_signal_policy(
+    policy: Option<BasketSignalPolicyArg>,
+    lookback: Option<usize>,
+    min_history: Option<usize>,
+    exit_threshold: Option<f64>,
+    direct_flip: Option<bool>,
+    entry_mode: Option<BasketSignalEntryModeArg>,
+) -> Result<GatePolicyKind, String> {
+    match policy.unwrap_or(BasketSignalPolicyArg::Bertram) {
+        BasketSignalPolicyArg::Bertram => Ok(GatePolicyKind::BertramFrozen),
+        BasketSignalPolicyArg::RollingSScoreV1 => {
+            let cfg = RollingSScoreV1Config {
+                lookback: lookback.unwrap_or(20),
+                min_history: min_history.unwrap_or(20),
+                exit_threshold: exit_threshold.unwrap_or(0.5),
+                direct_flip: direct_flip.unwrap_or(true),
+                entry_mode: entry_mode.unwrap_or(BasketSignalEntryModeArg::RollingScore).into(),
+            };
+            let gate_policy = GatePolicyKind::RollingSScoreV1(cfg);
+            gate_policy.validate()?;
+            Ok(gate_policy)
+        }
+    }
+}
+
 struct BasketRuntimeOverrides<'a> {
     capital: Option<f64>,
     n_active_baskets: Option<usize>,
+    basket_admission_score: Option<BasketAdmissionScoreArg>,
     disable_leadership_overlay: bool,
     leadership_overlay_sectors: &'a [String],
     leadership_ret5d_threshold: Option<f64>,
@@ -555,6 +674,10 @@ fn resolve_basket_runtime(
         n_active_baskets: overrides
             .n_active_baskets
             .unwrap_or(universe.runner.portfolio.n_active_baskets),
+        admission_score: overrides
+            .basket_admission_score
+            .map(Into::into)
+            .unwrap_or_default(),
     };
 
     let has_overlay_override = !overrides.leadership_overlay_sectors.is_empty()
@@ -1078,6 +1201,7 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
         BasketRuntimeOverrides {
             capital: args.capital,
             n_active_baskets: args.n_active_baskets,
+            basket_admission_score: args.basket_admission_score,
             disable_leadership_overlay: args.disable_leadership_overlay,
             leadership_overlay_sectors: &args.leadership_overlay_sectors,
             leadership_ret5d_threshold: args.leadership_ret5d_threshold,
@@ -1220,6 +1344,20 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
             None => base,
         }
     });
+    let gate_policy = match resolve_basket_signal_policy(
+        args.basket_signal_policy,
+        args.basket_signal_lookback,
+        args.basket_signal_min_history,
+        args.basket_signal_exit_threshold,
+        args.basket_signal_direct_flip,
+        args.basket_signal_entry_mode,
+    ) {
+        Ok(policy) => policy,
+        Err(e) => {
+            error!(error = %e, "invalid basket signal policy");
+            std::process::exit(1);
+        }
+    };
 
     if let Err(e) = basket_live::run_basket_live(
         &alpaca,
@@ -1238,6 +1376,7 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
             leadership_overlay,
             overlay_picker: runtime.overlay_picker,
             rule_v1_config: runtime.rule_v1_config,
+            gate_policy,
         },
     )
     .await
@@ -1990,6 +2129,7 @@ async fn run_basket_replay_live_path(args: ReplayArgs) {
         BasketRuntimeOverrides {
             capital: args.capital,
             n_active_baskets: args.n_active_baskets,
+            basket_admission_score: args.basket_admission_score,
             disable_leadership_overlay: args.disable_leadership_overlay,
             leadership_overlay_sectors: &args.leadership_overlay_sectors,
             leadership_ret5d_threshold: args.leadership_ret5d_threshold,
@@ -2081,6 +2221,20 @@ async fn run_basket_replay_live_path(args: ReplayArgs) {
     // reconciliation) runs identically to live. The execution flag
     // never reaches Alpaca because the broker IS our SimulatedBroker.
     let execution = basket_live::BasketExecution::Paper;
+    let gate_policy = match resolve_basket_signal_policy(
+        args.basket_signal_policy,
+        args.basket_signal_lookback,
+        args.basket_signal_min_history,
+        args.basket_signal_exit_threshold,
+        args.basket_signal_direct_flip,
+        args.basket_signal_entry_mode,
+    ) {
+        Ok(policy) => policy,
+        Err(e) => {
+            error!(error = %e, "invalid basket signal policy");
+            std::process::exit(1);
+        }
+    };
 
     let result = basket_live::run_basket_live(
         &broker,
@@ -2099,6 +2253,7 @@ async fn run_basket_replay_live_path(args: ReplayArgs) {
             leadership_overlay,
             overlay_picker: runtime.overlay_picker,
             rule_v1_config: runtime.rule_v1_config,
+            gate_policy,
         },
     )
     .await;

--- a/engine/crates/runner/src/main.rs
+++ b/engine/crates/runner/src/main.rs
@@ -222,6 +222,10 @@ struct StreamArgs {
     #[arg(long, value_enum)]
     basket_signal_entry_mode: Option<BasketSignalEntryModeArg>,
 
+    /// Rolling s-score v1: consecutive bars required to confirm entries/direct flips.
+    #[arg(long)]
+    basket_signal_entry_confirmation_bars: Option<usize>,
+
     /// Metric used to rank active baskets under the admission cap.
     #[arg(long, value_enum)]
     basket_admission_score: Option<BasketAdmissionScoreArg>,
@@ -372,6 +376,10 @@ struct ReplayArgs {
     /// Rolling s-score v1: metric used to trigger entries and direct flips.
     #[arg(long, value_enum)]
     basket_signal_entry_mode: Option<BasketSignalEntryModeArg>,
+
+    /// Rolling s-score v1: consecutive bars required to confirm entries/direct flips.
+    #[arg(long)]
+    basket_signal_entry_confirmation_bars: Option<usize>,
 
     /// Metric used to rank active baskets under the admission cap.
     #[arg(long, value_enum)]
@@ -561,6 +569,7 @@ fn resolve_basket_signal_policy(
     exit_threshold: Option<f64>,
     direct_flip: Option<bool>,
     entry_mode: Option<BasketSignalEntryModeArg>,
+    entry_confirmation_bars: Option<usize>,
 ) -> Result<GatePolicyKind, String> {
     match policy.unwrap_or(BasketSignalPolicyArg::Bertram) {
         BasketSignalPolicyArg::Bertram => Ok(GatePolicyKind::BertramFrozen),
@@ -573,6 +582,7 @@ fn resolve_basket_signal_policy(
                 entry_mode: entry_mode
                     .unwrap_or(BasketSignalEntryModeArg::RollingScore)
                     .into(),
+                entry_confirmation_bars: entry_confirmation_bars.unwrap_or(1),
             };
             let gate_policy = GatePolicyKind::RollingSScoreV1(cfg);
             gate_policy.validate()?;
@@ -1294,6 +1304,7 @@ async fn run_basket_stream(args: StreamArgs, is_live_command: bool) {
         args.basket_signal_exit_threshold,
         args.basket_signal_direct_flip,
         args.basket_signal_entry_mode,
+        args.basket_signal_entry_confirmation_bars,
     ) {
         Ok(policy) => policy,
         Err(e) => {
@@ -2105,6 +2116,7 @@ async fn run_basket_replay_live_path(args: ReplayArgs) {
         args.basket_signal_exit_threshold,
         args.basket_signal_direct_flip,
         args.basket_signal_entry_mode,
+        args.basket_signal_entry_confirmation_bars,
     ) {
         Ok(policy) => policy,
         Err(e) => {
@@ -2444,6 +2456,7 @@ mod tests {
             exit_threshold: 1.0,
             direct_flip: true,
             entry_mode: RollingEntryMode::RawZScore,
+            entry_confirmation_bars: 1,
         }))
         .unwrap();
         let path = path_with_suffix(

--- a/engine/crates/runner/src/simulated_broker.rs
+++ b/engine/crates/runner/src/simulated_broker.rs
@@ -426,6 +426,7 @@ mod tests {
             capital: 10_000.0,
             leverage: 4.0,
             n_active_baskets: 5,
+            admission_score: basket_engine::AdmissionScoreKind::SignalScore,
         }
     }
 


### PR DESCRIPTION
## Summary
- add a dedicated `gates/` module for basket signal policy logic
- introduce the v1 rolling s-score gate with configurable lookback, history, exit threshold, entry mode, and admission score
- isolate gate-policy runtime state and fix signal logging so replay/live observability matches the actual trigger metric

## Why
The existing basket engine made entry/flip calls from the latest z-score only. This PR adds a cleaner signal-policy layer so we can evaluate a history-aware v1 gate without entangling it with runner state or portfolio plumbing.

## Implementation
- add `basket_engine::gates` with typed config and policy evaluation
- wire gate policy selection through runner CLI and snapshot state
- keep `raw-z-score` entry and admission modes available inside the v1 framework
- make non-default gate policies use separate state paths
- fix `raw-z-score` intent logging to report the actual trigger score instead of `s_score`
- add regression coverage for gate policy state isolation and signal-log correctness

## Validation
- `cargo test -p basket-engine`
- `cargo test -p openquant-runner`

## Replay results
### 2026-01-02 to 2026-05-22
- current `buildout_core`: `+11.32%`, Sharpe `1.13`, max DD `13.69%`
- v1 `buildout_core`: `+17.24%`, Sharpe `1.65`, max DD `12.24%`
- current `buildout_overlay`: `+52.60%`, Sharpe `4.02`, max DD `8.15%`
- v1 `buildout_overlay`: `+52.77%`, Sharpe `4.10`, max DD `8.15%`

### 2025 Q4 overlay cross-check
- current `buildout_overlay`: `+0.11%`, Sharpe `0.14`, max DD `9.21%`
- v1 `buildout_overlay`: `+10.44%`, Sharpe `1.74`, max DD `8.26%`

## Notes
- uncommitted local experiments after `5c124dc3` were intentionally left out of this PR
- this PR contains only the committed v1 candidate plus review fixes
