### PR TITLE
basket: harden basket id persistence contract

### DIFF
--- a/engine/crates/basket-engine/src/engine.rs
+++ b/engine/crates/basket-engine/src/engine.rs
@@ -6,7 +6,8 @@ use std::path::Path;
 
 use basket_picker::{BasketFit, OuFit};
 use chrono::NaiveDate;
-use serde::{Deserialize, Serialize};
+use serde::de::{self, MapAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
 use tracing::{debug, info, trace, warn};
 
 use crate::gates::{evaluate_gate, GatePolicyKind};
@@ -55,6 +56,7 @@ pub struct EngineSnapshot {
     /// Per-basket parameters (frozen).
     pub params: Vec<BasketParams>,
     /// Per-basket runtime state.
+    #[serde(deserialize_with = "deserialize_unique_state_map")]
     pub states: HashMap<String, BasketState>,
     /// Signal / transition policy used to produce the persisted state.
     #[serde(default)]
@@ -83,22 +85,20 @@ impl BasketEngine {
     }
 
     pub fn with_gate_policy(fits: &[BasketFit], gate_policy: GatePolicyKind) -> Self {
-        let mut params = HashMap::new();
-        let mut states = HashMap::new();
+        Self::try_with_gate_policy(fits, gate_policy)
+            .unwrap_or_else(|e| panic!("invalid basket engine fit set: {e}"))
+    }
 
-        for fit in fits {
-            if let Some(p) = BasketParams::from_fit(fit) {
-                let id = p.basket_id.clone();
-                params.insert(id.clone(), p);
-                states.insert(id, BasketState::new());
-            }
-        }
-
-        Self {
+    pub fn try_with_gate_policy(
+        fits: &[BasketFit],
+        gate_policy: GatePolicyKind,
+    ) -> Result<Self, String> {
+        let (params, states) = build_engine_maps_from_fits(fits)?;
+        Ok(Self {
             params,
             states,
             gate_policy,
-        }
+        })
     }
 
     /// Get the number of active baskets.
@@ -384,11 +384,7 @@ impl BasketEngine {
     /// Load engine state from a JSON file.
     pub fn load_state(path: &Path) -> Result<Self, String> {
         let snapshot = Self::load_snapshot(path)?;
-
-        let mut params = HashMap::new();
-        for p in snapshot.params {
-            params.insert(p.basket_id.clone(), p);
-        }
+        let params = params_map_from_owned(snapshot.params)?;
 
         Ok(Self {
             params,
@@ -440,10 +436,7 @@ impl BasketEngine {
 
     fn validate_snapshot(snapshot: &EngineSnapshot) -> Result<(), String> {
         snapshot.gate_policy.validate()?;
-        let mut params = HashMap::new();
-        for p in &snapshot.params {
-            params.insert(p.basket_id.clone(), p);
-        }
+        let params = params_map_from_refs(&snapshot.params)?;
         for basket_id in params.keys() {
             if !snapshot.states.contains_key(basket_id) {
                 return Err(format!("missing runtime state for basket_id '{basket_id}'"));
@@ -458,6 +451,85 @@ impl BasketEngine {
         }
         Ok(())
     }
+}
+
+fn build_engine_maps_from_fits(
+    fits: &[BasketFit],
+) -> Result<(HashMap<String, BasketParams>, HashMap<String, BasketState>), String> {
+    let mut params = HashMap::new();
+    let mut states = HashMap::new();
+
+    for fit in fits {
+        if let Some(param) = BasketParams::from_fit(fit) {
+            let id = param.basket_id.clone();
+            if params.insert(id.clone(), param).is_some() {
+                return Err(format!("duplicate basket_id '{id}' in fit set"));
+            }
+            states.insert(id, BasketState::new());
+        }
+    }
+
+    Ok((params, states))
+}
+
+fn params_map_from_owned(
+    params: Vec<BasketParams>,
+) -> Result<HashMap<String, BasketParams>, String> {
+    let mut out = HashMap::new();
+    for param in params {
+        let id = param.basket_id.clone();
+        if out.insert(id.clone(), param).is_some() {
+            return Err(format!("duplicate basket_id '{id}' in snapshot params"));
+        }
+    }
+    Ok(out)
+}
+
+fn params_map_from_refs<'a>(
+    params: &'a [BasketParams],
+) -> Result<HashMap<String, &'a BasketParams>, String> {
+    let mut out = HashMap::new();
+    for param in params {
+        let id = param.basket_id.clone();
+        if out.insert(id.clone(), param).is_some() {
+            return Err(format!("duplicate basket_id '{id}' in snapshot params"));
+        }
+    }
+    Ok(out)
+}
+
+fn deserialize_unique_state_map<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, BasketState>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct UniqueStateMapVisitor;
+
+    impl<'de> Visitor<'de> for UniqueStateMapVisitor {
+        type Value = HashMap<String, BasketState>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("a basket state map with unique basket_id keys")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: MapAccess<'de>,
+        {
+            let mut states = HashMap::new();
+            while let Some((basket_id, state)) = map.next_entry::<String, BasketState>()? {
+                if states.insert(basket_id.clone(), state).is_some() {
+                    return Err(de::Error::custom(format!(
+                        "duplicate runtime state for basket_id '{basket_id}'"
+                    )));
+                }
+            }
+            Ok(states)
+        }
+    }
+
+    deserializer.deserialize_map(UniqueStateMapVisitor)
 }
 
 #[cfg(test)]
@@ -513,6 +585,19 @@ mod tests {
         let fit = make_test_fit();
         let engine = BasketEngine::new(&[fit]);
         assert_eq!(engine.num_baskets(), 1);
+    }
+
+    #[test]
+    fn test_try_with_gate_policy_rejects_duplicate_basket_ids() {
+        let fit = make_test_fit();
+        let err = match BasketEngine::try_with_gate_policy(
+            &[fit.clone(), fit],
+            GatePolicyKind::BertramFrozen,
+        ) {
+            Ok(_) => panic!("expected duplicate basket_id rejection"),
+            Err(err) => err,
+        };
+        assert!(err.contains("duplicate basket_id"));
     }
 
     #[test]
@@ -724,6 +809,70 @@ mod tests {
         let loaded_state = loaded.get_state(&test_basket_id()).unwrap();
         assert_eq!(orig_state.position, loaded_state.position);
         assert_eq!(orig_state.entry_date, loaded_state.entry_date);
+    }
+
+    #[test]
+    fn test_load_state_rejects_duplicate_snapshot_param_ids() {
+        let fit = make_test_fit();
+        let engine = BasketEngine::new(std::slice::from_ref(&fit));
+        let basket_id = test_basket_id();
+        let snapshot = EngineSnapshot {
+            params: vec![
+                BasketParams::from_fit(&fit).unwrap(),
+                BasketParams::from_fit(&fit).unwrap(),
+            ],
+            states: HashMap::from([(basket_id, BasketState::default())]),
+            gate_policy: GatePolicyKind::BertramFrozen,
+            last_processed_trading_day: None,
+        };
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let json = serde_json::to_string_pretty(&snapshot).unwrap();
+        fs::write(tmp.path(), json).unwrap();
+
+        let err = match BasketEngine::load_state(tmp.path()) {
+            Ok(_) => panic!("expected duplicate snapshot param rejection"),
+            Err(err) => err,
+        };
+        assert!(err.contains("duplicate basket_id"));
+        assert_eq!(engine.num_baskets(), 1);
+    }
+
+    #[test]
+    fn test_load_snapshot_rejects_duplicate_runtime_state_keys() {
+        let fit = make_test_fit();
+        let params_json =
+            serde_json::to_string(&vec![BasketParams::from_fit(&fit).unwrap()]).unwrap();
+        let basket_id = test_basket_id();
+        let snapshot = format!(
+            r#"{{
+  "params": {params_json},
+  "states": {{
+    "{basket_id}": {{
+      "position": 0,
+      "entry_date": null,
+      "entry_spread": null,
+      "spread_history": [],
+      "last_z": null,
+      "last_signal_score": null
+    }},
+    "{basket_id}": {{
+      "position": 1,
+      "entry_date": null,
+      "entry_spread": null,
+      "spread_history": [],
+      "last_z": null,
+      "last_signal_score": null
+    }}
+  }},
+  "gate_policy": "BertramFrozen",
+  "last_processed_trading_day": null
+}}"#
+        );
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        fs::write(tmp.path(), snapshot).unwrap();
+
+        let err = BasketEngine::load_snapshot(tmp.path()).unwrap_err();
+        assert!(err.contains("duplicate runtime state"));
     }
 
     #[test]

--- a/engine/crates/basket-picker/src/schema.rs
+++ b/engine/crates/basket-picker/src/schema.rs
@@ -34,15 +34,25 @@ impl BasketCandidate {
 
     /// Compute a stable 8-char hex hash of the sorted members.
     fn members_hash(&self) -> String {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
-
         let mut sorted_members = self.members.clone();
         sorted_members.sort();
 
-        let mut hasher = DefaultHasher::new();
-        sorted_members.hash(&mut hasher);
-        let hash = hasher.finish();
+        // FNV-1a is simple, deterministic, and independent of Rust's
+        // randomized `DefaultHasher`, which is not a stable persistence contract.
+        const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+        const FNV_PRIME: u64 = 0x100000001b3;
+
+        let mut hash = FNV_OFFSET_BASIS;
+        for member in sorted_members {
+            for byte in member.as_bytes() {
+                hash ^= u64::from(*byte);
+                hash = hash.wrapping_mul(FNV_PRIME);
+            }
+            // Separate member boundaries so concatenation remains unambiguous.
+            hash ^= 0x1f;
+            hash = hash.wrapping_mul(FNV_PRIME);
+        }
+
         format!("{:08x}", hash as u32)
     }
 }
@@ -87,5 +97,32 @@ impl BasketFit {
             valid: false,
             reject_reason: Some(reason.into()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidate_with_members(members: &[&str]) -> BasketCandidate {
+        BasketCandidate {
+            target: "AMD".to_string(),
+            members: members.iter().map(|member| member.to_string()).collect(),
+            sector: "chips".to_string(),
+            fit_date: NaiveDate::from_ymd_opt(2026, 4, 20).unwrap(),
+        }
+    }
+
+    #[test]
+    fn test_members_hash_is_order_independent() {
+        let a = candidate_with_members(&["NVDA", "INTC"]);
+        let b = candidate_with_members(&["INTC", "NVDA"]);
+        assert_eq!(a.id(), b.id());
+    }
+
+    #[test]
+    fn test_members_hash_is_stable_for_known_members() {
+        let candidate = candidate_with_members(&["NVDA", "INTC"]);
+        assert_eq!(candidate.id(), "chips:AMD:2026-04-20:398f398c");
     }
 }

--- a/engine/crates/runner/src/basket_live.rs
+++ b/engine/crates/runner/src/basket_live.rs
@@ -2480,7 +2480,7 @@ fn initialize_engine_state(
         .filter(|f| f.valid)
         .map(|f| f.candidate.id())
         .collect();
-    let mut fresh = BasketEngine::with_gate_policy(fits, gate_policy.clone());
+    let mut fresh = BasketEngine::try_with_gate_policy(fits, gate_policy.clone())?;
 
     if !state_path.exists() {
         if broker_execution_enabled && !broker_shares.is_empty() {


### PR DESCRIPTION
## Summary
- replace basket candidate member hashing with a deterministic stable FNV-1a scheme
- reject duplicate basket IDs when building engines from fit sets and when loading snapshots
- reject duplicate runtime state keys during snapshot deserialization instead of silently overwriting them

## Why
Issue #345 is a persisted-contract bug. Basket IDs flow through fit artifacts, engine state, and replay/live continuity, so they cannot depend on Rust's randomized `DefaultHasher`, and duplicate IDs cannot be allowed to silently collapse into one basket.

## What changed
- `BasketCandidate::members_hash()` now uses a deterministic FNV-1a hash over sorted members with explicit separators
- `BasketEngine::try_with_gate_policy()` validates fit sets for duplicate `basket_id`s
- `BasketEngine::with_gate_policy()` remains the existing infallible API but now panics immediately on duplicate IDs instead of last-write-wins behavior
- snapshot params now reject duplicate `basket_id`s during load/validation
- snapshot `states` now use a custom deserializer that rejects duplicate basket IDs at parse time
- runner startup now uses the fallible constructor path so live/replay fail with a normal error instead of panicking if the fit set is invalid

## Validation
- `cargo test --manifest-path /tmp/OpenQuant-pr-345/engine/Cargo.toml -p basket-picker schema::tests::test_members_hash_is_order_independent -- --nocapture`
- `cargo test --manifest-path /tmp/OpenQuant-pr-345/engine/Cargo.toml -p basket-picker schema::tests::test_members_hash_is_stable_for_known_members -- --nocapture`
- `cargo test --manifest-path /tmp/OpenQuant-pr-345/engine/Cargo.toml -p basket-engine test_try_with_gate_policy_rejects_duplicate_basket_ids -- --nocapture`
- `cargo test --manifest-path /tmp/OpenQuant-pr-345/engine/Cargo.toml -p basket-engine test_load_state_rejects_duplicate_snapshot_param_ids -- --nocapture`
- `cargo test --manifest-path /tmp/OpenQuant-pr-345/engine/Cargo.toml -p basket-engine test_load_snapshot_rejects_duplicate_runtime_state_keys -- --nocapture`
- `cargo test --manifest-path /tmp/OpenQuant-pr-345/engine/Cargo.toml -p openquant-runner --no-run`

Refs #345
