### PR TITLE
runner: align basket replay with deferred session-close fills

### DIFF
--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -49,7 +49,7 @@ use crate::basket_overlay_picker::{
     BasketOverlayMode, BasketOverlayPicker, BasketOverlayPickerFeatures, BasketOverlayPickerHandle,
     BasketOverlayPickerKind,
 };
-use crate::broker::Broker;
+use crate::broker::{Broker, SessionCloseFillContract};
 use crate::clock::Clock;
 use crate::market_session;
 use crate::session_trigger::SessionTrigger;
@@ -3218,6 +3218,7 @@ async fn process_session_close(
             }
         }
         Some(mode) => {
+            let fill_contract = broker.session_close_fill_contract();
             let reducing_target_shares =
                 apply_orders_to_shares(current_shares, &staged_orders.reducing);
             if let Err(e) = check_order_set_affordability(
@@ -3296,89 +3297,104 @@ async fn process_session_close(
             let mut shares_after_reducing = reducing_target_shares.clone();
             let mut phase_one_reconciliation_confirmed = false;
             if !staged_orders.expanding.is_empty() {
-                let reconciliation_delay_secs = broker.reconciliation_delay_secs();
-                if reconciliation_delay_secs > 0 {
-                    tokio::time::sleep(std::time::Duration::from_secs(reconciliation_delay_secs))
+                let reducing_settles_next_session = !staged_orders.reducing.is_empty()
+                    && reducing_batch.accepted_unfilled_orders > 0
+                    && matches!(fill_contract, SessionCloseFillContract::NextSessionOpen);
+                if reducing_settles_next_session {
+                    info!(
+                        date = %date,
+                        reducing_orders = staged_orders.reducing.len(),
+                        expanding_orders = staged_orders.expanding.len(),
+                        accepted_unfilled_reducing_orders = reducing_batch.accepted_unfilled_orders,
+                        "skipping phase-two expansions because reducing orders settle next session"
+                    );
+                } else {
+                    let reconciliation_delay_secs = broker.reconciliation_delay_secs();
+                    if reconciliation_delay_secs > 0 {
+                        tokio::time::sleep(std::time::Duration::from_secs(
+                            reconciliation_delay_secs,
+                        ))
                         .await;
-                }
-                match seed_current_shares_from_alpaca(broker, mode, &allowed_symbols).await {
-                    Ok(actual_shares) => {
-                        shares_after_reducing = actual_shares;
-                        phase_one_reconciliation_confirmed = true;
                     }
-                    Err(e) => {
-                        bug!(
-                            "phase_one_reconciliation_failed",
-                            date = %date,
-                            error = e.as_str(),
-                            "failed to reconcile broker positions after reducing orders"
-                        );
-                    }
-                }
-                let expanding_target_shares = subset_target_after_orders(
-                    &shares_after_reducing,
-                    &target_shares,
-                    &staged_orders.expanding,
-                );
-                let mut phase_two_orders =
-                    staged_diff_to_orders(&shares_after_reducing, &expanding_target_shares)
-                        .all_orders();
-                phase_two_orders.retain(|order| {
-                    can_submit_phase_two_order(
-                        current_shares,
-                        &target_shares,
-                        &shares_after_reducing,
-                        phase_one_reconciliation_confirmed,
-                        &order.symbol,
-                    )
-                });
-                if !phase_two_orders.is_empty() {
-                    if let Err(e) = check_order_set_affordability(
-                        broker,
-                        mode,
-                        date,
-                        &shares_after_reducing,
-                        &expanding_target_shares,
-                        &phase_two_orders,
-                        closes,
-                    )
-                    .await
-                    {
-                        if let Some(journal) = journal {
-                            journal.record_order_event(&BasketOrderEvent {
-                                run_id,
-                                trading_day: date,
-                                seq,
-                                symbol: "__phase2__",
-                                side: "n/a",
-                                requested_qty: 0.0,
-                                intended_notional: None,
-                                reason: "aggregated",
-                                basket_id: None,
-                                broker_order_id: None,
-                                broker_status: None,
-                                submission_status: "phase2_affordability_error",
-                                error_text: Some(e.as_str()),
-                            })?;
+                    match seed_current_shares_from_alpaca(broker, mode, &allowed_symbols).await {
+                        Ok(actual_shares) => {
+                            shares_after_reducing = actual_shares;
+                            phase_one_reconciliation_confirmed = true;
                         }
-                        failed_orders += phase_two_orders.len();
-                    } else {
-                        let expanding_batch = submit_order_batch(
+                        Err(e) => {
+                            bug!(
+                                "phase_one_reconciliation_failed",
+                                date = %date,
+                                error = e.as_str(),
+                                "failed to reconcile broker positions after reducing orders"
+                            );
+                        }
+                    }
+                    let expanding_target_shares = subset_target_after_orders(
+                        &shares_after_reducing,
+                        &target_shares,
+                        &staged_orders.expanding,
+                    );
+                    let mut phase_two_orders =
+                        staged_diff_to_orders(&shares_after_reducing, &expanding_target_shares)
+                            .all_orders();
+                    phase_two_orders.retain(|order| {
+                        can_submit_phase_two_order(
+                            current_shares,
+                            &target_shares,
+                            &shares_after_reducing,
+                            phase_one_reconciliation_confirmed,
+                            &order.symbol,
+                        )
+                    });
+                    if !phase_two_orders.is_empty() {
+                        if let Err(e) = check_order_set_affordability(
                             broker,
                             mode,
-                            execution,
-                            &phase_two_orders,
-                            run_id,
                             date,
+                            &shares_after_reducing,
+                            &expanding_target_shares,
+                            &phase_two_orders,
                             closes,
-                            journal,
-                            seq,
                         )
-                        .await?;
-                        accepted_orders += expanding_batch.accepted_orders;
-                        failed_orders += expanding_batch.failed_orders;
-                        accepted_unfilled_orders += expanding_batch.accepted_unfilled_orders;
-                        let _ = expanding_batch.next_seq;
+                        .await
+                        {
+                            if let Some(journal) = journal {
+                                journal.record_order_event(&BasketOrderEvent {
+                                    run_id,
+                                    trading_day: date,
+                                    seq,
+                                    symbol: "__phase2__",
+                                    side: "n/a",
+                                    requested_qty: 0.0,
+                                    intended_notional: None,
+                                    reason: "aggregated",
+                                    basket_id: None,
+                                    broker_order_id: None,
+                                    broker_status: None,
+                                    submission_status: "phase2_affordability_error",
+                                    error_text: Some(e.as_str()),
+                                })?;
+                            }
+                            failed_orders += phase_two_orders.len();
+                        } else {
+                            let expanding_batch = submit_order_batch(
+                                broker,
+                                mode,
+                                execution,
+                                &phase_two_orders,
+                                run_id,
+                                date,
+                                closes,
+                                journal,
+                                seq,
+                            )
+                            .await?;
+                            accepted_orders += expanding_batch.accepted_orders;
+                            failed_orders += expanding_batch.failed_orders;
+                            accepted_unfilled_orders += expanding_batch.accepted_unfilled_orders;
+                            let _ = expanding_batch.next_seq;
+                        }
                     }
                 }
             }
@@ -3415,9 +3431,11 @@ async fn process_session_close(
                         } else {
                             0.0
                         };
-                        let settlement_pending = accepted_unfilled_orders > 0
-                            && target_positions_len > 0
-                            && actual_shares.is_empty();
+                        let settlement_pending = (accepted_unfilled_orders > 0
+                            && matches!(fill_contract, SessionCloseFillContract::NextSessionOpen))
+                            || (accepted_unfilled_orders > 0
+                                && target_positions_len > 0
+                                && actual_shares.is_empty());
                         actual_gross = Some(actual_gross_value);
                         divergence_pct = Some(divergence_pct_value);
                         current_positions_after = actual_shares.len();

--- a/engine/crates/runner/src/broker.rs
+++ b/engine/crates/runner/src/broker.rs
@@ -9,6 +9,12 @@ use chrono::NaiveDate;
 
 use crate::alpaca::{AlpacaAccount, AlpacaClient, AlpacaOrder, ExecutionMode};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionCloseFillContract {
+    Immediate,
+    NextSessionOpen,
+}
+
 /// Abstraction over the brokerage backend.
 ///
 /// Only broker actions (place orders, query positions / account) go through
@@ -45,6 +51,12 @@ pub trait Broker: Send + Sync {
     fn reconciliation_delay_secs(&self) -> u64 {
         30
     }
+
+    /// Fill contract for orders submitted by the basket runner after the
+    /// session-close decision point.
+    fn session_close_fill_contract(&self) -> SessionCloseFillContract {
+        SessionCloseFillContract::Immediate
+    }
 }
 
 impl Broker for AlpacaClient {
@@ -70,9 +82,12 @@ impl Broker for AlpacaClient {
     }
 
     fn reconciliation_delay_secs(&self) -> u64 {
-        // Paper/live MOC-style orders can remain accepted for a while after the
-        // close before positions reflect the fills. Give Alpaca more time than
-        // replay's synchronous broker path before judging reconciliation.
+        // The basket runner submits after the close, so Alpaca can keep
+        // those market/day orders queued until the next regular session.
         120
+    }
+
+    fn session_close_fill_contract(&self) -> SessionCloseFillContract {
+        SessionCloseFillContract::NextSessionOpen
     }
 }

--- a/engine/crates/runner/src/main.rs
+++ b/engine/crates/runner/src/main.rs
@@ -389,6 +389,11 @@ struct ReplayArgs {
     #[arg(long, default_value_t = 0.0)]
     slippage_bps: f64,
 
+    /// Replay-only: fill basket orders this many minutes after the next
+    /// session open. `0` = next-session open, `60` = 10:30 ET, `330` = 15:00 ET.
+    #[arg(long, default_value_t = 0)]
+    basket_fill_delay_minutes_after_open: u32,
+
     /// Per-order probability of simulated rejection (0.0..=1.0, default 0).
     /// Exercises the `error!("ORDER FAILED")` path in basket_live.
     #[arg(long, default_value_t = 0.0)]
@@ -2285,6 +2290,8 @@ async fn run_basket_replay_live_path(args: ReplayArgs) {
         partial_fill_rate: args.partial_fill_rate,
         stale_position_rate: args.stale_position_rate,
         seed: args.failure_seed,
+        fill_contract: simulated_broker::ReplayFillContract::NextSessionOpen,
+        fill_delay_minutes_after_open: args.basket_fill_delay_minutes_after_open,
     };
     let replay = parquet_bar_source::new_replay_components(
         bars_dir.clone(),

--- a/engine/crates/runner/src/market_session.rs
+++ b/engine/crates/runner/src/market_session.rs
@@ -26,6 +26,17 @@ pub fn is_after_close_grace_utc(dt_utc: DateTime<Utc>, grace_min: u32) -> bool {
     session_minute(local) >= (RTH_CLOSE.hour() * 60 + RTH_CLOSE.minute() + grace_min)
 }
 
+pub fn minutes_from_open_utc(dt_utc: DateTime<Utc>) -> Option<u32> {
+    let local = dt_utc.with_timezone(&New_York);
+    let minute = session_minute(local);
+    let open = RTH_OPEN.hour() * 60 + RTH_OPEN.minute();
+    let close = RTH_CLOSE.hour() * 60 + RTH_CLOSE.minute();
+    if !(open..close).contains(&minute) {
+        return None;
+    }
+    Some(minute - open)
+}
+
 pub fn is_trading_day(day: NaiveDate) -> bool {
     match day.is_busday() {
         Ok(open) => open,

--- a/engine/crates/runner/src/parquet_bar_source.rs
+++ b/engine/crates/runner/src/parquet_bar_source.rs
@@ -63,6 +63,7 @@ pub struct ParquetBarSource {
     bars_dir: PathBuf,
     start: NaiveDate,
     end: NaiveDate,
+    broker: SimulatedBroker,
     closes: SharedCloses,
     channels: StdRwLock<Option<ReplayChannels>>,
 }
@@ -85,11 +86,16 @@ impl BarSource for ParquetBarSource {
         let bars_dir = self.bars_dir.clone();
         let start = self.start;
         let end = self.end;
+        let broker = self.broker.clone();
         let closes = self.closes.clone();
         let symbols: Vec<String> = symbols.to_vec();
 
         tokio::spawn(async move {
-            if let Err(e) = emit_loop(&bars_dir, start, end, &symbols, tx, channels, closes).await {
+            if let Err(e) = emit_loop(
+                &bars_dir, start, end, &symbols, tx, channels, broker, closes,
+            )
+            .await
+            {
                 warn!(error = %e, "parquet replay emitter terminated with error");
             }
         });
@@ -120,6 +126,7 @@ pub fn new_replay_components(
         bars_dir,
         start,
         end,
+        broker: broker.clone(),
         closes,
         channels: StdRwLock::new(Some(channels)),
     };
@@ -191,6 +198,7 @@ async fn emit_loop(
     symbols: &[String],
     bar_tx: mpsc::Sender<StreamBar>,
     mut channels: ReplayChannels,
+    broker: SimulatedBroker,
     closes: SharedCloses,
 ) -> Result<(), String> {
     info!(
@@ -289,6 +297,10 @@ async fn emit_loop(
             }
         }
         current_date = Some(bar_date);
+
+        // Settle any queued after-close orders at the next session's
+        // first open before we overwrite the close snapshot.
+        broker.process_bar_open(sym.as_str(), dt_open, bar.open)?;
 
         // Update shared closes BEFORE we send the bar, so SimulatedBroker
         // sees this price if a place_order races with bar-emit. (In

--- a/engine/crates/runner/src/simulated_broker.rs
+++ b/engine/crates/runner/src/simulated_broker.rs
@@ -5,12 +5,13 @@
 //! [`AlpacaOrder`] records shaped like a successful fill so the
 //! basket-live code path runs unchanged.
 //!
-//! Replay fill contract (frozen here so replay vs paper/live stays
-//! comparable across PRs):
+//! Replay fill contract:
 //!
-//!   - Fills happen at the *latest known close* for the symbol — i.e.,
-//!     the close from the bar that triggered the session-close cycle.
-//!     This matches "MOC executes at the official close" used by paper.
+//!   - Default behavior matches the current live basket runner path:
+//!     orders submitted after the close are accepted immediately, then
+//!     filled on the next session's first RTH bar open for that symbol.
+//!   - Tests can still opt into the older same-close immediate-fill
+//!     behavior explicitly.
 //!   - Optional one-sided slippage in basis points: buys fill higher,
 //!     sells fill lower. Default 0 bps.
 //!
@@ -44,12 +45,12 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Mutex, RwLock};
 
 use basket_engine::PortfolioConfig;
-use chrono::NaiveDate;
+use chrono::{DateTime, NaiveDate, Utc};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 
 use crate::alpaca::{AlpacaAccount, AlpacaOrder, ExecutionMode};
-use crate::broker::Broker;
+use crate::broker::{Broker, SessionCloseFillContract};
 
 /// Shared close-price snapshot. Written by
 /// [`crate::parquet_bar_source::ParquetBarSource`] as bars are emitted,
@@ -62,6 +63,8 @@ pub type SharedCloses = Arc<RwLock<HashMap<String, f64>>>;
 #[derive(Debug, Clone)]
 pub struct SimulatedBrokerConfig {
     pub slippage_bps: f64,
+    pub fill_contract: ReplayFillContract,
+    pub fill_delay_minutes_after_open: u32,
     /// Per-order probability of returning a "buying power exceeded" /
     /// "insufficient liquidity"-shaped error. 0.0 = never reject.
     pub reject_rate: f64,
@@ -82,12 +85,21 @@ impl Default for SimulatedBrokerConfig {
     fn default() -> Self {
         Self {
             slippage_bps: 0.0,
+            fill_contract: ReplayFillContract::NextSessionOpen,
+            fill_delay_minutes_after_open: 0,
             reject_rate: 0.0,
             partial_fill_rate: 0.0,
             stale_position_rate: 0.0,
             seed: 0,
         }
     }
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplayFillContract {
+    ImmediateClose,
+    NextSessionOpen,
 }
 
 /// In-process broker. Cheaply cloneable — internal state is `Arc`-shared
@@ -106,6 +118,8 @@ struct SimulatedState {
     config: SimulatedBrokerConfig,
     next_order_id: std::sync::atomic::AtomicU64,
     rng: Mutex<StdRng>,
+    pending_orders: Mutex<Vec<PendingOrder>>,
+    last_seen_trading_day: Mutex<Option<NaiveDate>>,
     /// Snapshot of positions returned by the previous `get_positions`
     /// call. Used by `stale_position_rate` to occasionally serve a
     /// one-step-old view, exercising the BROKER DIVERGENCE path.
@@ -113,6 +127,14 @@ struct SimulatedState {
     /// End-of-day equity time series. Populated by `record_eod`,
     /// consumed by the parity wrapper after replay.
     daily_equity: Mutex<BTreeMap<NaiveDate, f64>>,
+}
+
+#[derive(Debug, Clone)]
+struct PendingOrder {
+    symbol: String,
+    side: String,
+    filled_qty: f64,
+    order_day: NaiveDate,
 }
 
 impl SimulatedBroker {
@@ -126,6 +148,7 @@ impl SimulatedBroker {
             closes,
             SimulatedBrokerConfig {
                 slippage_bps,
+                fill_contract: ReplayFillContract::ImmediateClose,
                 ..Default::default()
             },
         )
@@ -148,13 +171,28 @@ impl SimulatedBroker {
                 config,
                 next_order_id: std::sync::atomic::AtomicU64::new(1),
                 rng: Mutex::new(rng),
+                pending_orders: Mutex::new(Vec::new()),
+                last_seen_trading_day: Mutex::new(None),
                 prev_positions: Mutex::new(None),
                 daily_equity: Mutex::new(BTreeMap::new()),
             }),
         }
     }
 
-    fn fill_price(&self, symbol: &str, side: &str) -> Result<f64, String> {
+    fn slippage_adjusted_price(&self, raw_price: f64, side: &str) -> Result<f64, String> {
+        if !raw_price.is_finite() || raw_price <= 0.0 {
+            return Err(format!("non-finite price: {raw_price}"));
+        }
+        let bps = self.state.config.slippage_bps / 1e4;
+        let signed_bps = match side {
+            "buy" => bps,
+            "sell" => -bps,
+            other => return Err(format!("unknown side: {other}")),
+        };
+        Ok(raw_price * (1.0 + signed_bps))
+    }
+
+    fn submit_price(&self, symbol: &str, side: &str) -> Result<f64, String> {
         let close = self
             .state
             .closes
@@ -163,16 +201,7 @@ impl SimulatedBroker {
             .get(symbol)
             .copied()
             .ok_or_else(|| format!("no close price for {symbol} (bar source not seeded)"))?;
-        if !close.is_finite() || close <= 0.0 {
-            return Err(format!("non-finite close price for {symbol}: {close}"));
-        }
-        let bps = self.state.config.slippage_bps / 1e4;
-        let signed_bps = match side {
-            "buy" => bps,
-            "sell" => -bps,
-            other => return Err(format!("unknown side: {other}")),
-        };
-        Ok(close * (1.0 + signed_bps))
+        self.slippage_adjusted_price(close, side)
     }
 
     fn equity_unlocked(&self, positions: &HashMap<String, (f64, f64)>, cash: f64) -> f64 {
@@ -190,6 +219,88 @@ impl SimulatedBroker {
         let equity = self.equity_unlocked(&positions, cash);
         self.state.daily_equity.lock().unwrap().insert(date, equity);
     }
+
+    fn apply_fill(
+        &self,
+        symbol: &str,
+        side: &str,
+        filled_qty: f64,
+        price: f64,
+    ) -> Result<(), String> {
+        let signed_qty = match side {
+            "buy" => filled_qty,
+            "sell" => -filled_qty,
+            other => return Err(format!("unknown side: {other}")),
+        };
+
+        let mut positions = self.state.positions.write().unwrap();
+        let mut cash = self.state.cash.write().unwrap();
+        let entry = positions.entry(symbol.to_string()).or_insert((0.0, price));
+        let prev_qty = entry.0;
+        let prev_avg = entry.1;
+        let new_qty = prev_qty + signed_qty;
+        let new_avg = if new_qty.abs() > 1e-9 && prev_qty.signum() == signed_qty.signum() {
+            (prev_avg * prev_qty.abs() + price * filled_qty) / new_qty.abs()
+        } else {
+            price
+        };
+        entry.0 = new_qty;
+        entry.1 = new_avg;
+        if entry.0.abs() < 1e-9 {
+            positions.remove(symbol);
+        }
+        *cash -= signed_qty * price;
+        Ok(())
+    }
+
+    pub fn process_bar_open(
+        &self,
+        symbol: &str,
+        dt_open: DateTime<Utc>,
+        open: f64,
+    ) -> Result<(), String> {
+        if self.state.config.fill_contract != ReplayFillContract::NextSessionOpen {
+            return Ok(());
+        }
+        if !open.is_finite() || open <= 0.0 {
+            return Ok(());
+        }
+        let bar_day = crate::market_session::trading_day_utc(dt_open);
+        *self.state.last_seen_trading_day.lock().unwrap() = Some(bar_day);
+        let Some(minutes_from_open) = crate::market_session::minutes_from_open_utc(dt_open) else {
+            return Ok(());
+        };
+
+        let mut pending = self.state.pending_orders.lock().unwrap();
+        if pending.is_empty() {
+            return Ok(());
+        }
+        let mut ready = Vec::new();
+        let mut still_pending = Vec::with_capacity(pending.len());
+        for order in pending.drain(..) {
+            if order.symbol == symbol
+                && bar_day > order.order_day
+                && minutes_from_open >= self.state.config.fill_delay_minutes_after_open
+            {
+                ready.push(order);
+            } else {
+                still_pending.push(order);
+            }
+        }
+        *pending = still_pending;
+        drop(pending);
+
+        for order in ready {
+            let price = self.slippage_adjusted_price(open, order.side.as_str())?;
+            self.apply_fill(
+                order.symbol.as_str(),
+                order.side.as_str(),
+                order.filled_qty,
+                price,
+            )?;
+        }
+        Ok(())
+    }
 }
 
 impl Broker for SimulatedBroker {
@@ -203,7 +314,7 @@ impl Broker for SimulatedBroker {
         if !qty.is_finite() || qty <= 0.0 {
             return Err(format!("non-positive qty for {symbol}: {qty}"));
         }
-        let price = self.fill_price(symbol, side)?;
+        let submit_price = self.submit_price(symbol, side)?;
         let signed_qty_full = match side {
             "buy" => qty,
             "sell" => -qty,
@@ -238,10 +349,9 @@ impl Broker for SimulatedBroker {
 
         // Effective filled qty (may be smaller than requested).
         let filled_qty = partial_qty_opt.unwrap_or(qty);
-        let signed_filled_qty = signed_qty_full.signum() * filled_qty;
 
-        let mut positions = self.state.positions.write().unwrap();
-        let mut cash = self.state.cash.write().unwrap();
+        let positions = self.state.positions.write().unwrap();
+        let cash = self.state.cash.read().unwrap();
 
         // Buying-power check (per-symbol projection from the closes
         // map; see #302 review). Uses the FULL requested qty (not
@@ -262,7 +372,7 @@ impl Broker for SimulatedBroker {
                 .unwrap_or_else(|| positions.get(sym).map(|(_, a)| *a).unwrap_or(0.0));
             current_gross += q.abs() * current_price;
             if sym == symbol {
-                projected_gross += new_qty_signed_full.abs() * price;
+                projected_gross += new_qty_signed_full.abs() * submit_price;
                 traded_symbol_seen = true;
             } else if let Some(p) = closes_snapshot.get(sym) {
                 projected_gross += q.abs() * p;
@@ -272,7 +382,7 @@ impl Broker for SimulatedBroker {
             }
         }
         if !traded_symbol_seen {
-            projected_gross += new_qty_signed_full.abs() * price;
+            projected_gross += new_qty_signed_full.abs() * submit_price;
         }
         drop(closes_snapshot);
         let reduces_gross = projected_gross <= current_gross + 1e-9;
@@ -281,39 +391,49 @@ impl Broker for SimulatedBroker {
                 "buying power exceeded: gross {projected_gross:.2} > buying_power {buying_power:.2}"
             ));
         }
+        drop(cash);
+        drop(positions);
 
-        // Apply the fill (partial or full).
-        let entry = positions.entry(symbol.to_string()).or_insert((0.0, price));
-        let prev_qty = entry.0;
-        let prev_avg = entry.1;
-        let new_qty = prev_qty + signed_filled_qty;
-        let new_avg = if new_qty.abs() > 1e-9 && prev_qty.signum() == signed_filled_qty.signum() {
-            (prev_avg * prev_qty.abs() + price * filled_qty) / new_qty.abs()
-        } else {
-            price
+        let status = match self.state.config.fill_contract {
+            ReplayFillContract::ImmediateClose => {
+                self.apply_fill(symbol, side, filled_qty, submit_price)?;
+                if partial_qty_opt.is_some() {
+                    "partially_filled"
+                } else {
+                    "filled"
+                }
+            }
+            ReplayFillContract::NextSessionOpen => {
+                let order_day = self
+                    .state
+                    .last_seen_trading_day
+                    .lock()
+                    .unwrap()
+                    .ok_or_else(|| "missing replay trading day for deferred fill".to_string())?;
+                self.state
+                    .pending_orders
+                    .lock()
+                    .unwrap()
+                    .push(PendingOrder {
+                        symbol: symbol.to_string(),
+                        side: side.to_string(),
+                        filled_qty,
+                        order_day,
+                    });
+                "accepted"
+            }
         };
-        entry.0 = new_qty;
-        entry.1 = new_avg;
-        if entry.0.abs() < 1e-9 {
-            positions.remove(symbol);
-        }
-        *cash -= signed_filled_qty * price;
 
         let id = self
             .state
             .next_order_id
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let status = if partial_qty_opt.is_some() {
-            "partially_filled"
-        } else {
-            "filled"
-        };
         Ok(AlpacaOrder {
             id: format!("sim-{id:08}"),
             status: status.to_string(),
             symbol: symbol.to_string(),
             side: side.to_string(),
-            qty: format!("{filled_qty}"),
+            qty: format!("{qty}"),
         })
     }
 
@@ -372,6 +492,13 @@ impl Broker for SimulatedBroker {
     fn reconciliation_delay_secs(&self) -> u64 {
         0
     }
+
+    fn session_close_fill_contract(&self) -> SessionCloseFillContract {
+        match self.state.config.fill_contract {
+            ReplayFillContract::ImmediateClose => SessionCloseFillContract::Immediate,
+            ReplayFillContract::NextSessionOpen => SessionCloseFillContract::NextSessionOpen,
+        }
+    }
 }
 
 impl SimulatedBroker {
@@ -414,6 +541,7 @@ pub struct ReplaySnapshot {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::TimeZone;
 
     fn shared_closes(pairs: &[(&str, f64)]) -> SharedCloses {
         Arc::new(RwLock::new(
@@ -595,6 +723,101 @@ mod tests {
         assert!(snap.positions.is_empty());
     }
 
+    #[tokio::test]
+    async fn next_session_open_contract_queues_then_fills_on_open() {
+        let closes = shared_closes(&[("AMD", 100.0)]);
+        let broker = SimulatedBroker::with_config(
+            &portfolio_config(),
+            closes,
+            SimulatedBrokerConfig {
+                fill_contract: ReplayFillContract::NextSessionOpen,
+                ..Default::default()
+            },
+        );
+        broker
+            .process_bar_open(
+                "AMD",
+                Utc.with_ymd_and_hms(2026, 1, 2, 14, 30, 0).unwrap(),
+                100.0,
+            )
+            .unwrap();
+        let order = broker
+            .place_order("AMD", 10.0, "buy", ExecutionMode::Paper)
+            .await
+            .unwrap();
+        assert_eq!(order.status, "accepted");
+        assert!(broker
+            .get_positions(ExecutionMode::Paper)
+            .await
+            .unwrap()
+            .is_empty());
+
+        broker
+            .process_bar_open(
+                "AMD",
+                Utc.with_ymd_and_hms(2026, 1, 5, 14, 30, 0).unwrap(),
+                102.0,
+            )
+            .unwrap();
+
+        let positions = broker.get_positions(ExecutionMode::Paper).await.unwrap();
+        assert_eq!(
+            positions.get("AMD").map(|(q, p)| (*q, *p)),
+            Some((10.0, 102.0))
+        );
+    }
+
+    #[tokio::test]
+    async fn delayed_next_session_fill_waits_until_target_minute() {
+        let closes = shared_closes(&[("AMD", 100.0)]);
+        let broker = SimulatedBroker::with_config(
+            &portfolio_config(),
+            closes,
+            SimulatedBrokerConfig {
+                fill_contract: ReplayFillContract::NextSessionOpen,
+                fill_delay_minutes_after_open: 60,
+                ..Default::default()
+            },
+        );
+        broker
+            .process_bar_open(
+                "AMD",
+                Utc.with_ymd_and_hms(2026, 1, 2, 14, 30, 0).unwrap(),
+                100.0,
+            )
+            .unwrap();
+        broker
+            .place_order("AMD", 10.0, "buy", ExecutionMode::Paper)
+            .await
+            .unwrap();
+
+        broker
+            .process_bar_open(
+                "AMD",
+                Utc.with_ymd_and_hms(2026, 1, 5, 14, 30, 0).unwrap(),
+                101.0,
+            )
+            .unwrap();
+        assert!(broker
+            .get_positions(ExecutionMode::Paper)
+            .await
+            .unwrap()
+            .is_empty());
+
+        broker
+            .process_bar_open(
+                "AMD",
+                Utc.with_ymd_and_hms(2026, 1, 5, 15, 30, 0).unwrap(),
+                103.0,
+            )
+            .unwrap();
+        let positions = broker.get_positions(ExecutionMode::Paper).await.unwrap();
+        assert_eq!(
+            positions.get("AMD").map(|(q, p)| (*q, *p)),
+            Some((10.0, 103.0))
+        );
+    }
+
     // ── failure injection (#294c-3) ───────────────────────────────
 
     #[tokio::test]
@@ -604,6 +827,7 @@ mod tests {
             &portfolio_config(),
             closes,
             SimulatedBrokerConfig {
+                fill_contract: ReplayFillContract::ImmediateClose,
                 reject_rate: 1.0, // always reject
                 seed: 42,
                 ..Default::default()
@@ -628,6 +852,7 @@ mod tests {
             &portfolio_config(),
             closes,
             SimulatedBrokerConfig {
+                fill_contract: ReplayFillContract::ImmediateClose,
                 partial_fill_rate: 1.0, // always partial
                 seed: 7,
                 ..Default::default()
@@ -656,6 +881,7 @@ mod tests {
             &portfolio_config(),
             closes,
             SimulatedBrokerConfig {
+                fill_contract: ReplayFillContract::ImmediateClose,
                 stale_position_rate: 1.0, // always stale (after the priming call)
                 seed: 1,
                 ..Default::default()


### PR DESCRIPTION
## Summary
- make replay model basket session-close orders as deferred next-session fills instead of same-close fills
- skip phase-two expansion orders when reducing orders have only been accepted and will settle next session
- add a replay-only fill-delay knob so we can compare next-session 09:30/10:30/15:00 ET fills causally

## Why
The old replay path was overstating basket performance by giving after-close orders same-close executions that the live Alpaca path cannot actually receive. This PR makes replay and live share the same execution contract, which is a prerequisite for trusting replay-vs-paper comparisons.

## What changed
- added `SessionCloseFillContract` to the broker abstraction
- set Alpaca basket session-close submissions to `NextSessionOpen`
- changed replay `SimulatedBroker` to queue accepted orders and fill them on the next session's first eligible RTH bar
- tracked deferred settlement in `basket_live` so phase-two expansion orders are skipped when phase-one reducing orders have not settled yet
- added `--basket-fill-delay-minutes-after-open` for replay-only execution timing experiments

## Validation
- `cargo test --manifest-path /tmp/OpenQuant-pr-274/engine/Cargo.toml -p openquant-runner next_session_open_contract_queues_then_fills_on_open -- --nocapture`
- `cargo test --manifest-path /tmp/OpenQuant-pr-274/engine/Cargo.toml -p openquant-runner delayed_next_session_fill_waits_until_target_minute -- --nocapture`
- `cargo test --manifest-path /tmp/OpenQuant-pr-274/engine/Cargo.toml -p openquant-runner fills_at_close_with_zero_slippage -- --nocapture`
- `cargo run --manifest-path /tmp/OpenQuant-pr-274/engine/Cargo.toml -p openquant-runner -- replay --engine basket --universe /tmp/OpenQuant-pr-274/config/basket_universe_buildout.toml --start 2026-05-21 --end 2026-05-27 --state-path /tmp/basket_exec_contract_smoke_pr.state.json --report-tsv /tmp/basket_exec_contract_smoke_pr.tsv`

## Replay impact
On the 2026 YTD buildout overlay replay, this change lowered the previously optimistic baseline from about `+52.40%` to about `+38.89%`, which is expected because the old replay was granting same-close fills after the close.

Refs #274
